### PR TITLE
Add --icons sub-option --icon-width

### DIFF
--- a/data/yad.1
+++ b/data/yad.1
@@ -367,9 +367,7 @@ separated by newline. \fIInTerm\fP is a case insensitive boolean constant (\fITR
 Sending \fIFormFeed\fP character clears iconbox.
 .TP
 .B \-\-icon-width
-Resize icons to the given width. Specify also
-.B \-\-item-width
-if you need padding around each icon.
+Resize icons to the given width.
 .TP
 .B \-\-item-width
 Set item width.

--- a/data/yad.1
+++ b/data/yad.1
@@ -366,8 +366,13 @@ Read data from stdin. Data must be in order - \fIName\fP, \fITooltip\fP, \fIIcon
 separated by newline. \fIInTerm\fP is a case insensitive boolean constant (\fITRUE\fP or \fIFALSE\fP).
 Sending \fIFormFeed\fP character clears iconbox.
 .TP
+.B \-\-icon-width
+Set icon width for full view only. Specify also
 .B \-\-item-width
-Set items width.
+if you need padding around each icon.
+.TP
+.B \-\-item-width
+Set item width.
 .TP
 .B \-\-compact
 Use compact mode. Icon and name of each item is placed in a single row.

--- a/data/yad.1
+++ b/data/yad.1
@@ -108,7 +108,7 @@ See \fIhttp://code.google.com/p/yad/wiki/TimeoutIndicator\fP for details.
 Send SIGNAL to parent process. Default value of SIGNAL is a SIGTERM.
 SIGNAL may be specified by it's number or symbolic name with or without SIG prefix.
 See signal(7) for details about signals.
-.TP 
+.TP
 .B \-\-print-xid=\fI[FILENAME]\fP
 Output X Window ID of a yad's window to the specified file or stderr.
 .TP
@@ -367,7 +367,7 @@ separated by newline. \fIInTerm\fP is a case insensitive boolean constant (\fITR
 Sending \fIFormFeed\fP character clears iconbox.
 .TP
 .B \-\-icon-width
-Set icon width for full view only. Specify also
+Resize icons to the given width. Specify also
 .B \-\-item-width
 if you need padding around each icon.
 .TP

--- a/src/icons.c
+++ b/src/icons.c
@@ -207,28 +207,13 @@ handle_stdin (GIOChannel * channel, GIOCondition condition, gpointer data)
               }
             case COL_PIXBUF:
               {
-                guint width, height, new_width, new_height;
                 if (options.icons_data.compact)
                   if (*string->str)
-                    pb = get_pixbuf (string->str, YAD_SMALL_ICON);
+                    pb = get_pixbuf_scaled (string->str, YAD_SMALL_ICON, options.icons_data.icon_width);
                   else
                     pb = NULL;
                 else
-                  pb = get_pixbuf (string->str, YAD_BIG_ICON);
-                if (pb)
-                  {
-                    width = gdk_pixbuf_get_width(pb);
-                    height = gdk_pixbuf_get_height(pb);
-                    if (options.icons_data.icon_width && width != options.icons_data.icon_width)
-                      {
-                        GdkPixbuf *new_pb;
-                        new_width = options.icons_data.icon_width;
-                        new_height = options.icons_data.icon_width * height / width;
-                        new_pb = gdk_pixbuf_scale_simple (pb, new_width, new_height, GDK_INTERP_BILINEAR);
-                        g_object_unref (pb);
-                        pb = new_pb;
-                      }
-                  }
+                  pb = get_pixbuf_scaled (string->str, YAD_BIG_ICON, options.icons_data.icon_width);
               }
               gtk_list_store_set (GTK_LIST_STORE (model), &iter, column_count, pb, -1);
               if (pb)
@@ -338,22 +323,10 @@ parse_desktop_file (gchar * filename)
           icon = g_key_file_get_string (kf, "Desktop Entry", "Icon", NULL);
           if (icon)
             {
-                guint width, height, new_width, new_height;
-                if (options.icons_data.compact)
-                  ent->pixbuf = get_pixbuf (icon, YAD_SMALL_ICON);
-                else
-                  ent->pixbuf = get_pixbuf (icon, YAD_BIG_ICON);
-                width = gdk_pixbuf_get_width(ent->pixbuf);
-                height = gdk_pixbuf_get_height(ent->pixbuf);
-                if (options.icons_data.icon_width && width != options.icons_data.icon_width)
-                {
-                  GdkPixbuf *new_pb;
-                  new_width = options.icons_data.icon_width;
-                  new_height = options.icons_data.icon_width * height / width;
-                  new_pb = gdk_pixbuf_scale_simple (ent->pixbuf, new_width, new_height, GDK_INTERP_BILINEAR);
-                  g_object_unref (ent->pixbuf);
-                  ent->pixbuf = new_pb;
-                }
+              if (options.icons_data.compact)
+                ent->pixbuf = get_pixbuf_scaled (icon, YAD_SMALL_ICON, options.icons_data.icon_width);
+              else
+                ent->pixbuf = get_pixbuf_scaled (icon, YAD_BIG_ICON, options.icons_data.icon_width);
               g_free (icon);
             }
         }

