### PR TITLE
fix UI not updated when sync command runs

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -686,7 +686,10 @@ run_command_sync (gchar *cmd, gchar **out)
   g_thread_new ("run_sync", (GThreadFunc) run_thread, d);
 
   while (run_lock != FALSE)
-    gtk_main_iteration ();
+    {
+      gtk_main_iteration_do (FALSE);
+      usleep (10000);
+    }
 
   g_free (d->cmd);
   g_free (d);


### PR DESCRIPTION
Before this commit, reproduce this issue with the following command:

```sh
yad --form --field=chk:CHK TRUE --changed-action='echo 2:' --field=changes
```

*don't* use your mouse; instead press the Space key *once* to toggle the checkbox. The "changes" field isn't updated but it should be. This is the issue.

Now pressing Space again (or dragging/clicking the mouse) pumps the main loop, which frees the thread to run, which updates the "changes" field. This is a manual work-around for this issue.

To fix this issue I replaced `gtk_main_iteration` with `gtk_main_iteration_do (FALSE)`. This way the main loop doesn't block when no events are pending, and the thread is always free to run.

Then slow down the busy-waiting loop not to hog the CPU. 10000 us keeps yad below 1% CPU on my rig, and the form UI remains very responsive. I'm using this command to test how responsive it is:
```sh
yad --no-buttons --form --changed-action='echo 1:' --field=changes '' --field=2:CHK TRUE --field=3:CHK TRUE --field=4:CHK TRUE --field=5:CHK TRUE --field=6:CHK TRUE --field=7:CHK TRUE &
```
Just keep pressing Tab Space Tab Space ... quickly to update each field. Test with and without `--changed-action`.