### PR TITLE
Maint fix list sep column: Fix segfault on --list --sep-column --sep-value for 2+ columns

### DIFF
--- a/data/yad.1
+++ b/data/yad.1
@@ -235,7 +235,7 @@ Enable spell checking in textview widgets
 .B \-\-spell-lang=\fILANGUAGE\fP
 Set spell checking language to \fILANGUAGE\fP. By default language guesses from current locale. Use option \fI\-\-show-langs\fP for get list of all possible languages.
 .TP
-.B \-\-boot-fmt=\fITYPE\fP
+.B \-\-bool-fmt=\fITYPE\fP
 Set the output type of boolean values to \fITYPE\fP. Possible types are \fIT\fP, \fIt\fP, \fIY\fP, \fIy\fP, \fIO\fP, \fIo\fP and \fI1\fP.
 .br
 \fIT\fP and \fIt\fP - for \fItrue/false\fP pair in appropriate case.

--- a/src/list.c
+++ b/src/list.c
@@ -928,11 +928,14 @@ static gboolean
 row_sep_func (GtkTreeModel * m, GtkTreeIter * it, gpointer data)
 {
   gchar *value;
+  gint offset = -1;
 
   if (!options.list_data.sep_value)
     return FALSE;
 
-  gtk_tree_model_get (m, it, options.list_data.sep_column - 1, &value, -1);
+  if (options.list_data.checkbox || options.list_data.radiobox)
+    offset = 0;
+  gtk_tree_model_get (m, it, options.list_data.sep_column - offset, &value, -1);
   return (value && strcmp (value, options.list_data.sep_value) == 0);
 }
 

--- a/src/list.c
+++ b/src/list.c
@@ -927,13 +927,13 @@ popup_menu_cb (GtkWidget * w, GdkEventButton * ev, gpointer data)
 static gboolean
 row_sep_func (GtkTreeModel * m, GtkTreeIter * it, gpointer data)
 {
-  gchar *name;
+  gchar *value;
 
   if (!options.list_data.sep_value)
     return FALSE;
 
-  gtk_tree_model_get (m, it, options.list_data.sep_column - 1, &name, -1);
-  return (strcmp (name, options.list_data.sep_value) == 0);
+  gtk_tree_model_get (m, it, options.list_data.sep_column - 1, &value, -1);
+  return (value && strcmp (value, options.list_data.sep_value) == 0);
 }
 
 static inline void

--- a/src/list.c
+++ b/src/list.c
@@ -928,14 +928,15 @@ static gboolean
 row_sep_func (GtkTreeModel * m, GtkTreeIter * it, gpointer data)
 {
   gchar *value;
-  gint offset = -1;
 
   if (!options.list_data.sep_value)
     return FALSE;
 
-  if (options.list_data.checkbox || options.list_data.radiobox)
-    offset = 0;
-  gtk_tree_model_get (m, it, options.list_data.sep_column - offset, &value, -1);
+  YadColumn *col = (YadColumn *) g_slist_nth_data (options.list_data.columns, options.list_data.sep_column -1);
+  if (!col || col->type != YAD_COLUMN_TEXT)
+    return FALSE;
+
+  gtk_tree_model_get (m, it, options.list_data.sep_column - 1, &value, -1);
   return (value && strcmp (value, options.list_data.sep_value) == 0);
 }
 


### PR DESCRIPTION
Fix segfault on --list --sep-column --sep-value for 2+ columns

Tested on GTK2 only.
Before this fix:

```sh
# /usr/bin/yad --list --sep-column=2 --sep-value=@@ --column= --column=
typing this, pressing ENTER
Segmentation fault
# echo | /usr/bin/yad --list --sep-column=2 --sep-value=@@ --column= --column=
Segmentation fault
```

After this fix:
```sh
# ./src/yad --list --sep-column=2 --sep-value=@@ --column= --column=
typing this, pressing ENTER
typing column 2, pressing ENTER
^C
# echo -e "1\n2" | ./src/yad --list --sep-column=2 --sep-value=@@ --column= --column=
#
```
No more segfault.