### PR TITLE
fix segmentation fault in icon-browser

### DIFF
--- a/src/browser.c
+++ b/src/browser.c
@@ -215,7 +215,7 @@ main (gint argc, gchar * argv[])
     { "symbolic", 's', 0, G_OPTION_ARG_NONE, &symbolic, _("Show only symbolic icons"), NULL },
     { "interactive", 'i', 0, G_OPTION_ARG_NONE, &interactive, _("Select and print icon on double-click"), NULL },
     { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_STRING_ARRAY, &themes, NULL, N_("THEME") },
-    { NULL }
+    NULL
   };
 
   setlocale (LC_ALL, "");


### PR DESCRIPTION
fix segmentation fault when passing unknown option, like `--blablah` to icon-browser