### PR TITLE
Make X11-specific widgets and behaviour optional

### DIFF
--- a/src/notebook.c
+++ b/src/notebook.c
@@ -52,6 +52,14 @@ notebook_create_widget (GtkWidget * dlg)
   gtk_notebook_set_tab_pos (GTK_NOTEBOOK (w), options.notebook_data.pos);
   gtk_container_set_border_width (GTK_CONTAINER (w), 5);
 
+#ifdef GDK_WINDOWING_X11
+  if (!GDK_IS_X11_WINDOW (gtk_widget_get_window (w)))
+    {
+      g_printerr("notebook only works with X11\n");
+      exit (-1);
+    }
+#endif
+
   /* add tabs */
   for (tab = options.notebook_data.tabs; tab; tab = tab->next)
     {

--- a/src/paned.c
+++ b/src/paned.c
@@ -51,6 +51,14 @@ paned_create_widget (GtkWidget * dlg)
 
   gtk_paned_set_position (GTK_PANED (w), options.paned_data.splitter);
 
+#ifdef GDK_WINDOWING_X11
+  if (!GDK_IS_X11_WINDOW (gtk_widget_get_window (w)))
+    {
+      g_printerr("paned only works with X11\n");
+      exit (-1);
+    }
+#endif
+
   s = gtk_socket_new ();
   gtk_paned_add1 (GTK_PANED (w), s);
   g_object_set_data (G_OBJECT (w), "s1", s);


### PR DESCRIPTION
This is a quick comment-out-and-make-it-compile-again set of changes
that allow to optionally disable all X11-specific widgets and behaviour.
In particular it gets rid of messages such as

(yad:115023): Gtk-WARNING **: 00:19:31.599: GtkSocket: only works under X11

(yad:115023): Gdk-WARNING **: 00:19:31.602:
/var/tmp/portage/x11-libs/gtk+-3.24.13/work/gtk+-3.24.13/gdk/x11/gdkwindow-x11.c:5633
drawable is not a native X11 window

Segmentation fault (core dumped)

when running under wayland and consequently prevents the segfault.

Closes #49.