--- a/src/icons.c
+++ b/src/icons.c
@@ -206,15 +206,13 @@ handle_stdin (GIOChannel * channel, GIOCondition condition, gpointer data)
                 break;
               }
             case COL_PIXBUF:
-              {
-                if (options.icons_data.compact)
-                  if (*string->str)
-                    pb = get_pixbuf_scaled (string->str, YAD_SMALL_ICON, options.icons_data.icon_width);
-                  else
-                    pb = NULL;
+              if (options.icons_data.compact)
+                if (*string->str)
+                  pb = get_pixbuf_scaled (string->str, YAD_SMALL_ICON, options.icons_data.icon_width);
                 else
-                  pb = get_pixbuf_scaled (string->str, YAD_BIG_ICON, options.icons_data.icon_width);
-              }
+                  pb = NULL;
+              else
+                pb = get_pixbuf_scaled (string->str, YAD_BIG_ICON, options.icons_data.icon_width);
               gtk_list_store_set (GTK_LIST_STORE (model), &iter, column_count, pb, -1);
               if (pb)
                 g_object_unref (pb);

--- a/src/icons.c
+++ b/src/icons.c
@@ -206,27 +206,30 @@ handle_stdin (GIOChannel * channel, GIOCondition condition, gpointer data)
                 break;
               }
             case COL_PIXBUF:
-              if (options.icons_data.compact)
-                if (*string->str)
-                  pb = get_pixbuf (string->str, YAD_SMALL_ICON);
+              {
+                guint width, height, new_width, new_height;
+                if (options.icons_data.compact)
+                  if (*string->str)
+                    pb = get_pixbuf (string->str, YAD_SMALL_ICON);
+                  else
+                    pb = NULL;
                 else
-                  pb = NULL;
-              else
-                {
-                  guint width, height, new_width, new_height;
                   pb = get_pixbuf (string->str, YAD_BIG_ICON);
-                  width = gdk_pixbuf_get_width(pb);
-                  height = gdk_pixbuf_get_height(pb);
-                  if (options.icons_data.icon_width && width != options.icons_data.icon_width)
-                    {
-                      GdkPixbuf *new_pb;
-                      new_width = options.icons_data.icon_width;
-                      new_height = options.icons_data.icon_width * height / width;
-                      new_pb = gdk_pixbuf_scale_simple (pb, new_width, new_height, GDK_INTERP_BILINEAR);
-                      g_object_unref (pb);
-                      pb = new_pb;
-                    }
-                }
+                if (pb)
+                  {
+                    width = gdk_pixbuf_get_width(pb);
+                    height = gdk_pixbuf_get_height(pb);
+                    if (options.icons_data.icon_width && width != options.icons_data.icon_width)
+                      {
+                        GdkPixbuf *new_pb;
+                        new_width = options.icons_data.icon_width;
+                        new_height = options.icons_data.icon_width * height / width;
+                        new_pb = gdk_pixbuf_scale_simple (pb, new_width, new_height, GDK_INTERP_BILINEAR);
+                        g_object_unref (pb);
+                        pb = new_pb;
+                      }
+                  }
+              }
               gtk_list_store_set (GTK_LIST_STORE (model), &iter, column_count, pb, -1);
               if (pb)
                 g_object_unref (pb);
