### PR TITLE
Add ability to disable list column tooltip markup.

### DIFF
--- a/data/yad.1
+++ b/data/yad.1
@@ -153,7 +153,7 @@ Set buttons layout type. Possible types are: \fIspread\fP, \fIedge\fP, \fIstart\
 Default is \fIend\fP.
 .TP
 .B \-\-no-markup
-Don't use pango markup in dialog's text.
+Don't use pango markup in dialog text. List column tooltip markup can be disabled independently with \fI--tooltip-column\fP.
 .TP
 .B \-\-no-escape
 Don't close dialog if \fIEscape\fP was pressed.
@@ -546,7 +546,7 @@ When dialog wors in browser mode additional data in command line interprets as \
 .TP
 .B \-\-column=\fISTRING[:TYPE]\fP
 Set the column header. Types are \fITEXT\fP, \fINUM\fP, \fISZ\fP, \fIFLT\fP, \fICHK\fP, \fIRD\fP, \fIBAR\fP, \fIIMG\fP, \fIHD\fP or \fITIP\fP.
-\fITEXT\fP type is default. Use \fINUM\fP for integers and \fIFLT\fP for double values. \fITIP\fP is used for define tooltip column.
+\fITEXT\fP type is default. Use \fINUM\fP for integers and \fIFLT\fP for double values. \fITIP\fP is used for defining tooltip column.
 \fISZ\fP size column type. Works exactly like \fINUM\fP column but shows human readable sizes instead of numbers.
 \fICHK\fP (checkboxes) and \fIRD\fP (radio toggle) are a boolean columns.
 \fIBAR\fP is a progress bar column. Value must be between \fI0\fP and \fI100\fP. If value is outside is range it will be croped to neares legal value.
@@ -606,7 +606,7 @@ Set the column expandable by default. \fI0\fP sets all columns expandable.
 Set the quick search column. \fI0\fP mean to disable searching. By default search mades on first column.
 .TP
 .B \-\-tooltip\-column=\fINUMBER\fP
-Set the column with popup tooltips.
+Set the column with popup tooltips. Use a positive \fINUMBER\fP for pango markup or a negative \fINUMBER\fP for plain text.
 .TP
 .B \-\-sep\-column=\fINUMBER\fP
 Set the row separator column. If the cell value from this column equal to specified row separator value such row will be draw as separator.

--- a/src/option.c
+++ b/src/option.c
@@ -431,7 +431,7 @@ static GOptionEntry list_options[] = {
   { "search-column", 0, 0, G_OPTION_ARG_INT, &options.list_data.search_column,
     N_("Set the quick search column. Default is first column. Set it to 0 for disable searching"), N_("NUMBER") },
   { "tooltip-column", 0, 0, G_OPTION_ARG_INT, &options.list_data.tooltip_column,
-    N_("Set the tooltip column"), N_("NUMBER") },
+    N_("Set the tooltip column (use negative NUMBER for no pango markup)"), N_("NUMBER") },
   { "sep-column", 0, 0, G_OPTION_ARG_INT, &options.list_data.sep_column,
     N_("Set the row separator column"), N_("NUMBER") },
   { "sep-value", 0, 0, G_OPTION_ARG_STRING, &options.list_data.sep_value,


### PR DESCRIPTION
The existing option --no-markup disables markup processing in dialog
text but not in list column tooltips set with --tooltip-column. This
patch allows disabling tooltip markup independently of --no-markup.
To disable tooltip markup specify a negative NUMBER for
--tooltip-column=NUMBER, e.g.

    ls | yad --no-markup --list --column=A --tooltip-column=-1

Notice how -1 was used to request "tooltip column 1 without markup".

Intended/typical usage: using --list to display file paths or URLs.
 It isn't uncommon for such data to include '&'. Without this patch
'&', '<', '>', etc. trigger GTK errors which prevent displaying the
data as tooltip. Try:

    echo 'a&b' | yad --no-markup --column=A --list-column=1

vs.

    echo 'a&b' | yad --no-markup --column=A --list-column=-1

Hover the mouse over the row to see the difference (error output to terminal
window). Add --editable and right-click the row to try other characters.

Open for further consideration:

* I'm happy with using a negative NUMBER to extend --tooltip-column. It
  seems to me simpler than adding yet another option, such as
  --no-tooltip-column-markup.  But you may think otherwise.
  Note: a negative NUMBER doesn't break compatibility with existing
  scripts.