### PR TITLE
Fix GTK2 warning message

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -408,16 +408,18 @@ get_label (gchar * str, guint border)
       if (vals[1] && *vals[1])
         i = gtk_image_new_from_pixbuf (get_pixbuf (vals[1], YAD_SMALL_ICON));
     }
-#if !GTK_CHECK_VERSION(3,0,0)
-  gtk_misc_set_alignment (GTK_MISC (l), 0.0, 0.5);
-#else
-  gtk_label_set_xalign (GTK_LABEL (l), 0.0);
-#endif
 
   if (i)
     gtk_box_pack_start (GTK_BOX (t), i, FALSE, FALSE, 1);
   if (l)
-    gtk_box_pack_start (GTK_BOX (t), l, FALSE, FALSE, 1);
+    {
+#if !GTK_CHECK_VERSION(3,0,0)
+      gtk_misc_set_alignment (GTK_MISC (l), 0.0, 0.5);
+#else
+      gtk_label_set_xalign (GTK_LABEL (l), 0.0);
+#endif
+      gtk_box_pack_start (GTK_BOX (t), l, FALSE, FALSE, 1);
+    }
 
   /* !!! must check both 1 and 2 values for !NULL */
   if (vals[1] && vals[2] && *vals[2])


### PR DESCRIPTION
Gtk-CRITICAL **: IA__gtk_misc_set_alignment: assertion 'GTK_IS_MISC (misc)' failed