### PR TITLE
Updated scale dialog so slider snaps to steps

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -111,6 +111,8 @@ AM_CONDITIONAL([BUILD_IB], [test x$build_ib = xyes])
 # GSettings
 GLIB_GSETTINGS
 
+AC_SEARCH_LIBS(round, m)
+
 # *******************************
 # Internationalization
 # ******************************* 

--- a/data/yad.1
+++ b/data/yad.1
@@ -923,6 +923,9 @@ Set maximum value.
 .B \-\-step=\fIVALUE\fP
 Set step size.
 .TP
+.B \-\-enforce-step
+Only allow values in step increments.
+.TP
 .B \-\-page=\fIVALUE\fP
 Set paging size. By default page value is STEP*10.
 .TP

--- a/src/option.c
+++ b/src/option.c
@@ -580,6 +580,8 @@ static GOptionEntry scale_options[] = {
     N_("Set maximum value"), N_("VALUE") },
   { "step", 0, 0, G_OPTION_ARG_INT, &options.scale_data.step,
     N_("Set step size"), N_("VALUE") },
+  { "enforce-step", 0, 0, G_OPTION_ARG_NONE,  &options.scale_data.enforce_step,
+    N_("Only allow values in step increments"), NULL },
   { "page", 0, 0, G_OPTION_ARG_INT, &options.scale_data.page,
     N_("Set paging size"), N_("VALUE") },
   { "print-partial", 0, 0, G_OPTION_ARG_NONE, &options.scale_data.print_partial,

--- a/src/scale.c
+++ b/src/scale.c
@@ -18,12 +18,14 @@
  */
 
 #include "yad.h"
+#include <math.h>
 
 enum {
   PLUS_BTN = 0,
   MINUS_BTN,
 };
 
+static GtkAdjustment *adj;
 static GtkWidget *scale;
 static GtkWidget *plus_btn = NULL;
 static GtkWidget *minus_btn = NULL;
@@ -31,6 +33,14 @@ static GtkWidget *minus_btn = NULL;
 static void
 value_changed_cb (GtkWidget * w, gpointer data)
 {
+  /* Make sure the new value corresponds to a step in the range. This is needed
+   * since the user can move the slider with the mouse which doesn't obey the
+   * step constraint like the keyboard or buttons
+   */
+  gdouble value = gtk_adjustment_get_value ((GtkAdjustment *)adj);
+  gdouble new_value = (gdouble) round(value/options.scale_data.step) * options.scale_data.step;
+  gtk_adjustment_set_value ((GtkAdjustment *)adj, new_value);
+
   if (options.scale_data.print_partial)
     g_print ("%.0f\n", gtk_range_get_value (GTK_RANGE (scale)));
 
@@ -72,7 +82,6 @@ GtkWidget *
 scale_create_widget (GtkWidget * dlg)
 {
   GtkWidget *w;
-  GtkAdjustment *adj;
   gint page;
 
   if (options.scale_data.min_value >= options.scale_data.max_value)

--- a/src/scale.c
+++ b/src/scale.c
@@ -33,13 +33,13 @@ static GtkWidget *minus_btn = NULL;
 static void
 value_changed_cb (GtkWidget * w, gpointer data)
 {
-  /* Make sure the new value corresponds to a step in the range. This is needed
-   * since the user can move the slider with the mouse which doesn't obey the
-   * step constraint like the keyboard or buttons
-   */
-  gdouble value = gtk_adjustment_get_value ((GtkAdjustment *)adj);
-  gdouble new_value = (gdouble) round(value/options.scale_data.step) * options.scale_data.step;
-  gtk_adjustment_set_value ((GtkAdjustment *)adj, new_value);
+  if (options.scale_data.enforce_step)
+  {
+    /* Make sure the new value corresponds to a step in the range. */
+    gdouble value = gtk_adjustment_get_value ((GtkAdjustment *)adj);
+    gdouble new_value = (gdouble) round(value/options.scale_data.step) * options.scale_data.step;
+    gtk_adjustment_set_value ((GtkAdjustment *)adj, new_value);
+  }
 
   if (options.scale_data.print_partial)
     g_print ("%.0f\n", gtk_range_get_value (GTK_RANGE (scale)));

--- a/src/yad.h
+++ b/src/yad.h
@@ -432,6 +432,7 @@ typedef struct {
   gboolean invert;
   gboolean buttons;
   GSList *marks;
+  gboolean enforce_step;
 } YadScaleData;
 
 typedef struct {


### PR DESCRIPTION
Updated scale dialog so moving the slider with the mouse will snap to the closest step instead of allowing any arbitrary value to be selected