### PR TITLE
Fix GTK2 icon browser crash.

### DIFF
--- a/src/browser.c
+++ b/src/browser.c
@@ -144,7 +144,11 @@ select_icon (GtkTreeSelection * sel, IconBrowserData * data)
   g_string_free (sizes, TRUE);
 
   if (info)
+#if !GTK_CHECK_VERSION(3,0,0)
+    gtk_icon_info_free(info);
+#else
     g_object_unref (info);
+#endif
 }
 
 static void


### PR DESCRIPTION
For the GTK2 icon browser only, selecting an icon crashed yad.
This is the fix, courtesy of Jake FSR.
Tested, it works for both the GTK2 and GTK3 builds.