### PR TITLE
New option: show specified cursor at startup

### DIFF
--- a/data/yad.1
+++ b/data/yad.1
@@ -170,6 +170,9 @@ Show separator between dialog and buttons. Works only with gtk+-2.0.
 .B \-\-borders=\fINUM\fP
 Set dialog window borders.
 .TP
+.B \-\-cursor=\fINAME\fP
+Use specified cursor on start.
+.TP
 .B \-\-sticky
 Make window visible on all desktops.
 .TP

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YAD\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-30 16:34+0200\n"
-"PO-Revision-Date: 2009-04-30 16:47+0300\n"
+"POT-Creation-Date: 2018-04-09 17:08+0000\n"
+"PO-Revision-Date: 2018-04-09 17:10+0000\n"
 "Last-Translator: Victor Ananjevsky <ananasik@gmail.com>\n"
 "Language-Team: \n"
 "Language: ru\n"
@@ -148,12 +148,12 @@ msgstr "Не могу открыть каталог %s: %s\n"
 msgid "%d sec"
 msgstr "%d сек"
 
-#: ../src/main.c:797 ../src/main.c:804
+#: ../src/main.c:795 ../src/main.c:802
 #, c-format
 msgid "Unable to parse YAD_OPTIONS: %s\n"
 msgstr "Не могу разобрать YAD_OPTIONS: %s\n"
 
-#: ../src/main.c:815
+#: ../src/main.c:813
 #, c-format
 msgid "Unable to parse command line: %s\n"
 msgstr "Не удается разобрать командную строку: %s\n"
@@ -231,12 +231,12 @@ msgid "Set the X position of a window"
 msgstr "Задать позицию окна по X"
 
 #: ../src/option.c:100 ../src/option.c:102 ../src/option.c:134
-#: ../src/option.c:138 ../src/option.c:169 ../src/option.c:183
-#: ../src/option.c:273 ../src/option.c:335 ../src/option.c:341
-#: ../src/option.c:420 ../src/option.c:428 ../src/option.c:430
-#: ../src/option.c:432 ../src/option.c:434 ../src/option.c:436
-#: ../src/option.c:438 ../src/option.c:442 ../src/option.c:464
-#: ../src/option.c:485 ../src/option.c:487 ../src/option.c:521
+#: ../src/option.c:138 ../src/option.c:171 ../src/option.c:185
+#: ../src/option.c:275 ../src/option.c:337 ../src/option.c:343
+#: ../src/option.c:422 ../src/option.c:430 ../src/option.c:432
+#: ../src/option.c:434 ../src/option.c:436 ../src/option.c:438
+#: ../src/option.c:440 ../src/option.c:444 ../src/option.c:466
+#: ../src/option.c:487 ../src/option.c:489 ../src/option.c:523
 msgid "NUMBER"
 msgstr "ЧИСЛО"
 
@@ -264,7 +264,7 @@ msgstr "ЗАДЕРЖКА"
 msgid "Show remaining time indicator (top, bottom, left, right)"
 msgstr "Показать индикатор задержки (top, bottom, left, right)"
 
-#: ../src/option.c:108 ../src/option.c:511
+#: ../src/option.c:108 ../src/option.c:513
 msgid "POS"
 msgstr "ПОЗИЦИЯ"
 
@@ -272,9 +272,9 @@ msgstr "ПОЗИЦИЯ"
 msgid "Set the dialog text"
 msgstr "Задать текст диалога"
 
-#: ../src/option.c:110 ../src/option.c:281 ../src/option.c:283
-#: ../src/option.c:285 ../src/option.c:321 ../src/option.c:440
-#: ../src/option.c:539
+#: ../src/option.c:110 ../src/option.c:283 ../src/option.c:285
+#: ../src/option.c:287 ../src/option.c:323 ../src/option.c:442
+#: ../src/option.c:541
 msgid "TEXT"
 msgstr "ТЕКСТ"
 
@@ -282,11 +282,11 @@ msgstr "ТЕКСТ"
 msgid "Set the dialog text alignment (left, center, right, fill)"
 msgstr "Задать выравнивание текста диалога (left, center, right, fill)"
 
-#: ../src/option.c:112 ../src/option.c:126 ../src/option.c:215
-#: ../src/option.c:333 ../src/option.c:358 ../src/option.c:414
-#: ../src/option.c:424 ../src/option.c:466 ../src/option.c:483
-#: ../src/option.c:509 ../src/option.c:519 ../src/option.c:529
-#: ../src/option.c:600 ../src/option.c:648 ../src/option.c:650
+#: ../src/option.c:112 ../src/option.c:126 ../src/option.c:217
+#: ../src/option.c:335 ../src/option.c:360 ../src/option.c:416
+#: ../src/option.c:426 ../src/option.c:468 ../src/option.c:485
+#: ../src/option.c:511 ../src/option.c:521 ../src/option.c:531
+#: ../src/option.c:602 ../src/option.c:650 ../src/option.c:652
 msgid "TYPE"
 msgstr "ТИП"
 
@@ -294,7 +294,7 @@ msgstr "ТИП"
 msgid "Set the dialog image"
 msgstr "Задать картинку диалога"
 
-#: ../src/option.c:114 ../src/option.c:291 ../src/option.c:295
+#: ../src/option.c:114 ../src/option.c:293 ../src/option.c:297
 msgid "IMAGE"
 msgstr "КАРТИНКА"
 
@@ -306,7 +306,7 @@ msgstr "Показывать картинку над основным видже
 msgid "Use specified icon theme instead of default"
 msgstr "Использовать указанную тему иконок"
 
-#: ../src/option.c:118 ../src/option.c:617
+#: ../src/option.c:118 ../src/option.c:619
 msgid "THEME"
 msgstr "ТЕМА"
 
@@ -314,7 +314,7 @@ msgstr "ТЕМА"
 msgid "Hide main widget with expander"
 msgstr "Спрятать основной виджет"
 
-#: ../src/option.c:120 ../src/option.c:311 ../src/option.c:554
+#: ../src/option.c:120 ../src/option.c:313 ../src/option.c:556
 msgid "[TEXT]"
 msgstr "[ТЕКСТ]"
 
@@ -363,466 +363,474 @@ msgid "Dialog text can be selected"
 msgstr "Текст диалога может быть выделен"
 
 #: ../src/option.c:143
+msgid "Use specified cursor name on start"
+msgstr "Использовать указанный курсор при старте"
+
+#: ../src/option.c:143
+msgid "CURSORNAME"
+msgstr "ИМЯ_КУРСОРА"
+
+#: ../src/option.c:145
 msgid "Set window sticky"
 msgstr "Окно видимо на всех рабочих столах"
 
-#: ../src/option.c:145
+#: ../src/option.c:147
 msgid "Set window unresizable"
 msgstr "Неизменяемый размер"
 
-#: ../src/option.c:147
+#: ../src/option.c:149
 msgid "Place window on top"
 msgstr "Разместить окно поверх остальных"
 
-#: ../src/option.c:149
+#: ../src/option.c:151
 msgid "Place window on center of screen"
 msgstr "Разместить окно в центре экрана"
 
-#: ../src/option.c:151
+#: ../src/option.c:153
 msgid "Place window at the mouse position"
 msgstr "Разместить окно под указателем мыши"
 
-#: ../src/option.c:153
+#: ../src/option.c:155
 msgid "Set window undecorated"
 msgstr "Убрать обрамление"
 
-#: ../src/option.c:155
+#: ../src/option.c:157
 msgid "Don't show window in taskbar"
 msgstr "Не показывать окно в панели задач"
 
-#: ../src/option.c:157
+#: ../src/option.c:159
 msgid "Set window maximized"
 msgstr "Задать окну максимальный размер"
 
-#: ../src/option.c:159
+#: ../src/option.c:161
 msgid "Set window fullscreen"
 msgstr "Развернуть окно на весь экран"
 
-#: ../src/option.c:161
+#: ../src/option.c:163
 msgid "Don't focus dialog window"
 msgstr "Не давать фокус окну диалога"
 
-#: ../src/option.c:163
+#: ../src/option.c:165
 msgid "Close window when it sets unfocused"
 msgstr "Закрыть окно при потере фокуса"
 
-#: ../src/option.c:165
+#: ../src/option.c:167
 msgid "Open window as a splashscreen"
 msgstr "Открыть окно в режиме splashscreen"
 
-#: ../src/option.c:167
+#: ../src/option.c:169
 msgid "Special type of dialog for XEMBED"
 msgstr "Специальный режим диалога для встраивания"
 
-#: ../src/option.c:167 ../src/option.c:213
+#: ../src/option.c:169 ../src/option.c:215
 msgid "KEY"
 msgstr "КЛЮЧ"
 
-#: ../src/option.c:169
+#: ../src/option.c:171
 msgid "Tab number of this dialog"
 msgstr "Номер вкладки для этого диалога"
 
-#: ../src/option.c:172
+#: ../src/option.c:174
 msgid "Send SIGNAL to parent"
 msgstr "Послать СИГНАЛ родителю"
 
-#: ../src/option.c:172
+#: ../src/option.c:174
 msgid "[SIGNAL]"
 msgstr "[СИГНАЛ]"
 
-#: ../src/option.c:174
+#: ../src/option.c:176
 msgid "Print X Window Id to the file/stderr"
 msgstr "Вывести идентификатор окна в файл/stderr"
 
-#: ../src/option.c:174 ../src/option.c:255
+#: ../src/option.c:176 ../src/option.c:257
 msgid "[FILENAME]"
 msgstr "[ИМЯ_ФАЙЛА]"
 
-#: ../src/option.c:181
+#: ../src/option.c:183
 msgid "Set the format for the returned date"
 msgstr "Задать формат возвращаемой даты"
 
-#: ../src/option.c:181 ../src/option.c:384
+#: ../src/option.c:183 ../src/option.c:386
 msgid "PATTERN"
 msgstr "ШАБЛОН"
 
-#: ../src/option.c:183
+#: ../src/option.c:185
 msgid "Set presicion of floating numbers (default - 3)"
 msgstr "Задать точность чисел с плавающей точкой (по умолчанию - 3)"
 
-#: ../src/option.c:185
+#: ../src/option.c:187
 msgid "Set command handler"
 msgstr "Задать команду-обработчик"
 
-#: ../src/option.c:185 ../src/option.c:293 ../src/option.c:297
-#: ../src/option.c:362 ../src/option.c:444 ../src/option.c:446
-#: ../src/option.c:448
+#: ../src/option.c:187 ../src/option.c:295 ../src/option.c:299
+#: ../src/option.c:364 ../src/option.c:446 ../src/option.c:448
+#: ../src/option.c:450
 msgid "CMD"
 msgstr "КОМАНДА"
 
-#: ../src/option.c:187
+#: ../src/option.c:189
 msgid "Listen for data on stdin"
 msgstr "Получать данные со стандартного ввода"
 
-#: ../src/option.c:189
+#: ../src/option.c:191
 msgid "Set common separator character"
 msgstr "Установить общий разделяющий символ"
 
-#: ../src/option.c:189 ../src/option.c:191
+#: ../src/option.c:191 ../src/option.c:193
 msgid "SEPARATOR"
 msgstr "РАЗДЕЛИТЕЛЬ"
 
-#: ../src/option.c:191
+#: ../src/option.c:193
 msgid "Set item separator character"
 msgstr "Установить разделяющий символ для элементов"
 
-#: ../src/option.c:193
+#: ../src/option.c:195
 msgid "Allow changes to text in some cases"
 msgstr "Разрешить изменять текст в определенных случаях"
 
-#: ../src/option.c:195
+#: ../src/option.c:197
 msgid "Autoscroll to end of text"
 msgstr "Автопрокрутка в конец текста"
 
-#: ../src/option.c:197
+#: ../src/option.c:199
 msgid "Quote dialogs output"
 msgstr "Вывод значений в кавычках"
 
-#: ../src/option.c:199
+#: ../src/option.c:201
 msgid "Output number instead of text for combo-box"
 msgstr "Выводить номер вместо текста для списка значений"
 
-#: ../src/option.c:201
+#: ../src/option.c:203
 msgid "Specify font name to use"
 msgstr "Указать имя используемого шрифта"
 
-#: ../src/option.c:201
+#: ../src/option.c:203
 msgid "FONTNAME"
 msgstr "ШРИФТ"
 
-#: ../src/option.c:203
+#: ../src/option.c:205
 msgid "Allow multiple selection"
 msgstr "Разрешить множественный выбор"
 
-#: ../src/option.c:205
+#: ../src/option.c:207
 msgid "Enable preview"
 msgstr "Добавить предпросмотр"
 
-#: ../src/option.c:207
+#: ../src/option.c:209
 msgid "Show hidden files in file selection dialogs"
 msgstr "Показывать скрытые файлы в диалоге выбора файла"
 
-#: ../src/option.c:209
+#: ../src/option.c:211
 msgid "Set source filename"
 msgstr "Имя исходного файла"
 
-#: ../src/option.c:209 ../src/option.c:239 ../src/option.c:646
-#: ../src/option.c:658
+#: ../src/option.c:211 ../src/option.c:241 ../src/option.c:648
+#: ../src/option.c:660
 msgid "FILENAME"
 msgstr "ИМЯ_ФАЙЛА"
 
-#: ../src/option.c:211
+#: ../src/option.c:213
 msgid "Set vertical orientation"
 msgstr "Использовать вертикальное расположение"
 
-#: ../src/option.c:213
+#: ../src/option.c:215
 msgid "Identifier of embedded dialogs"
 msgstr "Идентификатор встраиваемых диалогов"
 
-#: ../src/option.c:215
+#: ../src/option.c:217
 msgid "Set extended completion for entries (any, all, or regex)"
 msgstr "Задать расширенное дополнение для текстовых полей (any, all или regex)"
 
-#: ../src/option.c:218
+#: ../src/option.c:220
 msgid "Use IEC (base 1024) units with for size values"
 msgstr "Использовать формат IEC (база 1024) для размеров данных"
 
-#: ../src/option.c:222
+#: ../src/option.c:224
 msgid "Enable spell check for text"
 msgstr "Разрешить проверку орфографии"
 
-#: ../src/option.c:224
+#: ../src/option.c:226
 msgid "Set spell checking language"
 msgstr "Установить язык проверки орфографии"
 
-#: ../src/option.c:224
+#: ../src/option.c:226
 msgid "LANGUAGE"
 msgstr "ЯЗЫК"
 
