### PR TITLE
include locale.h for musl builds

### DIFF
--- a/src/browser.c
+++ b/src/browser.c
@@ -18,7 +18,7 @@
  */
 
 #include <config.h>
-
+#include <locale.h>
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
 #include <gdk/gdkkeysyms.h>

--- a/src/tools.c
+++ b/src/tools.c
@@ -18,7 +18,7 @@
  */
 
 #include <config.h>
-
+#include <locale.h>
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
 


### PR DESCRIPTION
Building yad on musl fails due to the lack of locale.h in browser.c and tools.c, on Void Linux we're currently having this commit as patches to fix builds, but it'd be great to have it upstream.