### PR TITLE
Fix --notebook --active-tab

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -638,6 +638,10 @@ create_dialog (void)
         gtk_window_fullscreen (GTK_WINDOW (dlg));
     }
 
+  /* must be after showing widgets */
+  if (options.mode == YAD_MODE_NOTEBOOK)
+    notebook_set_active_tab ();
+
 #ifndef G_OS_WIN32
   /* print xid */
   if (options.print_xid)

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -70,11 +70,6 @@ notebook_create_widget (GtkWidget * dlg)
       gtk_container_child_set( GTK_CONTAINER (w), a, "tab-expand", options.notebook_data.expand, NULL);
     }
 
-  /* set active tab */
-  if (options.notebook_data.active <= 0)
-    options.notebook_data.active = 1;
-  gtk_notebook_set_current_page (GTK_NOTEBOOK (w), options.notebook_data.active - 1);
-
   return w;
 }
 
@@ -145,4 +140,13 @@ notebook_close_childs (void)
   /* cleanup shared memory */
   shmctl (tabs[0].pid, IPC_RMID, &buf);
   shmdt (tabs);
+}
+
+void
+notebook_set_active_tab (void)
+{
+  /* Says gtk docs: Due to historical reasons, GtkNotebook refuses to switch to a page unless the child widget is visible */
+  if (options.notebook_data.active <= 0)
+    options.notebook_data.active = 1;
+  gtk_notebook_set_current_page (GTK_NOTEBOOK (notebook), options.notebook_data.active - 1);
 }

--- a/src/yad.h
+++ b/src/yad.h
@@ -602,6 +602,7 @@ gint yad_about (void);
 
 gboolean yad_send_notify (gboolean);
 
+void notebook_set_active_tab (void);
 void notebook_close_childs (void);
 void paned_close_childs (void);
 


### PR DESCRIPTION
Before this fix the --active-tab=NUMBER option does nothing (tested on
GTK2 build).  This happens because the active tab must be set after
showing the children widget, as documented in
https://developer.gnome.org/gtk3/stable/GtkNotebook.html#gtk-notebook-set-current-page

This commit simply moves the relevant code to after gtk_widget_show_all.

Test case
    for i in 1 2; do yad --text=$i --tabnum=$i --plug=12345 >/dev/null & done; yad --key=12345 --notebook --tab=1 --tab=2 --center --active-tab=2