### PR TITLE
Trim whitespace around `cmd` to fix special `quit ` menuitem

### DIFF
--- a/src/notification.c
+++ b/src/notification.c
@@ -174,7 +174,7 @@ popup_menu_item_activate_cb (GtkWidget * w, gpointer data)
 
   if (cmd)
     {
-      if (g_ascii_strcasecmp (cmd, "quit") == 0)
+      if (g_ascii_strcasecmp (g_strstrip (cmd), "quit") == 0)
         {
           exit_code = YAD_RESPONSE_OK;
           gtk_main_quit ();


### PR DESCRIPTION
Fixes #38. This is my first time dabbling with C so there may be a better way, I'm not sure.

I've built and ran it on my machine though, and it seems to be working. With this PR, `quit` works as a special menu item regardless of whether or not it's padded with space on either side.