-#: ../src/option.c:231
+#: ../src/option.c:233
 msgid "Display calendar dialog"
 msgstr "Отобразить диалог для выбора даты"
 
-#: ../src/option.c:233
+#: ../src/option.c:235
 msgid "Set the calendar day"
 msgstr "Задать день календаря"
 
-#: ../src/option.c:233
+#: ../src/option.c:235
 msgid "DAY"
 msgstr "ДЕНЬ"
 
-#: ../src/option.c:235
+#: ../src/option.c:237
 msgid "Set the calendar month"
 msgstr "Задать месяц календаря"
 
-#: ../src/option.c:235
+#: ../src/option.c:237
 msgid "MONTH"
 msgstr "МЕСЯЦ"
 
-#: ../src/option.c:237
+#: ../src/option.c:239
 msgid "Set the calendar year"
 msgstr "Задать год календаря"
 
-#: ../src/option.c:237
+#: ../src/option.c:239
 msgid "YEAR"
 msgstr "ГОД"
 
-#: ../src/option.c:239
+#: ../src/option.c:241
 msgid "Set the filename with dates details"
 msgstr "Задать имя файла с описанием дат"
 
-#: ../src/option.c:241
+#: ../src/option.c:243
 msgid "Show week numbers at the left side of calendar"
 msgstr "Показывать нумерацию недель слева"
 
-#: ../src/option.c:247
+#: ../src/option.c:249
 msgid "Display color selection dialog"
 msgstr "Отобразить диалог для выбора цвета"
 
-#: ../src/option.c:249
+#: ../src/option.c:251
 msgid "Alias for --color"
 msgstr "Синоним для --color"
 
-#: ../src/option.c:251
+#: ../src/option.c:253
 msgid "Set initial color value"
 msgstr "Задать начальное значение цвета"
 
-#: ../src/option.c:251 ../src/option.c:594 ../src/option.c:596
-#: ../src/option.c:608
+#: ../src/option.c:253 ../src/option.c:596 ../src/option.c:598
+#: ../src/option.c:610
 msgid "COLOR"
 msgstr "ЦВЕТ"
 
-#: ../src/option.c:253
+#: ../src/option.c:255
 msgid "Show system palette in color dialog"
 msgstr "Показывать системную палитру"
 
-#: ../src/option.c:255
+#: ../src/option.c:257
 msgid "Set path to palette file. Default - "
 msgstr "Задать путь к файлу цветов. По умолчанию - "
 
-#: ../src/option.c:257
+#: ../src/option.c:259
 msgid "Expand user palette"
 msgstr "Раскрывать пользовательскую палитру"
 
-#: ../src/option.c:259
+#: ../src/option.c:261
 msgid "Set output mode to MODE. Values are hex (default) or rgb"
 msgstr "Установить режим вывода в РЕЖИМ. Значения - hex (по-умолчанию) или rgb"
 
-#: ../src/option.c:259
+#: ../src/option.c:261
 msgid "MODE"
 msgstr "РЕЖИМ"
 
-#: ../src/option.c:261
+#: ../src/option.c:263
 msgid "Use #rrrrggggbbbb format instead of #rrggbb"
 msgstr "Использовать формат #rrrrggggbbbb вместо #rrggbb"
 
-#: ../src/option.c:263
+#: ../src/option.c:265
 msgid "Add opacity to output color value"
 msgstr "Добавить прозрачность к значению цвета"
 
-#: ../src/option.c:269
+#: ../src/option.c:271
 msgid "Display drag-n-drop box"
 msgstr "Отобразить диалог для перехвата dnd"
 
-#: ../src/option.c:271
+#: ../src/option.c:273
 msgid "Use dialog text as tooltip"
 msgstr "Использовать текст диалога в качестве подсказки"
 
-#: ../src/option.c:273
+#: ../src/option.c:275
 msgid "Exit after NUMBER of drops"
 msgstr "Выход после определенного количества срабатываний"
 
-#: ../src/option.c:279
+#: ../src/option.c:281
 msgid "Display text entry or combo-box dialog"
 msgstr "Отобразить диалог для ввода текста или выбора варианта"
 
-#: ../src/option.c:281
+#: ../src/option.c:283
 msgid "Set the entry label"
 msgstr "Задать метку поля ввода"
 
-#: ../src/option.c:283
+#: ../src/option.c:285
 msgid "Set the entry text"
 msgstr "Задать текст по умолчанию для ввода"
 
-#: ../src/option.c:285
+#: ../src/option.c:287
 msgid "Hide the entry text"
 msgstr "Прятать введенный текст (Пароль)"
 
-#: ../src/option.c:287
+#: ../src/option.c:289
 msgid "Use completion instead of combo-box"
 msgstr "Использовать автодополнение вместо списка значений"
 
-#: ../src/option.c:289
+#: ../src/option.c:291
 msgid "Use spin button for text entry"
 msgstr "Использовать числовое поле вместо текста"
 
-#: ../src/option.c:291
+#: ../src/option.c:293
 msgid "Set the left entry icon"
 msgstr "Задать левый значок"
 
-#: ../src/option.c:293
+#: ../src/option.c:295
 msgid "Set the left entry icon action"
 msgstr "Действие для левого значка"
 
-#: ../src/option.c:295
+#: ../src/option.c:297
 msgid "Set the right entry icon"
 msgstr "Задать правый значок"
 
-#: ../src/option.c:297
+#: ../src/option.c:299
 msgid "Set the right entry icon action"
 msgstr "Действие для правого значка"
 
-#: ../src/option.c:303
+#: ../src/option.c:305
 msgid "Display file selection dialog"
 msgstr "Отобразить диалог для выбора файла"
 
-#: ../src/option.c:305
+#: ../src/option.c:307
 msgid "Alias for --file"
 msgstr "Синоним для --file"
 
-#: ../src/option.c:307
+#: ../src/option.c:309
 msgid "Activate directory-only selection"
 msgstr "Активировать выделение только по каталогам"
 
-#: ../src/option.c:309
+#: ../src/option.c:311
 msgid "Activate save mode"
 msgstr "Активировать режим сохранения"
 
-#: ../src/option.c:311
+#: ../src/option.c:313
 msgid "Confirm file selection if filename already exists"
 msgstr "Подтверждать выбор файла, если файл уже существует"
 
-#: ../src/option.c:317
+#: ../src/option.c:319
 msgid "Display font selection dialog"
 msgstr "Отобразить диалог для выбора шрифта"
 
-#: ../src/option.c:319
+#: ../src/option.c:321
 msgid "Alias for --font"
 msgstr "Синоним для --font"
 
-#: ../src/option.c:321
+#: ../src/option.c:323
 msgid "Set text string for preview"
 msgstr "Задать текст для предпросмотра"
 
-#: ../src/option.c:323
+#: ../src/option.c:325
 msgid "Separate output of font description"
 msgstr "Раздельный вывод для описания шрифта"
 
-#: ../src/option.c:329
+#: ../src/option.c:331
 msgid "Display form dialog"
 msgstr "Отобразить диалог формы ввода"
 
-#: ../src/option.c:331
+#: ../src/option.c:333
 msgid "Add field to form (see man page for list of possible types)"
 msgstr "Добавить поле к форме (список типов указан в странице руководства)"
 
-#: ../src/option.c:331 ../src/option.c:462
+#: ../src/option.c:333 ../src/option.c:464
 msgid "LABEL[:TYPE]"
 msgstr "МЕТКА[:ТИП]"
 
-#: ../src/option.c:333
+#: ../src/option.c:335
 msgid "Set alignment of filed labels (left, center or right)"
 msgstr "Задать выравнивание меток полей (left, center или right)"
 
-#: ../src/option.c:335
+#: ../src/option.c:337
 msgid "Set number of columns in form"
 msgstr "Задать количество колонок в форме"
 
-#: ../src/option.c:337
+#: ../src/option.c:339
 msgid "Make form scrollable"
 msgstr "Сделать форму прокручиваемой"
 
-#: ../src/option.c:339
+#: ../src/option.c:341
 msgid "Order output fields by rows"
 msgstr "Упорядочить вывод по строкам"
 
-#: ../src/option.c:341
+#: ../src/option.c:343
 msgid "Set focused field"
 msgstr "Задать поле, получающее фокус"
 
-#: ../src/option.c:343
+#: ../src/option.c:345
 msgid "Cycled reading of stdin data"
 msgstr "Циклическое чтение со стандартного ввода"
 
-#: ../src/option.c:350
+#: ../src/option.c:352
 msgid "Display HTML dialog"
 msgstr "Отобразить HTML диалог"
 
-#: ../src/option.c:352
+#: ../src/option.c:354
 msgid "Open specified location"
 msgstr "Открыть указанный адрес"
 
-#: ../src/option.c:354
+#: ../src/option.c:356
 msgid "Turn on browser mode"
 msgstr "Включить режим браузера"
 
-#: ../src/option.c:356
+#: ../src/option.c:358
 msgid "Print clicked uri to stdout"
 msgstr "Печатать ссылки по щелчку"
 
-#: ../src/option.c:358
+#: ../src/option.c:360
 msgid "Set mime type of input stream data"
 msgstr "Задать тип mime для входных данных"
 
-#: ../src/option.c:360
+#: ../src/option.c:362
 msgid "Set encoding of input stream data"
 msgstr "Задать кодировку для входных данных"
 
-#: ../src/option.c:360
+#: ../src/option.c:362
 msgid "ENCODING"
 msgstr "КОДИРОВКА"
 
-#: ../src/option.c:362
+#: ../src/option.c:364
 msgid "Set external handler for clicked uri"
 msgstr "Задать внешний обработчик для выбираемых ссылок"
 
-#: ../src/option.c:364
+#: ../src/option.c:366
 msgid "Set user agent string"
 msgstr "Задать строку агента"
 
-#: ../src/option.c:364 ../src/option.c:495
+#: ../src/option.c:366 ../src/option.c:497
 msgid "STRING"
 msgstr "СТРОКА"
 
-#: ../src/option.c:366
+#: ../src/option.c:368
 msgid "Set path or uri to user styles"
 msgstr "Задать путь или адрес пользовательских стилей"
 
-#: ../src/option.c:373
+#: ../src/option.c:375
 msgid "Display icons box dialog"
 msgstr "Отобразить диалог со значками быстрого доступа"
 
-#: ../src/option.c:375
+#: ../src/option.c:377
 msgid "Read data from .desktop files in specified directory"
 msgstr "Читать данные из .desktop файлов в определенном каталоге"
 
-#: ../src/option.c:375
+#: ../src/option.c:377
 msgid "DIR"
 msgstr "КАТАЛОГ"
 
-#: ../src/option.c:377
+#: ../src/option.c:379
 msgid "Use compact (list) view"
 msgstr "Использовать компактный вид (список)"
 
-#: ../src/option.c:379
+#: ../src/option.c:381
 msgid "Use GenericName field instead of Name for icon label"
 msgstr "Использовать поле GenericName вместо Name для метки"
 
-#: ../src/option.c:381
+#: ../src/option.c:383
 msgid "Set the width of dialog items"
 msgstr "Задать ширину элемента диалога"
 
-#: ../src/option.c:384
+#: ../src/option.c:386
 #, no-c-format
 msgid ""
 "Use specified pattern for launch command in terminal (default: xterm -e %s)"
@@ -830,88 +838,88 @@ msgstr ""
 "Использовать указанный шаблон для запуска в терминале (по умолчанию: xterm -"
 "e %s)"
 
-#: ../src/option.c:386
+#: ../src/option.c:388
 msgid "Sort items by name instead of filename"
 msgstr "Сортировать по полю Имя вместо имени файла"
 
-#: ../src/option.c:388
+#: ../src/option.c:390
 msgid "Sort items in descending order"
 msgstr "Сортировать в убывающем порядке"
 
-#: ../src/option.c:390
+#: ../src/option.c:392
 msgid "Activate items by single click"
 msgstr "Активировать элемент одинарным щелчком"
 
-#: ../src/option.c:393
+#: ../src/option.c:395
 msgid "Watch fot changes in directory"
 msgstr "Отслеживать изменения в каталоге"
 
-#: ../src/option.c:400
+#: ../src/option.c:402
 msgid "Display list dialog"
 msgstr "Отобразить диалог со списком"
 
-#: ../src/option.c:402
+#: ../src/option.c:404
 msgid "Set the column header (see man page for list of possible types)"
 msgstr "Задать заголовок колонки (список типов указан в странице руководства)"
 
-#: ../src/option.c:402
+#: ../src/option.c:404
 msgid "COLUMN[:TYPE]"
 msgstr "СТОЛБЕЦ[:ТИП]"
 
-#: ../src/option.c:404
+#: ../src/option.c:406
 msgid "Use checkboxes for first column"
 msgstr "Использовать флажки для первой колонки"
 
-#: ../src/option.c:406
+#: ../src/option.c:408
 msgid "Use radioboxes for first column"
 msgstr "Использовать переключатель для первой колонки"
 
-#: ../src/option.c:408
+#: ../src/option.c:410
 msgid "Don't show column headers"
 msgstr "Не показывать заголовки колонок"
 
-#: ../src/option.c:410
+#: ../src/option.c:412
 msgid "Disable clickable column headers"
 msgstr "Запретить нажимаемые заголовки"
 
-#: ../src/option.c:412
+#: ../src/option.c:414
 msgid "Disable rules hints"
 msgstr "Запретить раскраску строк"
 
-#: ../src/option.c:414
+#: ../src/option.c:416
 msgid "Set grid lines (hor[izontal], vert[ical] or both)"
 msgstr "Задать разделительные линиии (hor[izontal], vert[ical] или both)"
 
-#: ../src/option.c:416
+#: ../src/option.c:418
 msgid "Print all data from list"
 msgstr "Печатать таблицу полностью"
 
-#: ../src/option.c:418
+#: ../src/option.c:420
 msgid "Set the list of editable columns"
 msgstr "Задать список редактируемых колонок"
 
-#: ../src/option.c:418 ../src/option.c:422 ../src/option.c:426
+#: ../src/option.c:420 ../src/option.c:424 ../src/option.c:428
 msgid "LIST"
 msgstr "СПИСОК"
 
-#: ../src/option.c:420
+#: ../src/option.c:422
 msgid "Set the width of a column for start wrapping text"
 msgstr "Задать ширину колонки для переноса"
 
-#: ../src/option.c:422
+#: ../src/option.c:424
 msgid "Set the list of wrapped columns"
 msgstr "Задать список колонок для переноса"
 
