### PR TITLE
add the ability to set width or height on a plug

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -593,6 +593,9 @@ create_plug (void)
   if (box)
     gtk_container_add (GTK_CONTAINER (win), box);
 
+  if (options.data.width != -1 || options.data.height != -1)
+    gtk_widget_set_size_request(GTK_CONTAINER(win), options.data.width, options.data.height);
+
   gtk_widget_show_all (win);
 
   /* add plug data */


### PR DESCRIPTION
When trying to make a panel with two text areas the same size, I found the slitter was not going where it should.  This is my first time looking at GTK, and think it may be due an ordering issue of the plug being linked in the a socket for the panel to draw, that the panel trying to set the splitter before the size of the text-panels are known.

here was my test code that did not work:
```
#!/usr/bin/env bash
TEXT="aaaaaa bbbbbb ccccc ddddd eeeeee fffff gggg hhhh iii  jjjjj kkkkk llllll mmmm nnnn oooo ppp qqqqqq rrrr sss ttt uuuu vvvv wwww xxxx yyyy zzzzz !!!!!!!"
KEY=$RANDOM
yad --plug=$KEY --tabnum=1 --text-info  --text  "1 $TEXT $TEXT"  &
yad --plug=$KEY --tabnum=2 --text-info  --text  "2 $TEXT $TEXT" -&
yad --paned --key=$KEY --orient=hor  --width=600  --height=600 --splitter=300 
```

now with the PR the following will work:
```
#!/usr/bin/env bash
TEXT="aaaaaa bbbbbb ccccc ddddd eeeeee fffff gggg hhhh iii  jjjjj kkkkk llllll mmmm nnnn oooo ppp qqqqqq rrrr sss ttt uuuu vvvv wwww xxxx yyyy zzzzz !!!!!!!"
KEY=$RANDOM
yad --plug=$KEY --tabnum=1 --text-info  --text  "1 $TEXT $TEXT" --width=300  &
yad --plug=$KEY --tabnum=2 --text-info  --text  "2 $TEXT $TEXT" --width=300  &
yad --paned --key=$KEY --orient=hor  --width=600  --height=600 
```

Another way around this I found, if you wanted to make this Paned specific is to add the YadOptions to the YadNTabs struct and then set the WxH in the panel code.

Not sure if this is related to #87 


