### PR TITLE
feature: form symbolic ID

### DIFF
--- a/data/yad.1
+++ b/data/yad.1
@@ -506,7 +506,7 @@ Output data will be in shell-style quotes.
 
 .SS Form options
 .TP
-.B \-\-field=\fILABEL[!TOOLTIP][:TYPE]\fP
+.B \-\-field=\fILABEL[!TOOLTIP][:TYPE[@ID]]\fP
 Add field to form. Type may be \fIH\fP, \fIRO\fP, \fINUM\fP, \fICHK\fP, \fICB\fP, \fICBE\fP, \fICE\fP, \fIFL\fP, \fISFL\fP, \fIDIR\fP, \fICDIR\fP, \fIFN\fP, \fIMFL\fP, \fIMDIR\fP, \fIDT\fP, \fISCL\fP, \fISW\fP, \fIAPP\fP, \fIICON\fP, \fICLR\fP, \fIBTN\fP, \fIFBTN\fP, \fILINK\fP, \fILBL\fP or \fITXT\fP.
 .br
 \fBH\fP - hidden field type. All characters are displayed as the invisible char.
@@ -549,8 +549,9 @@ Add field to form. Type may be \fIH\fP, \fIRO\fP, \fINUM\fP, \fICHK\fP, \fICB\fP
 .br
 \fBCLR\fP - color selection button. Output values for this field generates in the same manner as for color dialog.
 .br
-\fBBTN\fP - button field. Label may be in form text in a form \fILABEL[!ICON[!TOOLTIP]]\fP where `!' is an item separator. \fILABEL\fP is a text of button label or yad stock id. \fIICON\fP is a buttons icon (stock id or file name). \fITOOLTIP\fP is an optional text for popup help string. Initial value is a command which is running when button is clicked. A special sympols \fI%N\fP in command are replaced by value of field \fIN\fP. If command starts with \fI@\fP, the output of command will be parsed and lines started with number and colon will be treats as a new field values.
-A quoting style for value when \fIsh -c\fP is used \- a single quotes around command and double quotes around -c argument
+\fBBTN\fP - button field. Label text may be formatted as \fILABEL[!ICON[!TOOLTIP]]\fP where `!' is an item separator. \fILABEL\fP is the text of a button label or a yad stock id. \fIICON\fP is a button icon (stock id or file name). \fITOOLTIP\fP is the text of an optional help popup tooltip. Initial value is a command which is started when the button is clicked. Special symbols \fI%N\fP (percent followed by a number) in command will be replaced by the value of the \fIN\fPth field. If command starts with \fI@\fP, the output of command will be parsed and lines that start with \fIM:\fP (a number followed by colon) will set the new value of the \fIM\fPth field.
+\fI@ID\fP can be used instead of \fI%N\fP and \fPM:\fP.
+A quoting style for value when \fIsh -c\fP is used \- single quotes around command and double quotes around -c argument.
 .br
 \fBFBTN\fP - same as button field, but with full relief of a button.
 .br
@@ -605,6 +606,9 @@ Output of a command parsing in a same manner as in \fIBTN\fP fields with \fI@\fP
 .TP
 .B \-\-quoted-output
 Output values will be in shell-style quotes.
+.TP
+.B \-\-use-output-prefix[=\fIPREFIX\fP]
+Prefix output field value with PREFIX. Default \fIPREFIX\fP is \fI%@=\fP. If \fI%@\fP is included in PREFIX, it will be replaced by the field's \fI@ID\fP (without the leading "@") if defined, otherwise by fixed string "nul".
 .TP
 .B \-\-output-by-row
 Output field values row by row if several columns is specified.

--- a/src/form.c
+++ b/src/form.c
@@ -29,13 +29,113 @@ static guint n_fields;
 
 static gboolean disable_changed = TRUE;
 