-#: ../src/option.c:424
+#: ../src/option.c:426
 msgid "Set ellipsize mode for text columns (none, start, middle or end)"
 msgstr ""
 "Задать тип усечсения для текстовых колонок (none, start, middle или end)"
 
-#: ../src/option.c:426
+#: ../src/option.c:428
 msgid "Set the list of ellipsized columns"
 msgstr "Задать список колонок для усечения"
 
-#: ../src/option.c:428
+#: ../src/option.c:430
 msgid ""
 "Print a specific column. By default or if 0 is specified will be printed all "
 "columns"
@@ -919,680 +927,680 @@ msgstr ""
 "Распечатать только определённую колонку. По умолчанию или если колонка равна "
 "0, будут распечатаны все колонки"
 
-#: ../src/option.c:430
+#: ../src/option.c:432
 msgid "Hide a specific column"
 msgstr "Скрыть указанную колонку"
 
-#: ../src/option.c:432
+#: ../src/option.c:434
 msgid "Set the column expandable by default. 0 sets all columns expandable"
 msgstr ""
 "Задать колонку, расширяемую по умолчанию. 0 устанавливает расширяемыми все "
 "колонки"
 
-#: ../src/option.c:434
+#: ../src/option.c:436
 msgid ""
 "Set the quick search column. Default is first column. Set it to 0 for "
 "disable searching"
 msgstr "Задать колонку поиска. По умолчанию первая. 0 запрещает поиск"
 
-#: ../src/option.c:436
+#: ../src/option.c:438
 msgid "Set the tooltip column"
 msgstr "Задать колонку всплывающих подсказок"
 
-#: ../src/option.c:438
+#: ../src/option.c:440
 msgid "Set the row separator column"
 msgstr "Задать колонку разделителя строк"
 
-#: ../src/option.c:440
+#: ../src/option.c:442
 msgid "Set the row separator value"
 msgstr "Задать значение разделителя строк"
 
-#: ../src/option.c:442
+#: ../src/option.c:444
 msgid "Set the limit of rows in list"
 msgstr "Задать количество строк в списке"
 
-#: ../src/option.c:444
+#: ../src/option.c:446
 msgid "Set double-click action"
 msgstr "Действие по двойному щелчку мыши"
 
-#: ../src/option.c:446
+#: ../src/option.c:448
 msgid "Set select action"
 msgstr "Действие при выделении строки"
 
-#: ../src/option.c:448
+#: ../src/option.c:450
 msgid "Set add action"
 msgstr "Действие при добавлении строки"
 
-#: ../src/option.c:450
+#: ../src/option.c:452
 msgid "Use regex in search"
 msgstr "Использовать регулярные выражения при поиске"
 
-#: ../src/option.c:452
+#: ../src/option.c:454
 msgid "Disable selection"
 msgstr "Запретить выделение"
 
-#: ../src/option.c:454
+#: ../src/option.c:456
 msgid "Add new records on the top of a list"
 msgstr "Добавлять новые записи в начало списка"
 
-#: ../src/option.c:460
+#: ../src/option.c:462
 msgid "Display multi progress bars dialog"
 msgstr "Отобразить диалог c несколькими индикаторами"
 
-#: ../src/option.c:462
+#: ../src/option.c:464
 msgid "Add the progress bar (norm, rtl, pulse or perm)"
 msgstr "Добавить индикатор (norm, rtl, pulse или perm)"
 
-#: ../src/option.c:464
+#: ../src/option.c:466
 msgid "Watch for specific bar for auto close"
 msgstr "Следить за определенным индикатором для автозакрытия"
 
-#: ../src/option.c:466
+#: ../src/option.c:468
 msgid "Set alignment of bar labels (left, center or right)"
 msgstr "Задать выравнивание меток индикаторов (left, center или right)"
 
-#: ../src/option.c:469
+#: ../src/option.c:471
 #, no-c-format
 msgid "Dismiss the dialog when 100% of all bars has been reached"
 msgstr "Закрыть диалог по достижении 100% всеми индикаторами"
 
-#: ../src/option.c:472 ../src/option.c:549
+#: ../src/option.c:474 ../src/option.c:551
 msgid "Kill parent process if cancel button is pressed"
 msgstr "Завершить родительский процесс, если нажата кнопка отмены"
 
-#: ../src/option.c:479
+#: ../src/option.c:481
 msgid "Display notebook dialog"
 msgstr "Отобразить диалог с вкладками"
 
-#: ../src/option.c:481
+#: ../src/option.c:483
 msgid "Add a tab to notebook"
 msgstr "Добавить вкладку"
 
-#: ../src/option.c:481
+#: ../src/option.c:483
 msgid "LABEL"
 msgstr "МЕТКА"
 
-#: ../src/option.c:483
+#: ../src/option.c:485
 msgid "Set position of a notebook tabs (top, bottom, left or right)"
 msgstr "Задать позицию метки вкладки (top, bottom, left или right)"
 
-#: ../src/option.c:485
+#: ../src/option.c:487
 msgid "Set tab borders"
 msgstr "Установить границы вкладки"
 
-#: ../src/option.c:487
+#: ../src/option.c:489
 msgid "Set active tab"
 msgstr "Задать активную вкладку"
 
-#: ../src/option.c:493
+#: ../src/option.c:495
 msgid "Display notification"
 msgstr "Отобразить диалог уведомления"
 
-#: ../src/option.c:495
+#: ../src/option.c:497
 msgid "Set initial popup menu"
 msgstr "Задать начальное меню"
 
-#: ../src/option.c:497
+#: ../src/option.c:499
 msgid "Disable exit on middle click"
 msgstr "Запретить выход по щелчку средней кнопкой"
 
-#: ../src/option.c:499
+#: ../src/option.c:501
 msgid "Doesn't show icon at startup"
 msgstr "Не показывать иконку при запуске"
 
-#: ../src/option.c:501
+#: ../src/option.c:503
 msgid "Set icon size for fully specified icons (default - 16)"
 msgstr "Задать размер иконки для полностью указанных (по умолчанию - 16)"
 
-#: ../src/option.c:501 ../src/option.c:602
+#: ../src/option.c:503 ../src/option.c:604
 msgid "SIZE"
 msgstr "РАЗМЕР"
 
-#: ../src/option.c:507
+#: ../src/option.c:509
 msgid "Display paned dialog"
 msgstr "Отобразить диалог панелей"
 
-#: ../src/option.c:509
+#: ../src/option.c:511
 msgid "Set orientation (hor[izontal] or vert[ical])"
 msgstr "Задать ориентацию (hor[izontal] или vert[ical])"
 
-#: ../src/option.c:511
+#: ../src/option.c:513
 msgid "Set initial splitter position"
 msgstr "Задать начальную позицию разделителя"
 
-#: ../src/option.c:517
+#: ../src/option.c:519
 msgid "Display picture dialog"
 msgstr "Отобразить диалог показа картинки"
 
-#: ../src/option.c:519
+#: ../src/option.c:521
 msgid "Set initial size (fit or orig)"
 msgstr "Задать начальный размер (fit или orig)"
 
-#: ../src/option.c:521
+#: ../src/option.c:523
 msgid "Set increment for picture scaling (default - 5)"
 msgstr "Задать шаг для масштабирования картинки (по умолчанию - 5)"
 
-#: ../src/option.c:527
+#: ../src/option.c:529
 msgid "Display printing dialog"
 msgstr "Отобразить диалог печати"
 
-#: ../src/option.c:529
+#: ../src/option.c:531
 msgid "Set source type (text, image or raw)"
 msgstr "Тип исходных данных (text, image или raw)"
 
-#: ../src/option.c:531
+#: ../src/option.c:533
 msgid "Add headers to page"
 msgstr "Добавлять колонтитулы на страницу"
 
-#: ../src/option.c:537
+#: ../src/option.c:539
 msgid "Display progress indication dialog"
 msgstr "Отобразить диалог хода процесса"
 
-#: ../src/option.c:539
+#: ../src/option.c:541
 msgid "Set progress text"
 msgstr "Показывать текст на индикаторе"
 
-#: ../src/option.c:541
+#: ../src/option.c:543
 msgid "Set initial percentage"
 msgstr "Задать начальный процент"
 
-#: ../src/option.c:541
+#: ../src/option.c:543
 msgid "PERCENTAGE"
 msgstr "ПРОЦЕНТЫ"
 
-#: ../src/option.c:543
+#: ../src/option.c:545
 msgid "Pulsate progress bar"
 msgstr "Пульсирующий индикатор прогресса"
 
-#: ../src/option.c:546
+#: ../src/option.c:548
 #, no-c-format
 msgid "Dismiss the dialog when 100% has been reached"
 msgstr "Закрыть диалог по достижении 100%"
 
-#: ../src/option.c:552
+#: ../src/option.c:554
 msgid "Right-To-Left progress bar direction"
 msgstr "Направление индикатора Справа-Налево"
 
-#: ../src/option.c:554
+#: ../src/option.c:556
 msgid "Show log window"
 msgstr "Показать окно журнала"
 
-#: ../src/option.c:556
+#: ../src/option.c:558
 msgid "Expand log window"
 msgstr "Развернуть окно журнала"
 
-#: ../src/option.c:558
+#: ../src/option.c:560
 msgid "Place log window above progress bar"
 msgstr "Разместить окно журнала над индикатором прогресса"
 
-#: ../src/option.c:560
+#: ../src/option.c:562
 msgid "Height of log window"
 msgstr "Высота окна журнала"
 
-#: ../src/option.c:566
+#: ../src/option.c:568
 msgid "Display scale dialog"
 msgstr "Отобразить диалог масштаба"
 
-#: ../src/option.c:568
+#: ../src/option.c:570
 msgid "Set initial value"
 msgstr "Задать начальное значение"
 
-#: ../src/option.c:568 ../src/option.c:570 ../src/option.c:572
-#: ../src/option.c:574 ../src/option.c:576
+#: ../src/option.c:570 ../src/option.c:572 ../src/option.c:574
+#: ../src/option.c:576 ../src/option.c:578
 msgid "VALUE"
 msgstr "ЗНАЧЕНИЕ"
 
-#: ../src/option.c:570
+#: ../src/option.c:572
 msgid "Set minimum value"
 msgstr "Задать минимальное значение"
 
-#: ../src/option.c:572
+#: ../src/option.c:574
 msgid "Set maximum value"
 msgstr "Задать максимальное значение"
 
-#: ../src/option.c:574
+#: ../src/option.c:576
 msgid "Set step size"
 msgstr "Задать шаг"
 
-#: ../src/option.c:576
+#: ../src/option.c:578
 msgid "Set paging size"
 msgstr "Задать шаг страницы"
 
-#: ../src/option.c:578
+#: ../src/option.c:580
 msgid "Print partial values"
 msgstr "Печатать частичные значения"
 
-#: ../src/option.c:580
+#: ../src/option.c:582
 msgid "Hide value"
 msgstr "Скрыть величину"
 
-#: ../src/option.c:582
+#: ../src/option.c:584
 msgid "Invert direction"
 msgstr "Инвертировать направление"
 
-#: ../src/option.c:584
+#: ../src/option.c:586
 msgid "Show +/- buttons in scale"
 msgstr "Показывать кнопки +/-"
 
-#: ../src/option.c:586
+#: ../src/option.c:588
 msgid "Add mark to scale (may be used multiple times)"
 msgstr "Добавить метку (может использоваться несколько раз)"
 
-#: ../src/option.c:586
+#: ../src/option.c:588
 msgid "NAME:VALUE"
 msgstr "ИМЯ:ЗНАЧЕНИЕ"
 
-#: ../src/option.c:592
+#: ../src/option.c:594
 msgid "Display text information dialog"
 msgstr "Отобразить диалог с текстовой информацией"
 
-#: ../src/option.c:594
+#: ../src/option.c:596
 msgid "Use specified color for text"
 msgstr "Использовать указанный цвет текста"
 
-#: ../src/option.c:596
+#: ../src/option.c:598
 msgid "Use specified color for background"
 msgstr "Использовать указанный цвет фона"
 
-#: ../src/option.c:598
+#: ../src/option.c:600
 msgid "Enable text wrapping"
 msgstr "Разрешить перенос текста"
 
-#: ../src/option.c:600
+#: ../src/option.c:602
 msgid "Set justification (left, right, center or fill)"
 msgstr "Установить выравнивание (left, right, center или fill)"
 
-#: ../src/option.c:602
+#: ../src/option.c:604
 msgid "Set text margins"
 msgstr "Установить отступы"
 
-#: ../src/option.c:604
+#: ../src/option.c:606
 msgid "Show cursor in read-only mode"
 msgstr "Показывать курсор в режиме для чтения"
 
-#: ../src/option.c:606
+#: ../src/option.c:608
 msgid "Make URI clickable"
 msgstr "Сделать ссылки активными"
 
-#: ../src/option.c:608
+#: ../src/option.c:610
 msgid "Use specified color for links"
 msgstr "Использовать указанный цвет для ссылок"
 
-#: ../src/option.c:615
+#: ../src/option.c:617
 msgid "Use specified langauge for syntax highlighting"
 msgstr "Использовать указанный язык для подсветки синтаксиса"
 
-#: ../src/option.c:615
+#: ../src/option.c:617
 msgid "LANG"
 msgstr "ЯЗЫК"
 
-#: ../src/option.c:617
+#: ../src/option.c:619
 msgid "Use specified theme"
 msgstr "Использовать указанную тему"
 
-#: ../src/option.c:624
+#: ../src/option.c:626
 msgid "Sets a filename filter"
 msgstr "Задать фильтр файлов по маске"
 
-#: ../src/option.c:624
+#: ../src/option.c:626
 msgid "NAME | PATTERN1 PATTERN2 ..."
 msgstr "ИМЯ | ШАБЛОН1 ШАБЛОН2 ..."
 
-#: ../src/option.c:626
+#: ../src/option.c:628
 msgid "Sets a mime-type filter"
 msgstr "Задать фильтр файлов по типу mime"
 
-#: ../src/option.c:626
+#: ../src/option.c:628
 msgid "NAME | MIME1 MIME2 ..."
 msgstr "ИМЯ | ТИП1 ТИП2 ..."
 
-#: ../src/option.c:628
+#: ../src/option.c:630
 msgid "Add filter for images"
 msgstr "Добавить фильтр изображений"
 
-#: ../src/option.c:628
+#: ../src/option.c:630
 msgid "[NAME]"
 msgstr "[ИМЯ]"
 
