### PR TITLE
Set _NET_WM_WINDOW_TYPE to _NET_WM_WINDOW_TYPE_DIALOG.

### DIFF
--- a/data/yad.1
+++ b/data/yad.1
@@ -213,9 +213,18 @@ Run dialog window maximized.
 .B \-\-fullscreen
 Run dialog in fullscreen mode. This option may not work on all window managers.
 .TP
-.B \-\-splash
+.B \-\-splash (DEPRECATED)
 Open window with "splashscreen" window hints. For details see description of \fI_NET_WM_WINDOW_TYPE_SPLASH\fP
 in EWMH specification. The behavior of dialog with this option is HIGHLY DEPENDS on settings of your window manager.
+
+This option is deprecated. Use \fB--window-type=splash\fP instead.
+.TP
+.B \-\-window-type=\fITYPE\fP
+Create a window with the specified window type. Can be one of "normal", "dialog" or "splash".
+The behavior of each window type depends on your window manager.
+
+Tiling window managers will often float a "dialog" window but tile a "normal" window.
+The behavior of splash windows HIGHLY DEPENDS on settings of your window manager.
 .TP
 .B \-\-no-focus
 Dialog window never take focus.
@@ -239,7 +248,7 @@ Set default exit code to \fINUMBER\fP instead of \fI0\fP.
 .B \-\-css=\fISTRING\fP
 Read and parse additional GTK+ CSS styles from given data. If \fISTRING\fP is filename, the content of file is loaded. If not \fISTRING\fP treats like CSS data.
 .TP
-.B \-\-gtkrc=\fIFILENAME\fP
+.B \-\-gtkrc=\fIFILENAME\fP (DEPRECATED)
 Read and parse additional GTK+ CSS styles from given file. This option is deprecated. Use \fB--css\fP instead.
 .TP
 .B \-\-hscroll-policy=\fITYPE\fP

--- a/src/main.c
+++ b/src/main.c
@@ -405,6 +405,8 @@ create_dialog (void)
   dlg = gtk_window_new (GTK_WINDOW_TOPLEVEL);
   if (options.data.splash)
     gtk_window_set_type_hint (GTK_WINDOW (dlg), GDK_WINDOW_TYPE_HINT_SPLASHSCREEN);
+  else
+    gtk_window_set_type_hint (GTK_WINDOW (dlg), GDK_WINDOW_TYPE_HINT_DIALOG);
   gtk_window_set_title (GTK_WINDOW (dlg), options.data.dialog_title);
   gtk_widget_set_name (dlg, "yad-dialog-window");
 

--- a/src/main.c
+++ b/src/main.c
@@ -403,10 +403,19 @@ create_dialog (void)
 
   /* create dialog window */
   dlg = gtk_window_new (GTK_WINDOW_TOPLEVEL);
-  if (options.data.splash)
-    gtk_window_set_type_hint (GTK_WINDOW (dlg), GDK_WINDOW_TYPE_HINT_SPLASHSCREEN);
-  else
-    gtk_window_set_type_hint (GTK_WINDOW (dlg), GDK_WINDOW_TYPE_HINT_DIALOG);
+  switch (options.data.window_type)
+    {
+      case YAD_WINDOW_UNSET:
+      case YAD_WINDOW_NORMAL:
+        gtk_window_set_type_hint (GTK_WINDOW (dlg), GDK_WINDOW_TYPE_HINT_NORMAL);
+        break;
+      case YAD_WINDOW_DIALOG:
+        gtk_window_set_type_hint (GTK_WINDOW (dlg), GDK_WINDOW_TYPE_HINT_DIALOG);
+        break;
+      case YAD_WINDOW_SPLASH:
+        gtk_window_set_type_hint (GTK_WINDOW (dlg), GDK_WINDOW_TYPE_HINT_SPLASHSCREEN);
+        break;
+    }
   gtk_window_set_title (GTK_WINDOW (dlg), options.data.dialog_title);
   gtk_widget_set_name (dlg, "yad-dialog-window");
 
@@ -780,6 +789,16 @@ main (gint argc, gchar ** argv)
       g_printerr (_("Unable to parse command line: %s\n"), err->message);
       return -1;
     }