+/* replace single match "@atid" => %N or "@atid:" => N: */
+static gboolean
+preprocess_cb (const GMatchInfo *info, GString *result, gpointer data)
+{
+  gchar *match, *r, *fmt, *atid;
+  gboolean colon_suffix, is_escaped;
+
+  match = g_match_info_fetch (info, 0);
+  is_escaped = *match == '\\';
+  if (is_escaped)
+    {
+      r = match + 1;
+      fmt = "%1$s";
+    }
+  else
+    {
+      atid = g_strdup (match);
+      r = atid + strlen (atid) - 1;
+      colon_suffix = *r == ':';   /* e.g. command "@... echo '@atid: ...'" */
+      if (colon_suffix)
+        *r = '\0';
+
+      r = g_hash_table_lookup ((GHashTable *)data, atid);
+      g_free (atid);
+
+      if (!r)
+        fmt = "%2$s"; /* pop the match back to the matched text */
+      else
+        fmt = colon_suffix ? "%1$s:" : "%%%s"; /* using domain knowledge */
+    }
+  g_string_append_printf (result, fmt, r, match);
+  g_free (match);
+
+  return FALSE;
+}
+
+/* replace each matched "@atid" or "@atid:" in text using preprocess_cb
+ * return TRUE if some replacement made hence result points to newly allocated memory
+ * @param format   regex pattern where '%1$s' is replaced with the current @atid value
+*/
+static gboolean
+preprocess_atid (gchar *text, gchar *format, gchar **result)
+{
+  static gchar *fmt = NULL;
+  static GRegex *regex = NULL;
+  static GHashTable *ht = NULL;
+  static gint n_varnames = -1;
+  gchar *atid, *p, **ap;
+  GSList *f;
+  gint num = 1;
+
+  if (n_varnames && g_strcmp0 (format, fmt))
+    {
+      if (ht)
+        g_hash_table_destroy (ht);
+      ht = g_hash_table_new_full (g_str_hash, g_str_equal, NULL, g_free);
+      ap = g_malloc (sizeof (gchar *) * n_fields + 1);
+      g_free (fmt);
+      fmt = g_strdup (format);
+
+      n_varnames = 0;
+      for (f = options.form_data.fields; f; f = f->next)
+        {
+          atid = ((YadField*)f->data)->atid;
+          if (atid)
+            {
+              p = g_regex_escape_string (atid, strlen (atid));
+              ap[n_varnames] = g_strdup_printf (fmt, p);
+              g_hash_table_insert (ht, atid, g_strdup_printf ("%ld", num));
+
+              g_free (p);
+              ++n_varnames;
+            }
+          ++num;
+        }
+
+      ap[n_varnames] = NULL;
+      if (n_varnames)
+        {
+          p = g_strjoinv ("|", ap);
+          if (regex)
+            g_regex_unref (regex);
+          regex = g_regex_new (p, G_REGEX_MULTILINE|G_REGEX_OPTIMIZE, 0, NULL);
+
+          g_free (p);
+        }
+      g_strfreev (ap);
+    }
+
+  if (n_varnames > 0 && regex)
+    *result = g_regex_replace_eval (regex, text, -1, 0, 0, preprocess_cb, ht, NULL);
+  else
+    *result = text;
+
+  return *result != text;
+}
+
 /* expand %N in command to fields values */
 static GString *
-expand_action (gchar * cmd)
+expand_action (gchar *command)
 {
   GString *xcmd;
   guint i = 0;
+  gchar *cmd;
+  gboolean needs_free;
 
+  needs_free = preprocess_atid (command, "\\\\%1$s|%1$s\\b(?!:)", &cmd);
   xcmd = g_string_new ("");
   while (cmd[i])
     {
@@ -170,6 +270,8 @@ expand_action (gchar * cmd)
         }
     }
   g_string_append_c (xcmd, '\0');
+  if (needs_free)
+    g_free (cmd);
 
   return xcmd;
 }
@@ -387,10 +489,14 @@ set_field_value (guint num, gchar *value)
 }
 
 static void