-#: ../src/option.c:634
+#: ../src/option.c:636
 msgid "Show about dialog"
 msgstr "Показать диалог 'О программе'"
 
-#: ../src/option.c:636
+#: ../src/option.c:638
 msgid "Print version"
 msgstr "Вывести версию"
 
-#: ../src/option.c:639
+#: ../src/option.c:641
 msgid "Show list of spell languages"
 msgstr "Показать список языков проверки орфографии"
 
-#: ../src/option.c:643
+#: ../src/option.c:645
 msgid "Show list of GtkSourceView themes"
 msgstr "Показать список текм для GtkSourceView"
 
-#: ../src/option.c:646
+#: ../src/option.c:648
 msgid "Load additional GTK settings from file"
 msgstr "Загрузить дополнительные настройки GTK из файла"
 
-#: ../src/option.c:648
+#: ../src/option.c:650
 msgid "Set policy for horizontal scrollbars (auto, always, never)"
 msgstr "Задать тип горизонтальной прокрутки (auto, always, never)"
 
-#: ../src/option.c:650
+#: ../src/option.c:652
 msgid "Set policy for vertical scrollbars (auto, always, never)"
 msgstr "Задать тип вертикальной прокрутки (auto, always, never)"
 
-#: ../src/option.c:652
+#: ../src/option.c:654
 msgid "Add path for search icons by name"
 msgstr "Добавить каталог для поиска изображений по имени"
 
-#: ../src/option.c:652
+#: ../src/option.c:654
 msgid "PATH"
 msgstr "ПУТЬ"
 
-#: ../src/option.c:658
+#: ../src/option.c:660
 msgid "Load extra arguments from file"
 msgstr "Загрузить дополнительные аргументы из файла"
 
-#: ../src/option.c:699 ../src/option.c:998
+#: ../src/option.c:701 ../src/option.c:1000
 #, c-format
 msgid "Unknown align type: %s\n"
 msgstr "Неизвестный тип выравнивания: %s\n"
 
-#: ../src/option.c:862
+#: ../src/option.c:864
 #, c-format
 msgid "Mark %s doesn't have a value\n"
 msgstr "Метке %s не задано значение\n"
 
-#: ../src/option.c:899
+#: ../src/option.c:901
 msgid "Images"
 msgstr "Изображения"
 
-#: ../src/option.c:964
+#: ../src/option.c:966
 #, c-format
 msgid "Unknown color mode: %s\n"
 msgstr "Неизвестный режим цвета: '%s'\n"
 
-#: ../src/option.c:983
+#: ../src/option.c:985
 #, c-format
 msgid "Unknown buttons layout type: %s\n"
 msgstr "Неизвестный тип расположения кнопок: %s\n"
 
-#: ../src/option.c:1015
+#: ../src/option.c:1017
 #, c-format
 msgid "Unknown justification type: %s\n"
 msgstr "Неизвестный тип выравнивания: %s\n"
 
-#: ../src/option.c:1032
+#: ../src/option.c:1034
 #, c-format
 msgid "Unknown tab position type: %s\n"
 msgstr "Неизвестный тип позиции вкладки: %s\n"
 
-#: ../src/option.c:1068
+#: ../src/option.c:1070
 #, c-format
 msgid "Unknown ellipsize type: %s\n"
 msgstr "Неизвестный тип усечения: %s\n"
 
-#: ../src/option.c:1081
+#: ../src/option.c:1083
 #, c-format
 msgid "Unknown orientation: %s\n"
 msgstr "Неизвестная ориентация: %s\n"
 
-#: ../src/option.c:1096
+#: ../src/option.c:1098
 #, c-format
 msgid "Unknown source type: %s\n"
 msgstr "Неизвестный исходный тип: %s\n"
 
-#: ../src/option.c:1107
+#: ../src/option.c:1109
 msgid "Progress log"
 msgstr "Окно журнала"
 
-#: ../src/option.c:1120
+#: ../src/option.c:1122
 #, c-format
 msgid "Unknown size type: %s\n"
 msgstr "Неизвестный тип размера: %s\n"
 
-#: ../src/option.c:1158
+#: ../src/option.c:1160
 #, c-format
 msgid "Unknown completion type: %s\n"
 msgstr "Неизвестный тип дополнения: %s\n"
 
-#: ../src/option.c:1173
+#: ../src/option.c:1175
 #, c-format
 msgid "Unknown grid lines type: %s\n"
 msgstr "Неизвестный тип разделительных линий: %s\n"
 
-#: ../src/option.c:1190
+#: ../src/option.c:1192
 #, c-format
 msgid "Unknown scrollbar policy type: %s\n"
 msgstr "Неизвестный тип прокрутки: %s\n"
 
-#: ../src/option.c:1308
+#: ../src/option.c:1310
 #, c-format
 msgid "Unknown signal: %s\n"
 msgstr "Неизвестный сигнал: %s\n"
 
-#: ../src/option.c:1500
+#: ../src/option.c:1503
 msgid "File exist. Overwrite?"
 msgstr "Файл существует. Перезаписать?"
 
-#: ../src/option.c:1648
+#: ../src/option.c:1651
 msgid "- Yet another dialoging program"
 msgstr "- Программа для отображения диалогов"
 
 #. Adds general option entries
-#: ../src/option.c:1652
+#: ../src/option.c:1655
 msgid "General options"
 msgstr "Основные параметры"
 
-#: ../src/option.c:1652
+#: ../src/option.c:1655
 msgid "Show general options"
 msgstr "Показывать основные параметры"
 
 #. Adds common option entries
-#: ../src/option.c:1658
+#: ../src/option.c:1661
 msgid "Common options"
 msgstr "Общие параметры"
 
-#: ../src/option.c:1658
+#: ../src/option.c:1661
 msgid "Show common options"
 msgstr "Показывать общие параметры диалогов"
 
 #. Adds calendar option entries
-#: ../src/option.c:1664
+#: ../src/option.c:1667
 msgid "Calendar options"
 msgstr "Параметры календаря"
 
-#: ../src/option.c:1664
+#: ../src/option.c:1667
 msgid "Show calendar options"
 msgstr "Показывать параметры календаря"
 
 #. Adds color option entries
-#: ../src/option.c:1670
+#: ../src/option.c:1673
 msgid "Color selection options"
 msgstr "Параметры диалога выбора цвета"
 
-#: ../src/option.c:1670
+#: ../src/option.c:1673
 msgid "Show color selection options"
 msgstr "Показывать параметры диалога выбора цвета"
 
 #. Adds dnd option entries
-#: ../src/option.c:1676
+#: ../src/option.c:1679
 msgid "DND options"
 msgstr "Параметры DND"
 
-#: ../src/option.c:1676
+#: ../src/option.c:1679
 msgid "Show drag-n-drop options"
 msgstr "Показывать параметры dnd"
 
 #. Adds entry option entries
-#: ../src/option.c:1682
+#: ../src/option.c:1685
 msgid "Text entry options"
 msgstr "Параметры ввода текста"
 
-#: ../src/option.c:1682
+#: ../src/option.c:1685
 msgid "Show text entry options"
 msgstr "Показывать параметры ввода текста"
 
 #. Adds file selection option entries
-#: ../src/option.c:1688
+#: ../src/option.c:1691
 msgid "File selection options"
 msgstr "Параметры диалога выбора файла"
 
-#: ../src/option.c:1688
+#: ../src/option.c:1691
 msgid "Show file selection options"
 msgstr "Показывать параметры диалога выбора файлов"
 
 #. Add font selection option entries
-#: ../src/option.c:1694
+#: ../src/option.c:1697
 msgid "Font selection options"
 msgstr "Параметры диалога выбора шрифта"
 
-#: ../src/option.c:1694
+#: ../src/option.c:1697
 msgid "Show font selection options"
 msgstr "Показывать параметры диалога выбора шрифта"
 
 #. Add form option entries
-#: ../src/option.c:1700
+#: ../src/option.c:1703
 msgid "Form options"
 msgstr "Параметры диалога формы"
 
-#: ../src/option.c:1700
+#: ../src/option.c:1703
 msgid "Show form options"
 msgstr "Показывать параметры диалога формы"
 
 #. Add html options entries
-#: ../src/option.c:1707
+#: ../src/option.c:1710
 msgid "HTML options"
 msgstr "Параметры HTML диалога"
 
-#: ../src/option.c:1707
+#: ../src/option.c:1710
 msgid "Show HTML options"
 msgstr "Показывать параметры HTML диалога"
 
 #. Add icons option entries
-#: ../src/option.c:1714
+#: ../src/option.c:1717
 msgid "Icons box options"
 msgstr "Параметры диалога значков"
 
-#: ../src/option.c:1714
+#: ../src/option.c:1717
 msgid "Show icons box options"
 msgstr "Показывать параметры диалога значков быстрого доступа"
 
 #. Adds list option entries
-#: ../src/option.c:1720
+#: ../src/option.c:1723
 msgid "List options"
 msgstr "Параметры списка"
 
-#: ../src/option.c:1720
+#: ../src/option.c:1723
 msgid "Show list options"
 msgstr "Показывать параметры списка"
 
 #. Adds multi progress option entries
-#: ../src/option.c:1726
+#: ../src/option.c:1729
 msgid "Multi progress bars options"
 msgstr "Параметры диалога с несколькими индикаторами"
 
-#: ../src/option.c:1727
+#: ../src/option.c:1730
 msgid "Show multi progress bars options"
 msgstr "Показывать параметры диалога с несколькими индикаторами"
 
 #. Adds notebook option entries
-#: ../src/option.c:1733
+#: ../src/option.c:1736
 msgid "Notebook options"
 msgstr "Параметры диалога с вкладками"
 
-#: ../src/option.c:1733
+#: ../src/option.c:1736
 msgid "Show notebook dialog options"
 msgstr "Показывать параметры диалога с вкладками"
 
 #. Adds notification option entries
-#: ../src/option.c:1739
+#: ../src/option.c:1742
 msgid "Notification icon options"
 msgstr "Параметры значка уведомления"
 
-#: ../src/option.c:1740
+#: ../src/option.c:1743
 msgid "Show notification icon options"
 msgstr "Показывать параметры значка уведомления"
 
 #. Adds paned option entries
-#: ../src/option.c:1746
+#: ../src/option.c:1749
 msgid "Paned dialog options"
 msgstr "Параметры диалога с панелями"
 
-#: ../src/option.c:1746
+#: ../src/option.c:1749
 msgid "Show paned dialog options"
 msgstr "Показывать параметры диалога с панелями"
 
 #. Adds picture option entries
-#: ../src/option.c:1752
+#: ../src/option.c:1755
 msgid "Picture dialog options"
 msgstr "Параметры диалога показа картинки"
 
-#: ../src/option.c:1752
+#: ../src/option.c:1755
 msgid "Show picture dialog options"
 msgstr "Показывать параметры диалога отображения картинки"
 
 #. Adds print option entries
-#: ../src/option.c:1758
+#: ../src/option.c:1761
 msgid "Print dialog options"
 msgstr "Параметры диалога печати"
 
-#: ../src/option.c:1758
+#: ../src/option.c:1761
 msgid "Show print dialog options"
 msgstr "Показывать параметры диалога печати"
 
 #. Adds progress option entries
-#: ../src/option.c:1764
+#: ../src/option.c:1767
 msgid "Progress options"
 msgstr "Параметры хода процесса"
 
-#: ../src/option.c:1764
+#: ../src/option.c:1767
 msgid "Show progress options"
 msgstr "Показывать параметры хода процесса"
 
 #. Adds scale option entries
-#: ../src/option.c:1770
+#: ../src/option.c:1773
 msgid "Scale options"
 msgstr "Параметры масштаба"
 
-#: ../src/option.c:1770
+#: ../src/option.c:1773
 msgid "Show scale options"
 msgstr "Показывать параметры масштаба"
 
 #. Adds text option entries
-#: ../src/option.c:1776
+#: ../src/option.c:1779
 msgid "Text information options"
 msgstr "Параметры текстовой информации"
 
-#: ../src/option.c:1776
+#: ../src/option.c:1779
 msgid "Show text information options"
 msgstr "Показывать параметры текстовой информации"
 
 #. Adds sourceview option entries
-#: ../src/option.c:1783
+#: ../src/option.c:1786
 msgid "SourceView options"
 msgstr "Параметры SourceView"
 
-#: ../src/option.c:1783
+#: ../src/option.c:1786
 msgid "Show SourceView options"
 msgstr "Показывать параметры SourceView"
 
 #. Adds file filters option entries
-#: ../src/option.c:1790
+#: ../src/option.c:1793
 msgid "File filter options"
 msgstr "Параметры фильтров диалога выбора файла"
 
-#: ../src/option.c:1790
+#: ../src/option.c:1793
 msgid "Show file filter options"
 msgstr "Показывать параметры фильтров диалога выбора файлов"
 
 #. Adds miscellaneous option entries
-#: ../src/option.c:1796
+#: ../src/option.c:1799
 msgid "Miscellaneous options"
 msgstr "Дополнительные параметры"
 
-#: ../src/option.c:1796
+#: ../src/option.c:1799
 msgid "Show miscellaneous options"
 msgstr "Показывать дополнительные параметры"
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YAD\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-10-30 16:34+0200\n"
-"PO-Revision-Date: 2009-04-30 16:47+0300\n"
+"POT-Creation-Date: 2018-04-09 17:08+0000\n"
+"PO-Revision-Date: 2018-04-09 17:12+0000\n"
 "Last-Translator: Victor Ananjevsky <ananasik@gmail.com>\n"
 "Language-Team: \n"
 "Language: uk\n"
@@ -148,12 +148,12 @@ msgstr "Не можу відкрити каталог %s: %s\n"
 msgid "%d sec"
 msgstr "%d сек"
 
-#: ../src/main.c:797 ../src/main.c:804
+#: ../src/main.c:795 ../src/main.c:802
 #, c-format
 msgid "Unable to parse YAD_OPTIONS: %s\n"
 msgstr "Не можу розібрати YAD_OPTIONS: %s\n"
 
-#: ../src/main.c:815
+#: ../src/main.c:813
 #, c-format
 msgid "Unable to parse command line: %s\n"
 msgstr "Не вдається розібрати командний рядок: %s\n"
@@ -231,12 +231,12 @@ msgid "Set the X position of a window"
 msgstr "Задати позицію вікна по X"
 
 #: ../src/option.c:100 ../src/option.c:102 ../src/option.c:134