+
+  if (options.data.splash)
+    {
+      g_warning(_("Use of deprecated option --splash, use --window-type=splash instead"));
+      if (options.data.window_type == YAD_WINDOW_UNSET)
+        options.data.window_type = YAD_WINDOW_SPLASH;
+      else
+       g_warning(_("Both --splash and --window-type are specified, ignoring --splash"));
+    }
+
   yad_set_mode ();
 
   /* check for current GDK backend */

--- a/src/option.c
+++ b/src/option.c
@@ -57,6 +57,7 @@ static gboolean set_scroll_policy (const gchar *, const gchar *, gpointer, GErro
 static gboolean set_size_format (const gchar *, const gchar *, gpointer, GError **);
 #endif
 static gboolean set_interp (const gchar *, const gchar *, gpointer, GError **);
+static gboolean set_window_type (const gchar * option_name, const gchar * value, gpointer data, GError ** err);
 #ifdef HAVE_SOURCEVIEW
 static gboolean set_right_margin (const gchar *, const gchar *, gpointer, GError **);
 static gboolean set_smart_homend (const gchar *, const gchar *, gpointer, GError **);
@@ -171,7 +172,9 @@ static GOptionEntry general_options[] = {
   { "close-on-unfocus", 0, 0, G_OPTION_ARG_NONE, &options.data.close_on_unfocus,
     N_("Close window when it sets unfocused"), NULL },
   { "splash", 0, 0, G_OPTION_ARG_NONE, &options.data.splash,
-    N_("Open window as a splashscreen"), NULL },
+    N_("Open window as a splashscreen (DEPRECATED: use --window-type=splash instead)"), NULL },
+  { "window-type", 0, 0, G_OPTION_ARG_CALLBACK, set_window_type,
+    N_("Specify the window type for the dialog"), N_("normal|dialog|splash") },
   { "plug", 0, 0, G_OPTION_ARG_INT, &options.plug,
     N_("Special type of dialog for XEMBED"), N_("KEY") },
   { "tabnum", 0, 0, G_OPTION_ARG_INT, &options.tabnum,
@@ -1369,6 +1372,21 @@ set_interp (const gchar * option_name, const gchar * value, gpointer data, GErro
   return TRUE;
 }
 
+static gboolean
+set_window_type (const gchar * option_name, const gchar * value, gpointer data, GError ** err)
+{
+  if (strcasecmp (value, "normal") == 0)
+    options.data.window_type = YAD_WINDOW_NORMAL;
+  else if (strcasecmp (value, "dialog") == 0)
+    options.data.window_type = YAD_WINDOW_DIALOG;
+  else if (strcasecmp (value, "splash") == 0)
+    options.data.window_type = YAD_WINDOW_SPLASH;
+  else
+    g_printerr (_("Unknown window type: %s\n"), value);
+
+  return TRUE;
+}
+
 #if HAVE_SOURCEVIEW
 static gboolean
 set_right_margin (const gchar * option_name, const gchar * value, gpointer data, GError ** err)
@@ -1644,6 +1662,7 @@ yad_options_init (void)
   options.data.maximized = FALSE;
   options.data.fullscreen = FALSE;
   options.data.splash = FALSE;
+  options.data.window_type = YAD_WINDOW_UNSET;
   options.data.focus = TRUE;
   options.data.close_on_unfocus = FALSE;
 

--- a/src/yad.h
+++ b/src/yad.h
@@ -188,6 +188,13 @@ typedef enum {
   YAD_BOOL_FMT_1
 } YadBoolFormat;
 
+typedef enum {
+  YAD_WINDOW_UNSET = 0,
+  YAD_WINDOW_NORMAL,
+  YAD_WINDOW_DIALOG,
+  YAD_WINDOW_SPLASH,
+} YadWindowType;
+
 typedef struct {
   gchar *name;
   gchar *cmd;
@@ -268,6 +275,7 @@ typedef struct {
   gboolean maximized;
   gboolean fullscreen;
   gboolean splash;
+  YadWindowType window_type;
   gboolean focus;
   gboolean close_on_unfocus;
 } YadData;


### PR DESCRIPTION
This PR ensures that `_NET_WM_WINDOW_TYPE` is set to `_NET_WM_WINDOW_TYPE_DIALOG` so that window managers can act accordingly.

Most tiling window managers will tile windows without this hint, which is not really desirable. Fixes #247.