### PR TITLE
Fix two race conditions (notebook and paned)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -39,7 +39,6 @@ static GtkWidget *dialog = NULL;
 static gint ret = YAD_RESPONSE_ESC;
 
 YadNTabs *tabs;
-gint t_sem;
 
 #ifndef G_OS_WIN32
 static void
@@ -675,6 +674,10 @@ create_plug (void)
       usleep (1000);
       tabs = get_tabs (options.plug, FALSE);
     }
+  while (!tabs[0].xid)
+    {
+      usleep (1000);
+    }
 
   win = gtk_plug_new (0);
   /* set window borders */
@@ -689,10 +692,9 @@ create_plug (void)
   gtk_widget_show_all (win);
 
   /* add plug data */
+  /* notebook/paned will count non-zero xids */
   tabs[options.tabnum].pid = getpid ();
   tabs[options.tabnum].xid = gtk_plug_get_id (GTK_PLUG (win));
-  /* FIXME: may be a race here */
-  tabs[0].xid++;
   shmdt (tabs);
 }
 

--- a/src/notebook.c
+++ b/src/notebook.c
@@ -82,12 +82,24 @@ void
 notebook_swallow_childs (void)
 {
   guint i, n_tabs;
+  gboolean all_registered;
 
   n_tabs = g_slist_length (options.notebook_data.tabs);
 
-  /* wait until all children are register */
-  while (tabs[0].xid != n_tabs)
-    usleep (1000);
+  /* wait until all children are registered */
+  do
+    {
+      all_registered = TRUE;
+      for (i = 1; i <= n_tabs; i++)
+        if (!tabs[i].xid)
+          {
+            all_registered = FALSE;
+            break;
+          }
+      if (!all_registered)
+        usleep (1000);
+    }
+  while (!all_registered);
 
   for (i = 1; i <= n_tabs; i++)
     {
@@ -118,7 +130,7 @@ notebook_close_childs (void)
 {
   guint i, n_tabs;
   struct shmid_ds buf;
-  gboolean is_running = TRUE;
+  gboolean is_running;
 
   n_tabs = g_slist_length (options.notebook_data.tabs);
   for (i = 1; i <= n_tabs; i++)
@@ -128,7 +140,7 @@ notebook_close_childs (void)
     }
 
   /* wait for stop subprocesses */
-  while (is_running)
+  do
     {
       is_running = FALSE;
       for (i = 1; i <= n_tabs; i++)
@@ -139,8 +151,10 @@ notebook_close_childs (void)
               break;
             }
         }
-      usleep (1000);
+      if (is_running)
+        usleep (1000);
     }
+  while (is_running);
 
   /* cleanup shared memory */
   shmctl (tabs[0].pid, IPC_RMID, &buf);

--- a/src/paned.c
+++ b/src/paned.c
@@ -77,8 +77,8 @@ paned_swallow_childs (void)
   s1 = GTK_WIDGET (g_object_get_data (G_OBJECT (paned), "s1"));
   s2 = GTK_WIDGET (g_object_get_data (G_OBJECT (paned), "s2"));
 
-  /* wait until all children are register */
-  while (tabs[0].xid != 2)
+  /* wait until all children are registered */
+  while (!tabs[1].xid || !tabs[2].xid)
     usleep (1000);
 
   if (tabs[1].pid != -1)

--- a/src/util.c
+++ b/src/util.c
@@ -370,6 +370,8 @@ get_tabs (key_t key, gboolean create)
           t[i].xid = 0;
         }
       t[0].pid = shmid;
+      /* lastly, allow plugs to write shmem */
+      t[0].xid = 1;
     }
 
   return t;

--- a/src/yad.h
+++ b/src/yad.h
@@ -548,9 +548,8 @@ typedef struct {
 /* pointer to shared memory for tabbed dialog */
 /* 0 item used for special info: */
 /*   pid - memory id */
-/*   xid - count of registered tabs (for sync) */
+/*   xid - allow plugs to write shmem (for sync) */
 extern YadNTabs *tabs;
-extern gint t_sem;
 
 void yad_options_init (void);
 GOptionContext *yad_create_context (void);


### PR DESCRIPTION
Before this commit there were two Critical Regions (CR) that could lead
to race conditions:
* among yad --plug processes, and   
* between yad --key (notebook or paned) and yad --plug processes.

The first CR had been marked as suspected in the existing code with
this comment `/* FIXME: may be race here */` but no fix. This CR
could lead to a race condition between multiple plugs trying to
increment counter `tabs[0].xid++` all at once. Given a collision, the
xid counter would never reach its target value, which is the number of
plugs connected to notebook (or paned). Therefore the notebook
or paned dialog would wait forever and never display their windows.
One could run `ps` and watch several yad processes sleeping in the
process list without visible yad windows.

To fix this problem I redefined the role of `tabs[0].xid` from a
read/write counter to a read-only (from the perspective of plugs)
boolean flag. Only when the flag goes true are the plugs allowed to
write to shared memory -- each plug to its own memory space `tabs[i]`.
This eliminates the CR therefore the problem. With this change only
the yad --key process is allowed to write `tabs[0]`.

The second CR occurred inside function `get_tabs` when the yad --key
process attached shared memory and initialized the `tabs[i]` slots.
In a race condition this initialization could overwrite a plug's slot
_after_ the plug had written the slot. This would make GTK unable to
set up a socket between the plug and the key therefore the key would
hang forever without displaying its window.

To fix this problem I used again `tabs[0].xid` as explained above to
make sure that `tabs[0].xid=1` (TRUE) is set only after the key has
initialized the shared memory block. While the flag is false, plug
can attach shared memory but they aren't allowed to write their slots.
After the flag is set true (and never reset false), each plug can write
only its own slot `tabs[i]`, for which there is no contention.

There was no need to set up a mutex or semaphore to solve the race
conditions.