-#: ../src/option.c:138 ../src/option.c:169 ../src/option.c:183
-#: ../src/option.c:273 ../src/option.c:335 ../src/option.c:341
-#: ../src/option.c:420 ../src/option.c:428 ../src/option.c:430
-#: ../src/option.c:432 ../src/option.c:434 ../src/option.c:436
-#: ../src/option.c:438 ../src/option.c:442 ../src/option.c:464
-#: ../src/option.c:485 ../src/option.c:487 ../src/option.c:521
+#: ../src/option.c:138 ../src/option.c:171 ../src/option.c:185
+#: ../src/option.c:275 ../src/option.c:337 ../src/option.c:343
+#: ../src/option.c:422 ../src/option.c:430 ../src/option.c:432
+#: ../src/option.c:434 ../src/option.c:436 ../src/option.c:438
+#: ../src/option.c:440 ../src/option.c:444 ../src/option.c:466
+#: ../src/option.c:487 ../src/option.c:489 ../src/option.c:523
 msgid "NUMBER"
 msgstr "ЧИСЛО"
 
@@ -264,7 +264,7 @@ msgstr "ЗАТРИМКА"
 msgid "Show remaining time indicator (top, bottom, left, right)"
 msgstr "Показник часу, який залишився (top, bottom, left, right)"
 
-#: ../src/option.c:108 ../src/option.c:511
+#: ../src/option.c:108 ../src/option.c:513
 msgid "POS"
 msgstr "ПОЗИЦІЯ"
 
@@ -272,9 +272,9 @@ msgstr "ПОЗИЦІЯ"
 msgid "Set the dialog text"
 msgstr "Задати текст діалогу"
 
-#: ../src/option.c:110 ../src/option.c:281 ../src/option.c:283
-#: ../src/option.c:285 ../src/option.c:321 ../src/option.c:440
-#: ../src/option.c:539
+#: ../src/option.c:110 ../src/option.c:283 ../src/option.c:285
+#: ../src/option.c:287 ../src/option.c:323 ../src/option.c:442
+#: ../src/option.c:541
 msgid "TEXT"
 msgstr "ТЕКСТ"
 
@@ -282,11 +282,11 @@ msgstr "ТЕКСТ"
 msgid "Set the dialog text alignment (left, center, right, fill)"
 msgstr "Задати вирівнювання тексту діалогу (left, center, right, fill)"
 
-#: ../src/option.c:112 ../src/option.c:126 ../src/option.c:215
-#: ../src/option.c:333 ../src/option.c:358 ../src/option.c:414
-#: ../src/option.c:424 ../src/option.c:466 ../src/option.c:483
-#: ../src/option.c:509 ../src/option.c:519 ../src/option.c:529
-#: ../src/option.c:600 ../src/option.c:648 ../src/option.c:650
+#: ../src/option.c:112 ../src/option.c:126 ../src/option.c:217
+#: ../src/option.c:335 ../src/option.c:360 ../src/option.c:416
+#: ../src/option.c:426 ../src/option.c:468 ../src/option.c:485
+#: ../src/option.c:511 ../src/option.c:521 ../src/option.c:531
+#: ../src/option.c:602 ../src/option.c:650 ../src/option.c:652
 msgid "TYPE"
 msgstr "ТИП"
 
@@ -294,7 +294,7 @@ msgstr "ТИП"
 msgid "Set the dialog image"
 msgstr "Задати зображення діалогу"
 
-#: ../src/option.c:114 ../src/option.c:291 ../src/option.c:295
+#: ../src/option.c:114 ../src/option.c:293 ../src/option.c:297
 msgid "IMAGE"
 msgstr "ЗОБРАЖЕННЯ"
 
@@ -306,7 +306,7 @@ msgstr "Показувати зображення над основним від
 msgid "Use specified icon theme instead of default"
 msgstr "Використовувати вказану тему іконок"
 
-#: ../src/option.c:118 ../src/option.c:617
+#: ../src/option.c:118 ../src/option.c:619
 msgid "THEME"
 msgstr "ТЕМА"
 
@@ -314,7 +314,7 @@ msgstr "ТЕМА"
 msgid "Hide main widget with expander"
 msgstr "Приховати головний віджет"
 
-#: ../src/option.c:120 ../src/option.c:311 ../src/option.c:554
+#: ../src/option.c:120 ../src/option.c:313 ../src/option.c:556
 msgid "[TEXT]"
 msgstr "[ТЕКСТ]"
 
@@ -364,468 +364,476 @@ msgid "Dialog text can be selected"
 msgstr "Текст діалогу може буди виділеним"
 
 #: ../src/option.c:143
+msgid "Use specified cursor name on start"
+msgstr "Використовувати вказаний курсор при старті"
+
+#: ../src/option.c:143
+msgid "CURSORNAME"
+msgstr "НАЗВА_КУРСОРУ"
+
+#: ../src/option.c:145
 msgid "Set window sticky"
 msgstr "Вікно на всіх стільницях"
 
-#: ../src/option.c:145
+#: ../src/option.c:147
 msgid "Set window unresizable"
 msgstr "Незмінний розмір вікна"
 
-#: ../src/option.c:147
+#: ../src/option.c:149
 msgid "Place window on top"
 msgstr "Розташувати вікно над іншими"
 
-#: ../src/option.c:149
+#: ../src/option.c:151
 msgid "Place window on center of screen"
 msgstr "Розташувати вікно по центру екрана"
 
-#: ../src/option.c:151
+#: ../src/option.c:153
 msgid "Place window at the mouse position"
 msgstr "Розташувати вікно в положенні мишки"
 
-#: ../src/option.c:153
+#: ../src/option.c:155
 msgid "Set window undecorated"
 msgstr "Прибрати декорації вікна"
 
-#: ../src/option.c:155
+#: ../src/option.c:157
 msgid "Don't show window in taskbar"
 msgstr "Не показувати вікна в панелі завдань"
 
-#: ../src/option.c:157
+#: ../src/option.c:159
 msgid "Set window maximized"
 msgstr "Задати вікну максимальний розмір"
 
-#: ../src/option.c:159
+#: ../src/option.c:161
 msgid "Set window fullscreen"
 msgstr "Розгорнути вікно на весь екран"
 
-#: ../src/option.c:161
+#: ../src/option.c:163
 msgid "Don't focus dialog window"
 msgstr "Не надавати фокус вікну діалогу"
 
-#: ../src/option.c:163
+#: ../src/option.c:165
 msgid "Close window when it sets unfocused"
 msgstr "Закрити вікно при втраті фокусу"
 
-#: ../src/option.c:165
+#: ../src/option.c:167
 msgid "Open window as a splashscreen"
 msgstr "Відкрити вікно у режимі splashscreen"
 
-#: ../src/option.c:167
+#: ../src/option.c:169
 msgid "Special type of dialog for XEMBED"
 msgstr "Особливий режим діалогу для вбудовування"
 
-#: ../src/option.c:167 ../src/option.c:213
+#: ../src/option.c:169 ../src/option.c:215
 msgid "KEY"
 msgstr "КЛЮЧ"
 
-#: ../src/option.c:169
+#: ../src/option.c:171
 msgid "Tab number of this dialog"
 msgstr "Номер вкладки для цього діалогу"
 
-#: ../src/option.c:172
+#: ../src/option.c:174
 msgid "Send SIGNAL to parent"
 msgstr "Послати СИГНАЛ батьківському процесу"
 
-#: ../src/option.c:172
+#: ../src/option.c:174
 msgid "[SIGNAL]"
 msgstr "[СИГНАЛ]"
 
-#: ../src/option.c:174
+#: ../src/option.c:176
 msgid "Print X Window Id to the file/stderr"
 msgstr "Вивести ідентифікатор вікна в файл/stderr"
 
-#: ../src/option.c:174 ../src/option.c:255
+#: ../src/option.c:176 ../src/option.c:257
 msgid "[FILENAME]"
 msgstr "[НАЗВА ФАЙЛУ]"
 
-#: ../src/option.c:181
+#: ../src/option.c:183
 msgid "Set the format for the returned date"
 msgstr "Задати формат відображення дати"
 
-#: ../src/option.c:181 ../src/option.c:384
+#: ../src/option.c:183 ../src/option.c:386
 msgid "PATTERN"
 msgstr "ШАБЛОН"
 
-#: ../src/option.c:183
+#: ../src/option.c:185
 msgid "Set presicion of floating numbers (default - 3)"
 msgstr "Задати точнісь чисел з плаваючою точкою (за умовчанням - 3)"
 
-#: ../src/option.c:185
+#: ../src/option.c:187
 msgid "Set command handler"
 msgstr "Задати команду-обробник"
 
-#: ../src/option.c:185 ../src/option.c:293 ../src/option.c:297
-#: ../src/option.c:362 ../src/option.c:444 ../src/option.c:446
-#: ../src/option.c:448
+#: ../src/option.c:187 ../src/option.c:295 ../src/option.c:299
+#: ../src/option.c:364 ../src/option.c:446 ../src/option.c:448
+#: ../src/option.c:450
 msgid "CMD"
 msgstr "КОМАНДА"
 
-#: ../src/option.c:187
+#: ../src/option.c:189
 msgid "Listen for data on stdin"
 msgstr "Читати дані зі стандартного вводу"
 
-#: ../src/option.c:189
+#: ../src/option.c:191
 msgid "Set common separator character"
 msgstr "Встановити загальний розділювач"
 
-#: ../src/option.c:189 ../src/option.c:191
+#: ../src/option.c:191 ../src/option.c:193
 msgid "SEPARATOR"
 msgstr "РОЗДІЛЮВАЧ"
 
-#: ../src/option.c:191
+#: ../src/option.c:193
 msgid "Set item separator character"
 msgstr "Встановити розділювач для елементів"
 
-#: ../src/option.c:193
+#: ../src/option.c:195
 msgid "Allow changes to text in some cases"
 msgstr "Дозволити змінювати текст у деяких режимах"
 
-#: ../src/option.c:195
+#: ../src/option.c:197
 msgid "Autoscroll to end of text"
 msgstr "Автопрокрутка в кінець тексту"
 
-#: ../src/option.c:197
+#: ../src/option.c:199
 msgid "Quote dialogs output"
 msgstr "Виводити значення у лапках"
 
-#: ../src/option.c:199
+#: ../src/option.c:201
 msgid "Output number instead of text for combo-box"
 msgstr "Виводити число замість тексту для списку значень"
 
-#: ../src/option.c:201
+#: ../src/option.c:203
 msgid "Specify font name to use"
 msgstr "Задати ім'я використовуємого шрифту"
 
-#: ../src/option.c:201
+#: ../src/option.c:203
 msgid "FONTNAME"
 msgstr "НАЗВА_ШРИФТУ"
 
-#: ../src/option.c:203
+#: ../src/option.c:205
 msgid "Allow multiple selection"
 msgstr "Дозволити вибір декількох елементів"
 
-#: ../src/option.c:205
+#: ../src/option.c:207
 msgid "Enable preview"
 msgstr "Додати попередній перегляд"
 
-#: ../src/option.c:207
+#: ../src/option.c:209
 msgid "Show hidden files in file selection dialogs"
 msgstr "Відобразити скриті файли у діалозі вибору файла"
 
-#: ../src/option.c:209
+#: ../src/option.c:211
 msgid "Set source filename"
 msgstr "Задати ім'я файлу"
 
-#: ../src/option.c:209 ../src/option.c:239 ../src/option.c:646
-#: ../src/option.c:658
+#: ../src/option.c:211 ../src/option.c:241 ../src/option.c:648
+#: ../src/option.c:660
 msgid "FILENAME"
 msgstr "НАЗВА ФАЙЛУ"
 
-#: ../src/option.c:211
+#: ../src/option.c:213
 msgid "Set vertical orientation"
 msgstr "Викорістовувати вертикальну орієнтацію"
 
-#: ../src/option.c:213
+#: ../src/option.c:215
 msgid "Identifier of embedded dialogs"
 msgstr "Ідентифікатор діалогів що вбудовуваються"
 
-#: ../src/option.c:215
+#: ../src/option.c:217
 msgid "Set extended completion for entries (any, all, or regex)"
 msgstr "Задати розширене доповнення для текстових полів (any, all або regex)"
 
-#: ../src/option.c:218
+#: ../src/option.c:220
 msgid "Use IEC (base 1024) units with for size values"
 msgstr "Використовувати формат IEC (база 1024) для розмірів даних"
 
-#: ../src/option.c:222
+#: ../src/option.c:224
 msgid "Enable spell check for text"
 msgstr "Дозволити перевірку правопису"
 
-#: ../src/option.c:224
+#: ../src/option.c:226
 msgid "Set spell checking language"
 msgstr "Задати мову для перевірки правопису"
 
-#: ../src/option.c:224
+#: ../src/option.c:226
 msgid "LANGUAGE"
 msgstr "МОВА"
 
-#: ../src/option.c:231
+#: ../src/option.c:233
 msgid "Display calendar dialog"
 msgstr "Відобразити діалог для вибору дати"
 
-#: ../src/option.c:233
+#: ../src/option.c:235
 msgid "Set the calendar day"
 msgstr "Задати календарний день"
 
-#: ../src/option.c:233
+#: ../src/option.c:235
 msgid "DAY"
 msgstr "ДЕНЬ"
 
-#: ../src/option.c:235
+#: ../src/option.c:237
 msgid "Set the calendar month"
 msgstr "Задати календарний місяць"
 
-#: ../src/option.c:235
+#: ../src/option.c:237
 msgid "MONTH"
 msgstr "МІСЯЦЬ"
 
-#: ../src/option.c:237
+#: ../src/option.c:239
 msgid "Set the calendar year"
 msgstr "Задати календарний рік"
 
-#: ../src/option.c:237
+#: ../src/option.c:239
 msgid "YEAR"
 msgstr "РІК"
 
-#: ../src/option.c:239
+#: ../src/option.c:241
 msgid "Set the filename with dates details"
 msgstr "Задати назву файлу з описом дат"
 
-#: ../src/option.c:241
+#: ../src/option.c:243
 msgid "Show week numbers at the left side of calendar"
 msgstr "Відобразити нумерацію тижднів зліва"
 
-#: ../src/option.c:247
+#: ../src/option.c:249
 msgid "Display color selection dialog"
 msgstr "Відобразити діалог для вибору кольору"
 
