### PR TITLE
fix --form --align-buttons --align=right not working

### DIFF
--- a/src/form.c
+++ b/src/form.c
@@ -1212,7 +1212,7 @@ form_create_widget (GtkWidget * dlg)
               l = get_label (fld->name, 2, e);
               gtk_container_add (GTK_CONTAINER (e), l);
               if (options.form_data.align_buttons)
-                gtk_widget_set_halign (l, options.common_data.align);
+                gtk_button_set_alignment (GTK_BUTTON (e), options.common_data.align, 0.5);
               if (fld->type == YAD_FIELD_BUTTON)
                 gtk_button_set_relief (GTK_BUTTON (e), GTK_RELIEF_NONE);
               gtk_grid_attach (GTK_GRID (tbl), e, col * 2, row, 2, 1);


### PR DESCRIPTION
Given this test command
```sh
yad --form --field=button:FBTN --field=one --field='two and more' --align-buttons --align=right
```
the button label doesn't align right here.
I replaced `gtk_widget_set_halign (l, options.common_data.align);` with `gtk_button_set_alignment (GTK_BUTTON (e), options.common_data.align, 0.5);` and now the button label aligns to the right. Another possible replacement, which also seems to work, is `g_object_set(e, "xalign", options.common_data.align, NULL);`