### PR TITLE
Run image changed hook after image load

### DIFF
--- a/src/picture.c
+++ b/src/picture.c
@@ -108,7 +108,9 @@ img_changed_hook ()
 
   if (options.picture_data.change_cmd == NULL)
     return;
-
+  if (!img)
+    return;
+  
   qfn = g_shell_quote (img->filename);
   if (g_strstr_len (options.picture_data.change_cmd, -1, "%s") != NULL)
     cmd = g_strdup_printf (options.picture_data.change_cmd, qfn);

--- a/src/picture.c
+++ b/src/picture.c
@@ -322,6 +322,7 @@ open_file_cb (GtkWidget *w, gpointer d)
       lp = g_list_first (img_list);
       img = (ImageItem *) lp->data;
       load_picture ();
+      img_changed_hook ();
 
       /* recreate menu */
       gtk_widget_destroy (popup_menu);


### PR DESCRIPTION
Runs after image file is selected via gtk_file_chooser_dialog
```yad --picture --file-op --image-changed="echo %s"```