-#: ../src/option.c:249
+#: ../src/option.c:251
 msgid "Alias for --color"
 msgstr "Синонім для --color"
 
-#: ../src/option.c:251
+#: ../src/option.c:253
 msgid "Set initial color value"
 msgstr "Задати початковий колір"
 
-#: ../src/option.c:251 ../src/option.c:594 ../src/option.c:596
-#: ../src/option.c:608
+#: ../src/option.c:253 ../src/option.c:596 ../src/option.c:598
+#: ../src/option.c:610
 msgid "COLOR"
 msgstr "КОЛІР"
 
-#: ../src/option.c:253
+#: ../src/option.c:255
 msgid "Show system palette in color dialog"
 msgstr "Відобразити системну палітру"
 
-#: ../src/option.c:255
+#: ../src/option.c:257
 msgid "Set path to palette file. Default - "
 msgstr "Задати шлях до файлу кольорів. Без назви - "
 
-#: ../src/option.c:257
+#: ../src/option.c:259
 msgid "Expand user palette"
 msgstr "Розкривати палітру користувача"
 
-#: ../src/option.c:259
+#: ../src/option.c:261
 msgid "Set output mode to MODE. Values are hex (default) or rgb"
 msgstr ""
 "Встановити режим вивода в РЕЖИМ. Значення - hex (за умовчанням) або rgb"
 
-#: ../src/option.c:259
+#: ../src/option.c:261
 msgid "MODE"
 msgstr "РЕЖИМ"
 
-#: ../src/option.c:261
+#: ../src/option.c:263
 msgid "Use #rrrrggggbbbb format instead of #rrggbb"
 msgstr "Використовувати формат #rrrrggggbbbb замість #rrggbb"
 
-#: ../src/option.c:263
+#: ../src/option.c:265
 msgid "Add opacity to output color value"
 msgstr "Додати прозорість до значення кольору"
 
-#: ../src/option.c:269
+#: ../src/option.c:271
 msgid "Display drag-n-drop box"
 msgstr "Відобразити діалог для перехоплення dnd"
 
-#: ../src/option.c:271
+#: ../src/option.c:273
 msgid "Use dialog text as tooltip"
 msgstr "Використовувати текст діалогу в якості підказки"
 
-#: ../src/option.c:273
+#: ../src/option.c:275
 msgid "Exit after NUMBER of drops"
 msgstr "Вихід після певної кількості спрацювань"
 
-#: ../src/option.c:279
+#: ../src/option.c:281
 msgid "Display text entry or combo-box dialog"
 msgstr "Відобразити діалог для вводу тексту або вибору варіанта"
 
-#: ../src/option.c:281
+#: ../src/option.c:283
 msgid "Set the entry label"
 msgstr "Задати мітку поля вводу"
 
-#: ../src/option.c:283
+#: ../src/option.c:285
 msgid "Set the entry text"
 msgstr "Задати текст для поля вводу"
 
-#: ../src/option.c:285
+#: ../src/option.c:287
 msgid "Hide the entry text"
 msgstr "Приховати введений текст (Пароль)"
 
-#: ../src/option.c:287
+#: ../src/option.c:289
 msgid "Use completion instead of combo-box"
 msgstr "Використовувати автозаповнення замість списку значень"
 
-#: ../src/option.c:289
+#: ../src/option.c:291
 msgid "Use spin button for text entry"
 msgstr "Використовувати числове поле замість тексту"
 
-#: ../src/option.c:291
+#: ../src/option.c:293
 msgid "Set the left entry icon"
 msgstr "Задати ліву іконку"
 
-#: ../src/option.c:293
+#: ../src/option.c:295
 msgid "Set the left entry icon action"
 msgstr "Дія для лівої іконки"
 
-#: ../src/option.c:295
+#: ../src/option.c:297
 msgid "Set the right entry icon"
 msgstr "Задати праву іконку"
 
-#: ../src/option.c:297
+#: ../src/option.c:299
 msgid "Set the right entry icon action"
 msgstr "Дія для правої іконки"
 
-#: ../src/option.c:303
+#: ../src/option.c:305
 msgid "Display file selection dialog"
 msgstr "Відобразити діалог для вибору файла"
 
-#: ../src/option.c:305
+#: ../src/option.c:307
 msgid "Alias for --file"
 msgstr "Синонім для --file"
 
-#: ../src/option.c:307
+#: ../src/option.c:309
 msgid "Activate directory-only selection"
 msgstr "Активувати виділення тільки по каталогах"
 
-#: ../src/option.c:309
+#: ../src/option.c:311
 msgid "Activate save mode"
 msgstr "Активувати режим зберігання"
 
-#: ../src/option.c:311
+#: ../src/option.c:313
 msgid "Confirm file selection if filename already exists"
 msgstr "Підтвердити вибір файлу, якщо файл вже існує"
 
-#: ../src/option.c:317
+#: ../src/option.c:319
 msgid "Display font selection dialog"
 msgstr "Відобразити діалог для вибору шрифту"
 
-#: ../src/option.c:319
+#: ../src/option.c:321
 msgid "Alias for --font"
 msgstr "Синонім для --font"
 
-#: ../src/option.c:321
+#: ../src/option.c:323
 msgid "Set text string for preview"
 msgstr "Задати текстову стрічку для передогляду"
 
-#: ../src/option.c:323
+#: ../src/option.c:325
 msgid "Separate output of font description"
 msgstr "Розділяти вивід описа шрифта"
 
-#: ../src/option.c:329
+#: ../src/option.c:331
 msgid "Display form dialog"
 msgstr "Відобразити діалог форми вводу"
 
-#: ../src/option.c:331
+#: ../src/option.c:333
 msgid "Add field to form (see man page for list of possible types)"
 msgstr ""
 "Додати поле до форми (дивись сторінку керівництва для отримання списку типів)"
 
-#: ../src/option.c:331 ../src/option.c:462
+#: ../src/option.c:333 ../src/option.c:464
 msgid "LABEL[:TYPE]"
 msgstr "МІТКА[:ТИП]"
 
-#: ../src/option.c:333
+#: ../src/option.c:335
 msgid "Set alignment of filed labels (left, center or right)"
 msgstr "Задати вирівнювання міток полів (left, center або right)"
 
-#: ../src/option.c:335
+#: ../src/option.c:337
 msgid "Set number of columns in form"
 msgstr "Задати кількість стовпчиків у формі"
 
-#: ../src/option.c:337
+#: ../src/option.c:339
 msgid "Make form scrollable"
 msgstr "Додати прокрутку до форми"
 
-#: ../src/option.c:339
+#: ../src/option.c:341
 msgid "Order output fields by rows"
 msgstr "Упорядкувати виведення по рядках"
 
-#: ../src/option.c:341
+#: ../src/option.c:343
 msgid "Set focused field"
 msgstr "Задати поле що отримує фокус"
 
-#: ../src/option.c:343
+#: ../src/option.c:345
 msgid "Cycled reading of stdin data"
 msgstr "Циклічне читання зі стандартного вводу"
 
-#: ../src/option.c:350
+#: ../src/option.c:352
 msgid "Display HTML dialog"
 msgstr "Відобразити HTML діалог"
 
-#: ../src/option.c:352
+#: ../src/option.c:354
 msgid "Open specified location"
 msgstr "Відкрити вказану адресу"
 
-#: ../src/option.c:354
+#: ../src/option.c:356
 msgid "Turn on browser mode"
 msgstr "Ввімкнути режим браузеру"
 
-#: ../src/option.c:356
+#: ../src/option.c:358
 msgid "Print clicked uri to stdout"
 msgstr "Друкувати натиснуті зсилки"
 
-#: ../src/option.c:358
+#: ../src/option.c:360
 msgid "Set mime type of input stream data"
 msgstr "Задати тип mime для вхідних даних"
 
-#: ../src/option.c:360
+#: ../src/option.c:362
 msgid "Set encoding of input stream data"
 msgstr "Задати кодування для вхідних даних"
 
-#: ../src/option.c:360
+#: ../src/option.c:362
 msgid "ENCODING"
 msgstr "КОДУВАННЯ"
 
-#: ../src/option.c:362
+#: ../src/option.c:364
 msgid "Set external handler for clicked uri"
 msgstr "Задати зовнішній обробник для натиснутих зсилок"
 
-#: ../src/option.c:364
+#: ../src/option.c:366
 msgid "Set user agent string"
 msgstr "Задати стрічку агента"
 
-#: ../src/option.c:364 ../src/option.c:495
+#: ../src/option.c:366 ../src/option.c:497
 msgid "STRING"
 msgstr "РЯДОК"
 
-#: ../src/option.c:366
+#: ../src/option.c:368
 msgid "Set path or uri to user styles"
 msgstr "Задати файл або шлях до стилей користувача"
 
-#: ../src/option.c:373
+#: ../src/option.c:375
 msgid "Display icons box dialog"
 msgstr "Відобразити діалог з іконками швидкого доступу"
 
-#: ../src/option.c:375
+#: ../src/option.c:377
 msgid "Read data from .desktop files in specified directory"
 msgstr "Читати дані з файлів .desktop у вказаному каталозі"
 
-#: ../src/option.c:375
+#: ../src/option.c:377
 msgid "DIR"
 msgstr "КАТАЛОГ"
 
-#: ../src/option.c:377
+#: ../src/option.c:379
 msgid "Use compact (list) view"
 msgstr "Використовувати компактний вигляд (список)"
 
-#: ../src/option.c:379
+#: ../src/option.c:381
 msgid "Use GenericName field instead of Name for icon label"
 msgstr "Використовувати поле GenericName замість Name для мітки"
 
-#: ../src/option.c:381
+#: ../src/option.c:383
 msgid "Set the width of dialog items"
 msgstr "Задати ширину елемента діалогу"
 
-#: ../src/option.c:384
+#: ../src/option.c:386
 #, no-c-format
 msgid ""
 "Use specified pattern for launch command in terminal (default: xterm -e %s)"
@@ -833,90 +841,90 @@ msgstr ""
 "Використовувати вказаний шаблон для запуску в терміналі (без шаблону: xterm -"
 "e %s)"
 
-#: ../src/option.c:386
+#: ../src/option.c:388
 msgid "Sort items by name instead of filename"
 msgstr "Сортувати по полю Назва замість назви файлу"
 
-#: ../src/option.c:388
+#: ../src/option.c:390
 msgid "Sort items in descending order"
 msgstr "Сортувати в порядку спадання"
 
-#: ../src/option.c:390
+#: ../src/option.c:392
 msgid "Activate items by single click"
 msgstr "Активувати елемент одним натисненням"
 
-#: ../src/option.c:393
+#: ../src/option.c:395
 msgid "Watch fot changes in directory"
 msgstr "Слідкувати за змінами в каталозі"
 
-#: ../src/option.c:400
+#: ../src/option.c:402
 msgid "Display list dialog"
 msgstr "Відобразити діалог зі списком"
 
-#: ../src/option.c:402
+#: ../src/option.c:404
 msgid "Set the column header (see man page for list of possible types)"
 msgstr ""
 "Задати заголовок стовпчика (дивись сторінку керівництва для отримання списку "
 "типів)"
 
-#: ../src/option.c:402
+#: ../src/option.c:404
 msgid "COLUMN[:TYPE]"
 msgstr "СТОВПЧИК[:ТИП]"
 
-#: ../src/option.c:404
+#: ../src/option.c:406
 msgid "Use checkboxes for first column"
 msgstr "Використовувати відмітки для першого стовпчика"
 
-#: ../src/option.c:406
+#: ../src/option.c:408
 msgid "Use radioboxes for first column"
 msgstr "Використовувати перемикач для першого стовпчика"
 
-#: ../src/option.c:408
+#: ../src/option.c:410
 msgid "Don't show column headers"
 msgstr "Не показувати заголовки стовпчиків"
 
-#: ../src/option.c:410
+#: ../src/option.c:412
 msgid "Disable clickable column headers"
 msgstr "Заборонити натискати на заголовок"
 
-#: ../src/option.c:412
+#: ../src/option.c:414
 msgid "Disable rules hints"
 msgstr "Заборонити розмальовку стрічок"
 
-#: ../src/option.c:414
+#: ../src/option.c:416
 msgid "Set grid lines (hor[izontal], vert[ical] or both)"
 msgstr "Задати роздільні лінії (hor[izontal], vert[ical] або both)"
 
-#: ../src/option.c:416
+#: ../src/option.c:418
 msgid "Print all data from list"
 msgstr "Виводити таблицю повністю"
 
-#: ../src/option.c:418
+#: ../src/option.c:420
 msgid "Set the list of editable columns"
 msgstr "Задати список стопчиків для редагування"
 
-#: ../src/option.c:418 ../src/option.c:422 ../src/option.c:426
+#: ../src/option.c:420 ../src/option.c:424 ../src/option.c:428
 msgid "LIST"
 msgstr "СПИСОК"
 
-#: ../src/option.c:420
+#: ../src/option.c:422
 msgid "Set the width of a column for start wrapping text"
 msgstr "Задати ширину стовпчика для переносу тексту"
 
-#: ../src/option.c:422
+#: ../src/option.c:424
 msgid "Set the list of wrapped columns"
 msgstr "Задати список стовпчиків для переносу"
 
-#: ../src/option.c:424
+#: ../src/option.c:426
 msgid "Set ellipsize mode for text columns (none, start, middle or end)"
 msgstr ""
 "Задати тип урізання для текстових стовпчиків (none, start, middle або end)"
 
-#: ../src/option.c:426
+#: ../src/option.c:428
 msgid "Set the list of ellipsized columns"
 msgstr "Задати список стовпчиків для урізання"
 
-#: ../src/option.c:428
+#: ../src/option.c:430
 msgid ""
 "Print a specific column. By default or if 0 is specified will be printed all "
 "columns"
@@ -924,15 +932,15 @@ msgstr ""
 "Виводити тільки вказаний стовпчик. Без вказівки або якщо стовпчик дорівнює "
 "0, будуть виведені усі стовпчики"
 
-#: ../src/option.c:430
+#: ../src/option.c:432
 msgid "Hide a specific column"
 msgstr "Сховати вказаний стовпчик"
 
-#: ../src/option.c:432
+#: ../src/option.c:434
 msgid "Set the column expandable by default. 0 sets all columns expandable"
 msgstr "Задати стовпчик, який розширюється. 0 розширює всі стовпчики"
 
-#: ../src/option.c:434
+#: ../src/option.c:436
 msgid ""
 "Set the quick search column. Default is first column. Set it to 0 for "
 "disable searching"