@@ -335,23 +338,21 @@ parse_desktop_file (gchar * filename)
           icon = g_key_file_get_string (kf, "Desktop Entry", "Icon", NULL);
           if (icon)
             {
-              if (options.icons_data.compact)
-                ent->pixbuf = get_pixbuf (icon, YAD_SMALL_ICON);
-              else
-                {
-                  guint width, height, new_width, new_height;
+                guint width, height, new_width, new_height;
+                if (options.icons_data.compact)
+                  ent->pixbuf = get_pixbuf (icon, YAD_SMALL_ICON);
+                else
                   ent->pixbuf = get_pixbuf (icon, YAD_BIG_ICON);
-                  width = gdk_pixbuf_get_width(ent->pixbuf);
-                  height = gdk_pixbuf_get_height(ent->pixbuf);
-                  if (options.icons_data.icon_width && width != options.icons_data.icon_width)
-                    {
-                      GdkPixbuf *new_pb;
-                      new_width = options.icons_data.icon_width;
-                      new_height = options.icons_data.icon_width * height / width;
-                      new_pb = gdk_pixbuf_scale_simple (ent->pixbuf, new_width, new_height, GDK_INTERP_BILINEAR);
-                      g_object_unref (ent->pixbuf);
-                      ent->pixbuf = new_pb;
-                    }
+                width = gdk_pixbuf_get_width(ent->pixbuf);
+                height = gdk_pixbuf_get_height(ent->pixbuf);
+                if (options.icons_data.icon_width && width != options.icons_data.icon_width)
+                {
+                  GdkPixbuf *new_pb;
+                  new_width = options.icons_data.icon_width;
+                  new_height = options.icons_data.icon_width * height / width;
+                  new_pb = gdk_pixbuf_scale_simple (ent->pixbuf, new_width, new_height, GDK_INTERP_BILINEAR);
+                  g_object_unref (ent->pixbuf);
+                  ent->pixbuf = new_pb;
                 }
               g_free (icon);
             }

--- a/src/icons.c
+++ b/src/icons.c
@@ -338,7 +338,21 @@ parse_desktop_file (gchar * filename)
               if (options.icons_data.compact)
                 ent->pixbuf = get_pixbuf (icon, YAD_SMALL_ICON);
               else
-                ent->pixbuf = get_pixbuf (icon, YAD_BIG_ICON);
+                {
+                  guint width, height, new_width, new_height;
+                  ent->pixbuf = get_pixbuf (icon, YAD_BIG_ICON);
+                  width = gdk_pixbuf_get_width(ent->pixbuf);
+                  height = gdk_pixbuf_get_height(ent->pixbuf);
+                  if (options.icons_data.icon_width && width != options.icons_data.icon_width)
+                    {
+                      GdkPixbuf *new_pb;
+                      new_width = options.icons_data.icon_width;
+                      new_height = options.icons_data.icon_width * height / width;
+                      new_pb = gdk_pixbuf_scale_simple (ent->pixbuf, new_width, new_height, GDK_INTERP_BILINEAR);
+                      g_object_unref (ent->pixbuf);
+                      ent->pixbuf = new_pb;
+                    }
+                }
               g_free (icon);
             }
         }

--- a/src/icons.c
+++ b/src/icons.c
@@ -212,7 +212,21 @@ handle_stdin (GIOChannel * channel, GIOCondition condition, gpointer data)
                 else
                   pb = NULL;
               else
-                pb = get_pixbuf (string->str, YAD_BIG_ICON);
+                {
+                  guint width, height, new_width, new_height;
+                  pb = get_pixbuf (string->str, YAD_BIG_ICON);
+                  width = gdk_pixbuf_get_width(pb);
+                  height = gdk_pixbuf_get_height(pb);
+                  if (options.icons_data.icon_width && width != options.icons_data.icon_width)
+                    {
+                      GdkPixbuf *new_pb;
+                      new_width = options.icons_data.icon_width;
+                      new_height = options.icons_data.icon_width * height / width;
+                      new_pb = gdk_pixbuf_scale_simple (pb, new_width, new_height, GDK_INTERP_BILINEAR);
+                      g_object_unref (pb);
+                      pb = new_pb;
+                    }
+                }
               gtk_list_store_set (GTK_LIST_STORE (model), &iter, column_count, pb, -1);
               if (pb)
                 g_object_unref (pb);

