### PR TITLE
Add toggle-action for lists

### DIFF
--- a/data/yad.1
+++ b/data/yad.1
@@ -748,6 +748,11 @@ Set the \fICMD\fP as a action when selection is changed. \fICMD\fP will be launc
 \fICMD\fP may contain a special character `%s' for setting a position for arguments. By default arguments will be concatenated to the end of \fICMD\fP.
 This option doesn't work with \fI--multiple\fP.
 .TP
+.B \-\-toggle-action=\fICMD\fP
+Set the \fICMD\fP as a action when either a checkbox or radiobox is toggled. \fICMD\fP will be launched with values of all columns as an arguments.
+\fICMD\fP may contain a special character `%s' for setting a position for arguments. By default arguments will be concatenated to the end of \fICMD\fP.
+This option doesn't work with \fI--multiple\fP.
+.TP
 .B \-\-row-action=\fICMD\fP
 Set the \fICMD\fP as a action when the row is added, modified or removed. First argument for the command is the name of action (\fIadd\fP, \fIedit\fP or \fIdel\fP).
 The rest of command line is data from selected row. Output of this command sets the new row values.

--- a/src/option.c
+++ b/src/option.c
@@ -492,6 +492,8 @@ static GOptionEntry list_options[] = {
     N_("Set double-click action"), N_("CMD") },
   { "select-action", 0, 0, G_OPTION_ARG_STRING, &options.list_data.select_action,
     N_("Set select action"), N_("CMD") },
+  { "toggle-action", 0, 0, G_OPTION_ARG_STRING, &options.list_data.toggle_action,
+    N_("Set toggle action"), N_("CMD") },
   { "row-action", 0, 0, G_OPTION_ARG_STRING, &options.list_data.row_action,
     N_("Set row action"), N_("CMD") },
   { "tree-expanded", 0, 0, G_OPTION_ARG_NONE, &options.list_data.tree_expanded,
@@ -1790,6 +1792,7 @@ yad_options_init (void)
   options.list_data.ellipsize_cols = NULL;
   options.list_data.dclick_action = NULL;
   options.list_data.select_action = NULL;
+  options.list_data.toggle_action = NULL;
   options.list_data.row_action = NULL;
   options.list_data.tree_expanded = FALSE;
   options.list_data.regex_search = FALSE;

--- a/src/yad.h
+++ b/src/yad.h
@@ -393,6 +393,7 @@ typedef struct {
   gchar *ellipsize_cols;
   gchar *dclick_action;
   gchar *select_action;
+  gchar *toggle_action;
   gchar *row_action;
   gboolean tree_expanded;
   gboolean regex_search;


### PR DESCRIPTION
Adds the toggle-action option to allow for a command to run when a checkbox or radio button is toggled in a list. 

Uses the same code to call the command as select-action so I pulled that logic out and refactored it into a method that is called in all 3 spots.