@@ -940,664 +948,664 @@ msgstr ""
 "Задати стовпчик швидкого пошуку. Без вказівки використовується перший "
 "стовпчик. 0 забороняє пошук"
 
-#: ../src/option.c:436
+#: ../src/option.c:438
 msgid "Set the tooltip column"
 msgstr "Задати стовпчик підказок"
 
-#: ../src/option.c:438
+#: ../src/option.c:440
 msgid "Set the row separator column"
 msgstr "Задати стовпчик розділювача стрічок"
 
-#: ../src/option.c:440
+#: ../src/option.c:442
 msgid "Set the row separator value"
 msgstr "Задати значення розділювача стрічок"
 
-#: ../src/option.c:442
+#: ../src/option.c:444
 msgid "Set the limit of rows in list"
 msgstr "Задати кількість рядків у списку"
 
-#: ../src/option.c:444
+#: ../src/option.c:446
 msgid "Set double-click action"
 msgstr "Дія для подвійного натискання мишки"
 
-#: ../src/option.c:446
+#: ../src/option.c:448
 msgid "Set select action"
 msgstr "Дія при виділенні стрічки"
 
-#: ../src/option.c:448
+#: ../src/option.c:450
 msgid "Set add action"
 msgstr "Дія при додаванні стрічки"
 
-#: ../src/option.c:450
+#: ../src/option.c:452
 msgid "Use regex in search"
 msgstr "Використовувати регулярні вирази в пошуку"
 
-#: ../src/option.c:452
+#: ../src/option.c:454
 msgid "Disable selection"
 msgstr "Заборонити виділення"
 
-#: ../src/option.c:454
+#: ../src/option.c:456
 msgid "Add new records on the top of a list"
 msgstr "Додавати нові стрічки на початку таблиці"
 
-#: ../src/option.c:460
+#: ../src/option.c:462
 msgid "Display multi progress bars dialog"
 msgstr "Відобразити діалог з декількома індикаторами виконання"
 
-#: ../src/option.c:462
+#: ../src/option.c:464
 msgid "Add the progress bar (norm, rtl, pulse or perm)"
 msgstr "Додати індикатор виконання (norm, rtl, pulse або perm)"
 
-#: ../src/option.c:464
+#: ../src/option.c:466
 msgid "Watch for specific bar for auto close"
 msgstr "Слідкувати за певним індикатором для автозакриття"
 
-#: ../src/option.c:466
+#: ../src/option.c:468
 msgid "Set alignment of bar labels (left, center or right)"
 msgstr "Задати вирівнювання міток індикаторів (left, center або right)"
 
-#: ../src/option.c:469
+#: ../src/option.c:471
 #, no-c-format
 msgid "Dismiss the dialog when 100% of all bars has been reached"
 msgstr "Закрити діалог по досягненні 100% усіма індикаторами"
 
-#: ../src/option.c:472 ../src/option.c:549
+#: ../src/option.c:474 ../src/option.c:551
 msgid "Kill parent process if cancel button is pressed"
 msgstr "Завершити батьківський процес, якщо натиснута кнопка відміни"
 
-#: ../src/option.c:479
+#: ../src/option.c:481
 msgid "Display notebook dialog"
 msgstr "Відобразити діалог із вкладинками"
 
-#: ../src/option.c:481
+#: ../src/option.c:483
 msgid "Add a tab to notebook"
 msgstr "Додати вкладку"
 
-#: ../src/option.c:481
+#: ../src/option.c:483
 msgid "LABEL"
 msgstr "МІТКА"
 
-#: ../src/option.c:483
+#: ../src/option.c:485
 msgid "Set position of a notebook tabs (top, bottom, left or right)"
 msgstr "Задати позицію ярлика вкладки (top, bottom, left, або right)"
 
-#: ../src/option.c:485
+#: ../src/option.c:487
 msgid "Set tab borders"
 msgstr "Задати межі вкладок"
 
-#: ../src/option.c:487
+#: ../src/option.c:489
 msgid "Set active tab"
 msgstr "Задати активну вкладку"
 
-#: ../src/option.c:493
+#: ../src/option.c:495
 msgid "Display notification"
 msgstr "Відобразити діалог повідомлень"
 
-#: ../src/option.c:495
+#: ../src/option.c:497
 msgid "Set initial popup menu"
 msgstr "Задати початкове меню"
 
-#: ../src/option.c:497
+#: ../src/option.c:499
 msgid "Disable exit on middle click"
 msgstr "Заборонити вихід середньою кнопкою мишки"
 
-#: ../src/option.c:499
+#: ../src/option.c:501
 msgid "Doesn't show icon at startup"
 msgstr "Не показувати іконку при старті"
 
-#: ../src/option.c:501
+#: ../src/option.c:503
 msgid "Set icon size for fully specified icons (default - 16)"
 msgstr "Задати розмір інконки для повністю вказаних (за умовчанням - 16)"
 
-#: ../src/option.c:501 ../src/option.c:602
+#: ../src/option.c:503 ../src/option.c:604
 msgid "SIZE"
 msgstr "РОЗМІР"
 
-#: ../src/option.c:507
+#: ../src/option.c:509
 msgid "Display paned dialog"
 msgstr "Відобразити діалог з панелями"
 
-#: ../src/option.c:509
+#: ../src/option.c:511
 msgid "Set orientation (hor[izontal] or vert[ical])"
 msgstr "Задати оріентицію (hor[izontal] або vert[ical])"
 
-#: ../src/option.c:511
+#: ../src/option.c:513
 msgid "Set initial splitter position"
 msgstr "Задати початкову позицію розділювача"
 
-#: ../src/option.c:517
+#: ../src/option.c:519
 msgid "Display picture dialog"
 msgstr "Відобразити діалог з картинкою"
 
-#: ../src/option.c:519
+#: ../src/option.c:521
 msgid "Set initial size (fit or orig)"
 msgstr "Задати початковий розмір картинки"
 
-#: ../src/option.c:521
+#: ../src/option.c:523
 msgid "Set increment for picture scaling (default - 5)"
 msgstr "Задати інкремент для зміни розміру картинки (за умовчанням - 5)"
 
-#: ../src/option.c:527
+#: ../src/option.c:529
 msgid "Display printing dialog"
 msgstr "Відобразити діалог друку"
 
-#: ../src/option.c:529
+#: ../src/option.c:531
 msgid "Set source type (text, image or raw)"
 msgstr "Задати тип даних (text, image або raw)"
 
-#: ../src/option.c:531
+#: ../src/option.c:533
 msgid "Add headers to page"
 msgstr "Додати колонтитули до сторінки"
 
-#: ../src/option.c:537
+#: ../src/option.c:539
 msgid "Display progress indication dialog"
 msgstr "Відобразити діалог прогресу"
 
-#: ../src/option.c:539
+#: ../src/option.c:541
 msgid "Set progress text"
 msgstr "Показувати текст на індикаторі"
 
-#: ../src/option.c:541
+#: ../src/option.c:543
 msgid "Set initial percentage"
 msgstr "Задати початковий процент"
 
-#: ../src/option.c:541
+#: ../src/option.c:543
 msgid "PERCENTAGE"
 msgstr "ВІДСОТКИ"
 
-#: ../src/option.c:543
+#: ../src/option.c:545
 msgid "Pulsate progress bar"
 msgstr "Пульсовий індикатор виконання"
 
-#: ../src/option.c:546
+#: ../src/option.c:548
 #, no-c-format
 msgid "Dismiss the dialog when 100% has been reached"
 msgstr "Закрити діалог по досягненні 100%"
 
-#: ../src/option.c:552
+#: ../src/option.c:554
 msgid "Right-To-Left progress bar direction"
 msgstr "Напрямок індикатору Справа-Наліво"
 
-#: ../src/option.c:554
+#: ../src/option.c:556
 msgid "Show log window"
 msgstr "Відобразити вікно журналу"
 
-#: ../src/option.c:556
+#: ../src/option.c:558
 msgid "Expand log window"
 msgstr "Розгорнути вікно журналу"
 
-#: ../src/option.c:558
+#: ../src/option.c:560
 msgid "Place log window above progress bar"
 msgstr "Розмістити вікно жуналу поверх індикатора виконання"
 
-#: ../src/option.c:560
+#: ../src/option.c:562
 msgid "Height of log window"
 msgstr "Висота вікна журналу"
 
-#: ../src/option.c:566
+#: ../src/option.c:568
 msgid "Display scale dialog"
 msgstr "Відобразити діалог масштабу"
 
-#: ../src/option.c:568
+#: ../src/option.c:570
 msgid "Set initial value"
 msgstr "Задати початкове значення"
 
-#: ../src/option.c:568 ../src/option.c:570 ../src/option.c:572
-#: ../src/option.c:574 ../src/option.c:576
+#: ../src/option.c:570 ../src/option.c:572 ../src/option.c:574
+#: ../src/option.c:576 ../src/option.c:578
 msgid "VALUE"
 msgstr "ЗНАЧЕННЯ"
 
-#: ../src/option.c:570
+#: ../src/option.c:572
 msgid "Set minimum value"
 msgstr "Задати мінімальне значення"
 
-#: ../src/option.c:572
+#: ../src/option.c:574
 msgid "Set maximum value"
 msgstr "Задати максимальне значення"
 
-#: ../src/option.c:574
+#: ../src/option.c:576
 msgid "Set step size"
 msgstr "Задати крок"
 
-#: ../src/option.c:576
+#: ../src/option.c:578
 msgid "Set paging size"
 msgstr "Задати крок сторінки"
 
-#: ../src/option.c:578
+#: ../src/option.c:580
 msgid "Print partial values"
 msgstr "Виводити часткові значення"
 
-#: ../src/option.c:580
+#: ../src/option.c:582
 msgid "Hide value"
 msgstr "Сховати значення"
 
-#: ../src/option.c:582
+#: ../src/option.c:584
 msgid "Invert direction"
 msgstr "Зворотній напрямок"
 
-#: ../src/option.c:584
+#: ../src/option.c:586
 msgid "Show +/- buttons in scale"
 msgstr "Відобразити кнопки +/-"
 
-#: ../src/option.c:586
+#: ../src/option.c:588
 msgid "Add mark to scale (may be used multiple times)"
 msgstr "Додати мітку шкали (може використовуватись декілька разів)"
 
-#: ../src/option.c:586
+#: ../src/option.c:588
 msgid "NAME:VALUE"
 msgstr "НАЗВА:ЗНАЧЕННЯ"
 
-#: ../src/option.c:592
+#: ../src/option.c:594
 msgid "Display text information dialog"
 msgstr "Відобразити діалог з текстовою інформацією"
 
-#: ../src/option.c:594
+#: ../src/option.c:596
 msgid "Use specified color for text"
 msgstr "Використовувати вказаний колір тексту"
 
-#: ../src/option.c:596
+#: ../src/option.c:598
 msgid "Use specified color for background"
 msgstr "Використовувати вказаний колір фону"
 
-#: ../src/option.c:598
+#: ../src/option.c:600
 msgid "Enable text wrapping"
 msgstr "Дозволити перенос тексту"
 
-#: ../src/option.c:600
+#: ../src/option.c:602
 msgid "Set justification (left, right, center or fill)"
 msgstr "Встановити вирівнювання (left, right, center або fill)"
 
-#: ../src/option.c:602
+#: ../src/option.c:604
 msgid "Set text margins"
 msgstr "Встановити відступи"
 
-#: ../src/option.c:604
+#: ../src/option.c:606
 msgid "Show cursor in read-only mode"
 msgstr "Відображувати курсор у режимі тільки для читання"
 
-#: ../src/option.c:606
+#: ../src/option.c:608
 msgid "Make URI clickable"
 msgstr "Зробити посилання активними"
 
-#: ../src/option.c:608
+#: ../src/option.c:610
 msgid "Use specified color for links"
 msgstr "Використовувати вказаний колір для посилань"
 
-#: ../src/option.c:615
+#: ../src/option.c:617
 msgid "Use specified langauge for syntax highlighting"
 msgstr "Використовувати вказану мову для підсвітки синтаксису"
 
-#: ../src/option.c:615
+#: ../src/option.c:617
 msgid "LANG"
 msgstr "МОВА"
 
-#: ../src/option.c:617
+#: ../src/option.c:619
 msgid "Use specified theme"
 msgstr "Використовувати вказану тему"
 
-#: ../src/option.c:624
+#: ../src/option.c:626
 msgid "Sets a filename filter"
 msgstr "Задати фільтр файлів по масці"
 
-#: ../src/option.c:624
+#: ../src/option.c:626
 msgid "NAME | PATTERN1 PATTERN2 ..."
 msgstr "НАЗВА | ШАБЛОН1 ШАБЛОН2 ..."
 
-#: ../src/option.c:626
+#: ../src/option.c:628
 msgid "Sets a mime-type filter"
 msgstr "Задати фільтр файлів по типу mime"
 
-#: ../src/option.c:626
+#: ../src/option.c:628
 msgid "NAME | MIME1 MIME2 ..."
 msgstr "НАЗВА | ТИП1 ТИП2 ..."
 
-#: ../src/option.c:628
+#: ../src/option.c:630
 msgid "Add filter for images"
 msgstr "Додати фільтр для зображень"
 
-#: ../src/option.c:628
+#: ../src/option.c:630
 msgid "[NAME]"
 msgstr "[ІМ'Я]"
 
-#: ../src/option.c:634
+#: ../src/option.c:636
 msgid "Show about dialog"
 msgstr "Показати діалог 'Про програму'"
 
-#: ../src/option.c:636
+#: ../src/option.c:638
 msgid "Print version"
 msgstr "Вивести версію"
 
-#: ../src/option.c:639
+#: ../src/option.c:641
 msgid "Show list of spell languages"
 msgstr "Відобразити перелік мов для перевірки правопису"
 
-#: ../src/option.c:643
+#: ../src/option.c:645
 msgid "Show list of GtkSourceView themes"
 msgstr "Відобразити перелік тем для GtkSourceView"
 
-#: ../src/option.c:646
+#: ../src/option.c:648
 msgid "Load additional GTK settings from file"
 msgstr "Завантажити додаткові налаштування GTK з файлу"
 
-#: ../src/option.c:648
+#: ../src/option.c:650
 msgid "Set policy for horizontal scrollbars (auto, always, never)"
 msgstr "Задати тип горизонтальної прокрутки (auto, always, never)"
 