--- a/src/option.c
+++ b/src/option.c
@@ -376,7 +376,7 @@ static GOptionEntry icons_options[] = {
   { "generic", 0, 0, G_OPTION_ARG_NONE, &options.icons_data.generic,
     N_("Use GenericName field instead of Name for icon label"), NULL },
   { "icon-width", 0, 0, G_OPTION_ARG_INT, &options.icons_data.icon_width,
-    N_("Set the width of full view dialog icons (use --item-width for padding)"), NULL },
+    N_("Resize dialog icons to the given width"), NULL },
   { "item-width", 0, 0, G_OPTION_ARG_INT, &options.icons_data.width,
     N_("Set the width of dialog items"), NULL },
   { "term", 0, 0, G_OPTION_ARG_STRING, &options.icons_data.term,

--- a/src/option.c
+++ b/src/option.c
@@ -375,6 +375,8 @@ static GOptionEntry icons_options[] = {
     N_("Use compact (list) view"), NULL },
   { "generic", 0, 0, G_OPTION_ARG_NONE, &options.icons_data.generic,
     N_("Use GenericName field instead of Name for icon label"), NULL },
+  { "icon-width", 0, 0, G_OPTION_ARG_INT, &options.icons_data.icon_width,
+    N_("Set the width of full view dialog icons (use --item-width for padding)"), NULL },
   { "item-width", 0, 0, G_OPTION_ARG_INT, &options.icons_data.width,
     N_("Set the width of dialog items"), NULL },
   { "term", 0, 0, G_OPTION_ARG_STRING, &options.icons_data.term,

--- a/src/yad.h
+++ b/src/yad.h
@@ -318,6 +318,7 @@ typedef struct {
   gboolean descend;
   gboolean sort_by_name;
   gboolean single_click;
+  guint icon_width;
   guint width;
   gchar *term;
 #ifdef HAVE_GIO

--- a/src/yad.h
+++ b/src/yad.h
@@ -613,6 +613,7 @@ void update_preview (GtkFileChooser *chooser, GtkWidget *p);
 void filechooser_mapped (GtkWidget *w, gpointer data);
 
 GdkPixbuf *get_pixbuf (gchar *name, YadIconSize size);
+GdkPixbuf *get_pixbuf_scaled (gchar *name, YadIconSize size, gint w);
 #if GTK_CHECK_VERSION(3,0,0)
 gchar *get_color (GdkRGBA *c);
 #else


### PR DESCRIPTION
This new option for mode --icons helps to make the icon box look more
tidy when icons of various sizes are used. The option applies to full
view only.

Currently yad declares all full view icons as YAD_BIG_ICON, 48 x 48,
regardless of actual icon size. Unfortunately, the icon image isn't
scaled to the requested size, so smaller or larger images are shown at
their natural size. This makes the icon grid look untidy, as shown in
the first screen capture below.

The second screen capture shows new option --icon-width in action.
Icon width is set to 48, item width 100 to provide some padding around
each icon.  Scaling is as follows:

   48 x 48 -> none    touchpad48.png
   16 x 18 -> 48 x 54 idea16.xpm
   14 x 14 -> 48 x 48 mini.window3d.xpm
   96 x 96 -> 48 x 48 Network.svg

The third screen capture shows scaling width to 32, a size that just
can't be achieved with the current implementation.

   48 x 48 -> 32 x 32 touchpad48.png
   16 x 18 -> 32 x 36 idea16.xpm
   14 x 14 -> 32 x 32 mini.window3d.xpm
   96 x 96 -> 32 x 32 Network.svg

Notes

* If --icon-width is used without --item-width items are displayed as
  wide as icons.

Screen captures

`yad --icons`
![first picture](https://user-images.githubusercontent.com/1414102/50778784-18ff5f00-129f-11e9-8f32-f7a17fd6dda8.png)

`yad --icons --icon-width=48 --item-width=100`
![second screen capture](https://user-images.githubusercontent.com/1414102/50778854-3d5b3b80-129f-11e9-838f-c90a05dcb1d6.png)

`yad --icons --icon-width=32 --item-width=100`
![third screen capture](https://user-images.githubusercontent.com/1414102/50778929-5cf26400-129f-11e9-847b-f3730c98cd07.png)
