### PR TITLE
fix returning 0 when an error occurred

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -659,6 +659,8 @@ run_thread (RunData *d)
       if (options.debug)
         g_printerr (_("WARNING: Run command failed: %s\n"), err->message);
       g_error_free (err);
+      if (!ret)
+        ret = 255; /* when cmd couldn't be executed */
     }
   run_lock = FALSE;
 }


### PR DESCRIPTION
Issue: `run_command_sync` can return 0 when `g_spawn_command_line_sync` didn't set its return value argument because it couldn't run the command.
Fix: return 255 in `run_thread` in such a case.