-#: ../src/option.c:650
+#: ../src/option.c:652
 msgid "Set policy for vertical scrollbars (auto, always, never)"
 msgstr "Задати тип вертикальної прокрутки (auto, always, never)"
 
-#: ../src/option.c:652
+#: ../src/option.c:654
 msgid "Add path for search icons by name"
 msgstr "Додати каталог для пошуку іконок"
 
-#: ../src/option.c:652
+#: ../src/option.c:654
 msgid "PATH"
 msgstr "КАТАЛОГ"
 
-#: ../src/option.c:658
+#: ../src/option.c:660
 msgid "Load extra arguments from file"
 msgstr "Завантажити додаткові аргументи з файлу"
 
-#: ../src/option.c:699 ../src/option.c:998
+#: ../src/option.c:701 ../src/option.c:1000
 #, c-format
 msgid "Unknown align type: %s\n"
 msgstr "Невідомий тип вирівнювання: %s\n"
 
-#: ../src/option.c:862
+#: ../src/option.c:864
 #, c-format
 msgid "Mark %s doesn't have a value\n"
 msgstr "Помітці %s не надано значення\n"
 
-#: ../src/option.c:899
+#: ../src/option.c:901
 msgid "Images"
 msgstr "Зображення"
 
-#: ../src/option.c:964
+#: ../src/option.c:966
 #, c-format
 msgid "Unknown color mode: %s\n"
 msgstr "Невідомий режим кольору: '%s'\n"
 
-#: ../src/option.c:983
+#: ../src/option.c:985
 #, c-format
 msgid "Unknown buttons layout type: %s\n"
 msgstr "Невідомий тип розміщення кнопок: %s\n"
 
-#: ../src/option.c:1015
+#: ../src/option.c:1017
 #, c-format
 msgid "Unknown justification type: %s\n"
 msgstr "Невідомий тип вирівнювання: %s\n"
 
-#: ../src/option.c:1032
+#: ../src/option.c:1034
 #, c-format
 msgid "Unknown tab position type: %s\n"
 msgstr "Невідомий тип позиції вкладки: %s\n"
 
-#: ../src/option.c:1068
+#: ../src/option.c:1070
 #, c-format
 msgid "Unknown ellipsize type: %s\n"
 msgstr "Невідомий тип урізання: %s\n"
 
-#: ../src/option.c:1081
+#: ../src/option.c:1083
 #, c-format
 msgid "Unknown orientation: %s\n"
 msgstr "Невідома орієнтація: %s\n"
 
-#: ../src/option.c:1096
+#: ../src/option.c:1098
 #, c-format
 msgid "Unknown source type: %s\n"
 msgstr "Невідомий тип даних: %s\n"
 
-#: ../src/option.c:1107
+#: ../src/option.c:1109
 msgid "Progress log"
 msgstr "Вікно журналу"
 
-#: ../src/option.c:1120
+#: ../src/option.c:1122
 #, c-format
 msgid "Unknown size type: %s\n"
 msgstr "Невідомий тип розміру: %s\n"
 
-#: ../src/option.c:1158
+#: ../src/option.c:1160
 #, c-format
 msgid "Unknown completion type: %s\n"
 msgstr "Невідомий тип доповнення: %s\n"
 
-#: ../src/option.c:1173
+#: ../src/option.c:1175
 #, c-format
 msgid "Unknown grid lines type: %s\n"
 msgstr "Невідомий тип розподільних ліній: %s\n"
 
-#: ../src/option.c:1190
+#: ../src/option.c:1192
 #, c-format
 msgid "Unknown scrollbar policy type: %s\n"
 msgstr "Невідомий тип прокрутки: %s\n"
 
-#: ../src/option.c:1308
+#: ../src/option.c:1310
 #, c-format
 msgid "Unknown signal: %s\n"
 msgstr "Невідомий сигнал: %s\n"
 
-#: ../src/option.c:1500
+#: ../src/option.c:1503
 msgid "File exist. Overwrite?"
 msgstr "Файл існує. Перезаписати?"
 
-#: ../src/option.c:1648
+#: ../src/option.c:1651
 msgid "- Yet another dialoging program"
 msgstr "- Програма для відображення діалогів"
 
 #. Adds general option entries
-#: ../src/option.c:1652
+#: ../src/option.c:1655
 msgid "General options"
 msgstr "Основні параметри"
 
-#: ../src/option.c:1652
+#: ../src/option.c:1655
 msgid "Show general options"
 msgstr "Показувати основні параметри"
 
 #. Adds common option entries
-#: ../src/option.c:1658
+#: ../src/option.c:1661
 msgid "Common options"
 msgstr "Загальні параметри"
 
-#: ../src/option.c:1658
+#: ../src/option.c:1661
 msgid "Show common options"
 msgstr "Показувати загальні параметри діалогів"
 
 #. Adds calendar option entries
-#: ../src/option.c:1664
+#: ../src/option.c:1667
 msgid "Calendar options"
 msgstr "Параметри календаря"
 
-#: ../src/option.c:1664
+#: ../src/option.c:1667
 msgid "Show calendar options"
 msgstr "Показувати параметри календаря"
 
 #. Adds color option entries
-#: ../src/option.c:1670
+#: ../src/option.c:1673
 msgid "Color selection options"
 msgstr "Параметри діалогу вибору кольору"
 
-#: ../src/option.c:1670
+#: ../src/option.c:1673
 msgid "Show color selection options"
 msgstr "Показувати параметри діалогу вибору кольору"
 
 #. Adds dnd option entries
-#: ../src/option.c:1676
+#: ../src/option.c:1679
 msgid "DND options"
 msgstr "Параметри DND"
 
-#: ../src/option.c:1676
+#: ../src/option.c:1679
 msgid "Show drag-n-drop options"
 msgstr "Показувати параметри dnd"
 
 #. Adds entry option entries
-#: ../src/option.c:1682
+#: ../src/option.c:1685
 msgid "Text entry options"
 msgstr "Параметри вводу тексту"
 
-#: ../src/option.c:1682
+#: ../src/option.c:1685
 msgid "Show text entry options"
 msgstr "Показувати параметри вводу тексту"
 
 #. Adds file selection option entries
-#: ../src/option.c:1688
+#: ../src/option.c:1691
 msgid "File selection options"
 msgstr "Параметри діалогу вибору файлів"
 
-#: ../src/option.c:1688
+#: ../src/option.c:1691
 msgid "Show file selection options"
 msgstr "Показувати параметри діалогу вибору файлів"
 
 #. Add font selection option entries
-#: ../src/option.c:1694
+#: ../src/option.c:1697
 msgid "Font selection options"
 msgstr "Параметри діалогу вибору шрифту"
 
-#: ../src/option.c:1694
+#: ../src/option.c:1697
 msgid "Show font selection options"
 msgstr "Показувати параметри діалоги вибору шрифту"
 
 #. Add form option entries
-#: ../src/option.c:1700
+#: ../src/option.c:1703
 msgid "Form options"
 msgstr "Параметри діалогу форми"
 
-#: ../src/option.c:1700
+#: ../src/option.c:1703
 msgid "Show form options"
 msgstr "Показувати параметри діалогу форми"
 
 #. Add html options entries
-#: ../src/option.c:1707
+#: ../src/option.c:1710
 msgid "HTML options"
 msgstr "Параметри HTML діалогу"
 
-#: ../src/option.c:1707
+#: ../src/option.c:1710
 msgid "Show HTML options"
 msgstr "Показувати параметри HTML діалогу"
 
 #. Add icons option entries
-#: ../src/option.c:1714
+#: ../src/option.c:1717
 msgid "Icons box options"
 msgstr "Параметри діалогу іконок"
 
-#: ../src/option.c:1714
+#: ../src/option.c:1717
 msgid "Show icons box options"
 msgstr "Показувати параметри діалогу іконок швидкого доступу"
 
 #. Adds list option entries
-#: ../src/option.c:1720
+#: ../src/option.c:1723
 msgid "List options"
 msgstr "Параметри списку"
 
-#: ../src/option.c:1720
+#: ../src/option.c:1723
 msgid "Show list options"
 msgstr "Показувати параметри списку"
 
 #. Adds multi progress option entries
-#: ../src/option.c:1726
+#: ../src/option.c:1729
 msgid "Multi progress bars options"
 msgstr "Параметри діалогу з декількома індикаторами"
 
-#: ../src/option.c:1727
+#: ../src/option.c:1730
 msgid "Show multi progress bars options"
 msgstr "Показувати параметри діалогу з декількома індикаторами"
 
 #. Adds notebook option entries
-#: ../src/option.c:1733
+#: ../src/option.c:1736
 msgid "Notebook options"
 msgstr "Параметри діалогу з вкладками"
 
-#: ../src/option.c:1733
+#: ../src/option.c:1736
 msgid "Show notebook dialog options"
 msgstr "Показувати параметри діалогу з вкладками"
 
 #. Adds notification option entries
-#: ../src/option.c:1739
+#: ../src/option.c:1742
 msgid "Notification icon options"
 msgstr "Параметри іконки повідомлень"
 
-#: ../src/option.c:1740
+#: ../src/option.c:1743
 msgid "Show notification icon options"
 msgstr "Показувати параметри іконки повідомлень"
 
 #. Adds paned option entries
-#: ../src/option.c:1746
+#: ../src/option.c:1749
 msgid "Paned dialog options"
 msgstr "Параметри діалогу з панелями"
 
-#: ../src/option.c:1746
+#: ../src/option.c:1749
 msgid "Show paned dialog options"
 msgstr "Показувати параметри діалогу з панелями"
 
 #. Adds picture option entries
-#: ../src/option.c:1752
+#: ../src/option.c:1755
 msgid "Picture dialog options"
 msgstr "Параметри діалогу з картинкою"
 
-#: ../src/option.c:1752
+#: ../src/option.c:1755
 msgid "Show picture dialog options"
 msgstr "Показувати параметри діалогу відображення картинки"
 
 #. Adds print option entries
-#: ../src/option.c:1758
+#: ../src/option.c:1761
 msgid "Print dialog options"
 msgstr "Параметри діалогу друку"
 
-#: ../src/option.c:1758
+#: ../src/option.c:1761
 msgid "Show print dialog options"
 msgstr "Показувати параметри діалогу друку"
 
 #. Adds progress option entries
-#: ../src/option.c:1764
+#: ../src/option.c:1767
 msgid "Progress options"
 msgstr "Параметри прогресу"
 
-#: ../src/option.c:1764
+#: ../src/option.c:1767
 msgid "Show progress options"
 msgstr "Показувати параметри прогресу"
 
 #. Adds scale option entries
-#: ../src/option.c:1770
+#: ../src/option.c:1773
 msgid "Scale options"
 msgstr "Параметри масштабу"
 
-#: ../src/option.c:1770
+#: ../src/option.c:1773
 msgid "Show scale options"
 msgstr "Показувати параметри масштабу"
 
 #. Adds text option entries
-#: ../src/option.c:1776
+#: ../src/option.c:1779
 msgid "Text information options"
 msgstr "Параметри текстової інформації"
 
-#: ../src/option.c:1776
+#: ../src/option.c:1779
 msgid "Show text information options"
 msgstr "Показувати параметри текстової інформації"
 
 #. Adds sourceview option entries
-#: ../src/option.c:1783
+#: ../src/option.c:1786
 msgid "SourceView options"
 msgstr "Параметри SourceView"
 
-#: ../src/option.c:1783
+#: ../src/option.c:1786
 msgid "Show SourceView options"
 msgstr "Показувати параметри SourceView"
 
 #. Adds file filters option entries
-#: ../src/option.c:1790
+#: ../src/option.c:1793
 msgid "File filter options"
 msgstr "Параметри фільтрів для діалогу вибору файлів"
 
-#: ../src/option.c:1790
+#: ../src/option.c:1793
 msgid "Show file filter options"
 msgstr "Показувати параметри фільтрів для діалогу вибору файлів"
 
 #. Adds miscellaneous option entries
-#: ../src/option.c:1796
+#: ../src/option.c:1799
 msgid "Miscellaneous options"
 msgstr "Додаткові параметри"
 
-#: ../src/option.c:1796
+#: ../src/option.c:1799
 msgid "Show miscellaneous options"
 msgstr "Показувати додаткові параметри"
 

--- a/src/main.c
+++ b/src/main.c
@@ -823,6 +823,13 @@ main (gint argc, gchar ** argv)
 #endif
     }
 
+  if(options.data.cursor_name)
+    gdk_window_set_cursor(
+	gdk_screen_get_root_window(
+	    gdk_display_get_default_screen(gdk_display_get_default())
+	),
+	gdk_cursor_new_from_name(gdk_display_get_default(),options.data.cursor_name)
+    );
   /* set default icons and icon theme */
   if (options.data.icon_theme)
     gtk_icon_theme_set_custom_theme (settings.icon_theme, options.data.icon_theme);

--- a/src/option.c
+++ b/src/option.c
@@ -139,6 +139,8 @@ static GOptionEntry general_options[] = {
   { "selectable-labels", 0, 0, G_OPTION_ARG_NONE, &options.data.selectable_labels,
     N_("Dialog text can be selected"), NULL },
   /* window settings */
+  { "cursor", 0, G_OPTION_FLAG_NOALIAS, G_OPTION_ARG_STRING, &options.data.cursor_name,
+    N_("Use specified cursor name on start"), N_("CURSORNAME") },
   { "sticky", 0, 0, G_OPTION_ARG_NONE, &options.data.sticky,
     N_("Set window sticky"), NULL },
   { "fixed", 0, 0, G_OPTION_ARG_NONE, &options.data.fixed,
@@ -1419,6 +1421,7 @@ yad_options_init (void)
   options.data.def_resp = YAD_RESPONSE_OK;
 
   /* Initialize window options */
+  options.data.cursor_name = NULL;
   options.data.sticky = FALSE;
   options.data.fixed = FALSE;
   options.data.ontop = FALSE;

--- a/src/yad.h
+++ b/src/yad.h
@@ -225,6 +225,7 @@ typedef struct {
   GtkButtonBoxStyle buttons_layout;
   gint def_resp;
   /* window settings */
+  gchar *cursor_name;
   gboolean sticky;
   gboolean fixed;
   gboolean ontop;


### PR DESCRIPTION
When starting yad without window manager (typically as first X11 app to select what to start next) there's no cursor shown, making thing uneasy. Xorg default behavior is not to show cursor until some application calls XDefineCursor(). So I provide a new option to choose a cursor an turn it on.