### PR TITLE
Fix --list prints empty cell as "(null)"

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -1162,7 +1162,7 @@ print_col (GtkTreeModel * model, GtkTreeIter * iter, gint num)
             g_free (buf);
           }
         else
-          g_printf ("%s", val);
+          g_printf ("%s", val ? val : "");
         break;
       }
     }


### PR DESCRIPTION
To illustrate the issue before and after this fix:

    # /usr/bin/yad --list --print-all --column=A a '' c
    a|
    (null)|
    c|
    # ./src/yad --list --print-all --column=A a '' c
    a|
    |
    c|

The empty string '' in the second row results in a NULL C pointer,
which g_printf prints as "(null)". The fix consists of passing the
empty string "" to g_printf when the pointer is NULL.