-parse_cmd_output (gchar *data)
+parse_cmd_output (gchar *text)
 {
   guint i = 0;
-  gchar **lines = g_strsplit (data, "\n", 0);
+  gchar **lines, *data;
+  gboolean needs_free;
+
+  needs_free = preprocess_atid (text, "\\\\%1$s|^%1$s:", &data);
+  lines = g_strsplit (data, "\n", 0);
 
   disable_changed = TRUE;
   while (lines[i] && lines[i][0])
@@ -410,6 +516,8 @@ parse_cmd_output (gchar *data)
         }
       i++;
     }
+  if (needs_free)
+    g_free (data);
   disable_changed = FALSE;
 }
 
@@ -1378,8 +1486,19 @@ form_create_widget (GtkWidget * dlg)
 static void
 form_print_field (guint fn)
 {
-  gchar *buf;
+  gchar *buf, *lhs;
+  static GRegex *regex;
   YadField *fld = g_slist_nth_data (options.form_data.fields, fn);
+
+  if (options.form_data.use_output_prefix)
+    {
+      if (!regex)
+        regex = g_regex_new ("\%@", G_REGEX_OPTIMIZE, 0, NULL);
+      lhs = g_regex_replace_literal (regex, options.form_data.output_prefix, -1, 0,
+                                     fld->atid ? fld->atid + 1 : "nul", 0, NULL);
+    }
+  else
+    lhs = g_strdup("");
 
   switch (fld->type)
     {
@@ -1396,53 +1515,53 @@ form_print_field (guint fn)
       if (options.common_data.quoted_output)
         {
           buf = g_shell_quote (gtk_entry_get_text (GTK_ENTRY (g_slist_nth_data (fields, fn))));
-          g_printf ("%s%s", buf, options.common_data.separator);
+          g_printf ("%s%s%s", lhs, buf, options.common_data.separator);
           g_free (buf);
         }
       else
-        g_printf ("%s%s", gtk_entry_get_text (GTK_ENTRY (g_slist_nth_data (fields, fn))),
+        g_printf ("%s%s%s", lhs, gtk_entry_get_text (GTK_ENTRY (g_slist_nth_data (fields, fn))),
                   options.common_data.separator);
       break;
     case YAD_FIELD_NUM:
       {
         guint prec = gtk_spin_button_get_digits (GTK_SPIN_BUTTON (g_slist_nth_data (fields, fn)));
         if (options.common_data.quoted_output)
-          g_printf ("'%.*f'%s", prec, gtk_spin_button_get_value (GTK_SPIN_BUTTON (g_slist_nth_data (fields, fn))),
+          g_printf ("%s'%.*f'%s", lhs, prec, gtk_spin_button_get_value (GTK_SPIN_BUTTON (g_slist_nth_data (fields, fn))),
                     options.common_data.separator);
         else
-          g_printf ("%.*f%s", prec, gtk_spin_button_get_value (GTK_SPIN_BUTTON (g_slist_nth_data (fields, fn))),
+          g_printf ("%s%.*f%s", lhs, prec, gtk_spin_button_get_value (GTK_SPIN_BUTTON (g_slist_nth_data (fields, fn))),
                     options.common_data.separator);
         break;
       }
     case YAD_FIELD_CHECK:
       if (options.common_data.quoted_output)
-        g_printf ("'%s'%s", print_bool_val (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (g_slist_nth_data (fields, fn)))),
+        g_printf ("%s'%s'%s", lhs, print_bool_val (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (g_slist_nth_data (fields, fn)))),
                   options.common_data.separator);
       else
-        g_printf ("%s%s", print_bool_val (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (g_slist_nth_data (fields, fn)))),
+        g_printf ("%s%s%s", lhs, print_bool_val (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (g_slist_nth_data (fields, fn)))),
                   options.common_data.separator);
       break;
     case YAD_FIELD_SWITCH:
       if (options.common_data.quoted_output)
-        g_printf ("'%s'%s", print_bool_val (gtk_switch_get_state (GTK_SWITCH (g_slist_nth_data (fields, fn)))),
+        g_printf ("%s'%s'%s", lhs, print_bool_val (gtk_switch_get_state (GTK_SWITCH (g_slist_nth_data (fields, fn)))),
                   options.common_data.separator);
       else
-        g_printf ("%s%s", print_bool_val (gtk_switch_get_state (GTK_SWITCH (g_slist_nth_data (fields, fn)))),
+        g_printf ("%s%s%s", lhs, print_bool_val (gtk_switch_get_state (GTK_SWITCH (g_slist_nth_data (fields, fn)))),
                   options.common_data.separator);
       break;
     case YAD_FIELD_COMBO:
     case YAD_FIELD_COMBO_ENTRY:
       if (options.common_data.num_output && fld->type == YAD_FIELD_COMBO)
-        g_printf ("%d%s", gtk_combo_box_get_active (GTK_COMBO_BOX (g_slist_nth_data (fields, fn))) + 1,
+        g_printf ("%s%d%s", lhs, gtk_combo_box_get_active (GTK_COMBO_BOX (g_slist_nth_data (fields, fn))) + 1,
                   options.common_data.separator);
       else if (options.common_data.quoted_output)
         {
           buf = g_shell_quote (gtk_combo_box_text_get_active_text (GTK_COMBO_BOX_TEXT (g_slist_nth_data (fields, fn))));
-          g_printf ("%s%s", buf, options.common_data.separator);
+          g_printf ("%s%s%s", lhs, buf, options.common_data.separator);
           g_free (buf);
         }
       else
-        g_printf ("%s%s", gtk_combo_box_text_get_active_text (GTK_COMBO_BOX_TEXT (g_slist_nth_data (fields, fn))),
+        g_printf ("%s%s%s", lhs, gtk_combo_box_text_get_active_text (GTK_COMBO_BOX_TEXT (g_slist_nth_data (fields, fn))),
                   options.common_data.separator);
       break;
     case YAD_FIELD_FILE:
@@ -1452,13 +1571,13 @@ form_print_field (guint fn)
           gchar *fname = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (g_slist_nth_data (fields, fn)));
           buf = g_shell_quote (fname ? fname : "");
           g_free (fname);
-          g_printf ("%s%s", buf ? buf : "", options.common_data.separator);
+          g_printf ("%s%s%s", lhs, buf ? buf : "", options.common_data.separator);
           g_free (buf);
         }
       else
         {
           buf = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (g_slist_nth_data (fields, fn)));
-          g_printf ("%s%s", buf ? buf : "", options.common_data.separator);
+          g_printf ("%s%s%s", lhs, buf ? buf : "", options.common_data.separator);
           g_free (buf);
         }
       break;
@@ -1466,9 +1585,9 @@ form_print_field (guint fn)
       {
         gchar *fname = gtk_font_chooser_get_font (GTK_FONT_CHOOSER (g_slist_nth_data (fields, fn)));
         if (options.common_data.quoted_output)
-          g_printf ("'%s'%s", fname ? fname : "", options.common_data.separator);
+          g_printf ("%s'%s'%s", lhs, fname ? fname : "", options.common_data.separator);
         else
-          g_printf ("%s%s", fname ? fname : "", options.common_data.separator);
+          g_printf ("%s%s%s", lhs, fname ? fname : "", options.common_data.separator);
         g_free (fname);
         break;
       }
@@ -1492,11 +1611,11 @@ form_print_field (guint fn)
         if (options.common_data.quoted_output)
           {
             buf = g_shell_quote (exec);
-            g_printf ("%s%s", buf, options.common_data.separator);
+            g_printf ("%s%s%s", lhs, buf, options.common_data.separator);
             g_free (buf);
           }
         else
-          g_printf ("%s%s", exec, options.common_data.separator);
+          g_printf ("%s%s%s", lhs, exec, options.common_data.separator);
         if (info)
           g_object_unref (info);
         break;
@@ -1512,40 +1631,40 @@ form_print_field (guint fn)
         if (options.common_data.quoted_output)
           {
             buf = g_shell_quote (cs ? cs : "");
-            g_printf ("%s%s", buf, options.common_data.separator);
+            g_printf ("%s%s%s", lhs, buf, options.common_data.separator);
             g_free (buf);
           }
         else
-          g_printf ("%s%s", cs, options.common_data.separator);
+          g_printf ("%s%s%s", lhs, cs, options.common_data.separator);
         g_free (cs);
         break;
       }
     case YAD_FIELD_SCALE:
       if (options.common_data.quoted_output)
-        g_printf ("'%d'%s", (gint) gtk_range_get_value (GTK_RANGE (g_slist_nth_data (fields, fn))),
+        g_printf ("%s'%d'%s", lhs, (gint) gtk_range_get_value (GTK_RANGE (g_slist_nth_data (fields, fn))),
                   options.common_data.separator);
       else
-        g_printf ("%d%s", (gint) gtk_range_get_value (GTK_RANGE (g_slist_nth_data (fields, fn))),
+        g_printf ("%s%d%s", lhs, (gint) gtk_range_get_value (GTK_RANGE (g_slist_nth_data (fields, fn))),
                   options.common_data.separator);
       break;
     case YAD_FIELD_LINK:
       if (options.common_data.quoted_output)
         {
           buf = g_shell_quote (gtk_link_button_get_uri (GTK_LINK_BUTTON (g_slist_nth_data (fields, fn))));
-          g_printf ("%s%s", buf, options.common_data.separator);
+          g_printf ("%s%s%s", lhs, buf, options.common_data.separator);
           g_free (buf);
         }
       else
-        g_printf ("%s%s", gtk_link_button_get_uri (GTK_LINK_BUTTON (g_slist_nth_data (fields, fn))),
+        g_printf ("%s%s%s", lhs, gtk_link_button_get_uri (GTK_LINK_BUTTON (g_slist_nth_data (fields, fn))),
                   options.common_data.separator);
       break;
     case YAD_FIELD_BUTTON:
     case YAD_FIELD_FULL_BUTTON:
     case YAD_FIELD_LABEL:
       if (options.common_data.quoted_output)
-        g_printf ("''%s", options.common_data.separator);
+        g_printf ("%s''%s", lhs, options.common_data.separator);
       else
-        g_printf ("%s", options.common_data.separator);
+        g_printf ("%s%s", lhs, options.common_data.separator);
       break;
     case YAD_FIELD_TEXT:
       {
@@ -1559,14 +1678,15 @@ form_print_field (guint fn)
         if (options.common_data.quoted_output)
           {
             buf = g_shell_quote (txt);
-            g_printf ("%s%s", buf, options.common_data.separator);
+            g_printf ("%s%s%s", lhs, buf, options.common_data.separator);
             g_free (buf);
           }
         else
-          g_printf ("%s%s", txt, options.common_data.separator);
+          g_printf ("%s%s%s", lhs, txt, options.common_data.separator);
         g_free (txt);
       }
     }
+  g_free (lhs);
 }
 
 void

--- a/src/form.c
+++ b/src/form.c
@@ -495,6 +495,9 @@ parse_cmd_output (gchar *text)
   gchar **lines, *data;
   gboolean needs_free;
 
+  if (!text)
+    return;
+
   needs_free = preprocess_atid (text, "\\\\%1$s|^%1$s:", &data);
   lines = g_strsplit (data, "\n", 0);
 

--- a/src/option.c
+++ b/src/option.c
@@ -57,6 +57,7 @@ static gboolean set_scroll_policy (const gchar *, const gchar *, gpointer, GErro
 static gboolean set_size_format (const gchar *, const gchar *, gpointer, GError **);
 #endif
 static gboolean set_interp (const gchar *, const gchar *, gpointer, GError **);
+static gboolean set_form_output_prefix (const gchar *, const gchar *, gpointer, GError **);
 #ifdef HAVE_SOURCEVIEW
 static gboolean set_right_margin (const gchar *, const gchar *, gpointer, GError **);
 static gboolean set_smart_homend (const gchar *, const gchar *, gpointer, GError **);
@@ -380,7 +381,7 @@ static GOptionEntry form_options[] = {
   { "form", 0, G_OPTION_FLAG_IN_MAIN, G_OPTION_ARG_NONE, &form_mode,
     N_("Display form dialog"), NULL },
   { "field", 0, 0, G_OPTION_ARG_CALLBACK, add_field,
-    N_ ("Add field to form (see man page for list of possible types)"), N_("LABEL[:TYPE]") },
+    N_ ("Add field to form (see man page for list of possible types)"), N_("LABEL[:TYPE[@ID]]") },
   { "align", 0, G_OPTION_FLAG_NOALIAS, G_OPTION_ARG_CALLBACK, set_align,
     N_("Set alignment of filed labels (left, center or right)"), N_("TYPE") },
   { "columns", 0, 0, G_OPTION_ARG_INT, &options.form_data.columns,
@@ -397,6 +398,8 @@ static GOptionEntry form_options[] = {
     N_("Align labels on button fields"), NULL },
   { "changed-action", 0, 0, G_OPTION_ARG_STRING, &options.form_data.changed_action,
     N_("Set changed action"), N_("CMD") },
+  { "use-output-prefix", 0, G_OPTION_FLAG_OPTIONAL_ARG, G_OPTION_ARG_CALLBACK, set_form_output_prefix,
+    N_("Prefix form output values (default: %@=)"), N_("[PREFIX]") },
   { NULL }
 };
 
@@ -850,6 +853,19 @@ add_field (const gchar * option_name, const gchar * value, gpointer data, GError
 
   if (fstr[1])
     {
+      gchar *atid;
+
+      /* on return fld->atid starts with '@' otherwise is NULL */
+      fld->atid = NULL;
+
+      atid = strchr(fstr[1], '@');
+      if (atid)
+        {
+          if (atid[1])
+            fld->atid = g_strdup(atid);
+          *atid = '\0';
+        }
+
       if (strcasecmp (fstr[1], "H") == 0)
         fld->type = YAD_FIELD_HIDDEN;
       else if (strcasecmp (fstr[1], "RO") == 0)
@@ -1395,6 +1411,17 @@ set_smart_homend (const gchar * option_name, const gchar * value, gpointer data,
 }
 #endif
 
+static gboolean
+set_form_output_prefix (const gchar * option_name, const gchar * value, gpointer data, GError ** err)
+{
+  options.form_data.use_output_prefix = TRUE;
+
+  if (value)
+    options.form_data.output_prefix = g_strdup (value);
+
+  return TRUE;
+}
+
 #ifndef G_OS_WIN32
 static gboolean
 set_xid_file (const gchar * option_name, const gchar * value, gpointer data, GError ** err)
@@ -1756,6 +1783,8 @@ yad_options_init (void)
   options.form_data.align_buttons = FALSE;
   options.form_data.changed_action = NULL;
   options.form_data.homogeneous = FALSE;
+  options.form_data.use_output_prefix = FALSE;
+  options.form_data.output_prefix = "%@=";
 
 #ifdef HAVE_HTML
   /* Initialize html data */

--- a/src/yad.h
+++ b/src/yad.h
@@ -198,6 +198,7 @@ typedef struct {
   gchar *name;
   gchar *tip;
   YadFieldType type;
+  gchar *atid;
 } YadField;
 
 typedef struct {
@@ -347,6 +348,8 @@ typedef struct {
   gboolean align_buttons;
   gchar *changed_action;
   gboolean homogeneous;
+  gboolean use_output_prefix;
+  gchar *output_prefix;
 } YadFormData;
 
 #ifdef HAVE_HTML


### PR DESCRIPTION
FORM SYMBOLIC ID
================

The main idea is to add support for symbolic IDs, such as `@name`, where one can already use ordinal IDs, such as `%N`, in a form. Similarly for command output redirection: add support for `@name:` where `%N:` can be used.

This commit adds two new features to forms:

        --form --use-output-prefix[=PREFIX] --field=label!tooltip:type@ID

Example:

	--form --use-output-prefix --field=Number:num@NUMBER 10
Output:

	NUMBER=10|

Can be combined with --quoted-output

	--form --quoted-output --separator="; " --use-output-prefix="%@ <- " \
		--field="R string:@r_string" "hello" --field= ""

Output:

	r_string <- 'hello'; nul=''

Fixed string "nul" is used automatically for any undeclared @ID.

```sh
yad --form --use-output-prefix --separator=" " --field=:@name test > /tmp/data.sh &&
        . /tmp/data.sh && echo "name=$name"

yad --form --use-output-prefix --separator=$'\n' \
        --field='code:ro' 'declare -A a' \
        --field=':@a[ka]' A --field=':@a[kb]' B \
        --field='code:ro' 'printf %s\\n "${a[@]}"' |
        bash -x
```

	--form --field=label!tooltip:type[@ID]

Example:

	--form --field='+1:fbtn@B' '@echo @N:$((@N+1))' --field=':num@N' 1 --use-interp

Can be escaped with \@ID to avoid expansion
Can be mixed with %N and ^N: but not recommended; better use one or the other

Wherever the use of symbolic references (@ID) vs ordinal references (%N) simplifies coding or maintaining the code.

```
Form options
    --field=LABEL[!TOOLTIP][:TYPE[@ID]]
...
    --use-output-prefix[=PREFIX]
           Prefix output field value with PREFIX. Default PREFIX is %@=. If %@ is included
           in PREFIX, it will be replaced by the field's @ID (without the leading "@") if
           defined, otherwise by fixed string "nul".
...
           BTN - button field. Label text may be formatted as LABEL[!ICON[!TOOLTIP]]
           where `!' is an item separator. LABEL is the text of button label or yad stock
           id. ICON is a button icon (stock id or file name). TOOLTIP is the text of an
           optional help popup tooltip. Initial value is a command which is started when
           the button is clicked. Special symbols %N (percent followed by a number) in
           command will be replaced by the value of the Nth field. If command starts with
           @, the output of com‐ mand will be parsed and lines that start with M: (a
           number followed by colon) will set the new value of the Mth field.  @ID can
           be used instead of %N and M:.  A quoting style for value when sh -c is used -
           single quotes around command and double quotes around -c argument.
```

In option.c, setting the default output prefix was similar to setting the default interpreter, so I followed that example. The setter function and the new options are:

```c
static gboolean set_form_output_prefix (const gchar *, const gchar *, gpointer, GError **);

options.form_data.use_output_prefix = FALSE;
options.form_data.output_prefix = "%@=";
```

Modifications of existing functions:
* IDs are parsed and stored in function `add_field()` as usual.
* PREFIX is inserted in function `form_print_field()`.  The code is straightforward, although it affects each `case` of the main `switch`.

Field ID is stored in struct `YadFields` as member `atid`. Mind that `atid` stores "@ID" not "ID".

```c
typedef struct {
  gchar *name;
  gchar *tip;
  YadFieldType type;
  gchar *atid;
} YadField;
```

IDs, if any, are expanded into their corresponding `%N` and ^`N:` forms, which are then processed as usual with the existing code. Two new functions in form.c perform ID expansion: `preprocess_atid()` and `preprocess_cb()` (callback). Expansion is based on regular expressions.

Function `preprocess_atid()` is called twice.
First in `expand_action()` before the latter expands `%N` into field value:

```c
  gboolean needs_free = preprocess_atid (command, "\\\\%1$s|%1$s\\b:?", &cmd);
```

* `needs_free` indicates the need to call `g_free()` on `*cmd`
* `command` (input) is the field value as specified by the user
* `cmd` (output) is the same value with `%N` standing for `@ID`
* `%1$s` in the regular expression stands for `%N` Of course N={1,...M}.

Second in `parse_cmd_output()` before the latter expands ^`N:` into output redirection:

```c
  gboolean needs_free = preprocess_atid (text, "\\\\%1$s|^%1$s:", &data);
```

* `text` (input) is the raw command output
* `data` (output) is the same text with `N:` standing for ^`@ID:`

This trace shows it all, @ID => %N value expansion, @ID: => N: redirection expansion, \@ID escaping.

**INCREMENT BY 1 AND REPROGRAM BUTTON ACTION**

```sh
export YAD_OPTIONS="--use-interp='dash -xc \"%s\"'"
yad=src/yad

$yad --form --field='+1:fbtn@B' '@echo @N:$((@N+1)); '"echo '@B:@echo @N:\$((\@N+1))'" --field=res:num@N 1

$yad --form --field='+1:fbtn@B' '@echo @N:$((@N+1)); '"printf '@'; printf 'B:@echo '; printf @; printf 'N:\$((\@N+1))'; echo" --field=res:num@N 1
```

`command` and `cmd` refer to before/after the call to `preprocess_atid()` in `expand_action()`. `text` and `data` refer to before/after the call to `preprocess_atid()` in `parse_cmd_output()`.

```
┌─────────────────────────────────────────────────────────┐  ·  ┌─────────────────────────────────────────────────────────┐
│  FIRST MOUSE CLICK 1+1                                  │  ·  │  FIRST MOUSE CLICK 1+1                                  │
└─────────────────────────────────────────────────────────┘  ·  └─────────────────────────────────────────────────────────┘
command( echo @N:$((@N+1)); echo '@B:@echo @N:$((\@N+1))' )  !  command( echo @N:$((@N+1)); printf '@'; printf 'B:@echo '; printf @; printf 'N:$((\@N+1))'; echo )
cmd    ( echo @N:$((%2+1)); echo '@B:@echo @N:$((@N+1))' )   !  cmd    ( echo @N:$((%2+1)); printf '@'; printf 'B:@echo '; printf @; printf 'N:$((@N+1))'; echo )
+ echo @N:2                                                  ·  + echo @N:2
+ echo @B:@echo @N:$((@N+1))                                 !  + printf @
                                                             >  + printf 'B:@echo '
                                                             >  + printf @
                                                             >  + printf N:$((@N+1))
                                                             >  + echo
text   ( @N:2                                                ·  text   ( @N:2
@B:@echo @N:$((@N+1))                                        ·  @B:@echo @N:$((@N+1))
 )                                                           ·   )
data   ( 2:2                                                 ·  data   ( 2:2
1:@echo @N:$((@N+1))                                         ·  1:@echo @N:$((@N+1))
 )                                                           ·   )
┌─────────────────────────────────────────────────────────┐  ·  ┌─────────────────────────────────────────────────────────┐
│  SECOND MOUSE CLICK 2+1                                 │  ·  │  SECOND MOUSE CLICK 2+1                                 │
└─────────────────────────────────────────────────────────┘  ·  └─────────────────────────────────────────────────────────┘
command( echo @N:$((@N+1)) )                                 ·  command( echo @N:$((@N+1)) )
cmd    ( echo @N:$((%2+1)) )                                 ·  cmd    ( echo @N:$((%2+1)) )
+ echo @N:3                                                  ·  + echo @N:3
text   ( @N:3                                                ·  text   ( @N:3
 )                                                           ·   )
data   ( 2:3                                                 ·  data   ( 2:3
 )                                                           ·   )
```