### PR TITLE
allow building with webkit2gtk-4.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ AC_ARG_ENABLE([html],
 			[Build YAD with HTML widget])],
 	[build_html=$enableval], [build_html=yes])
 if test x$build_html = xyes; then
-    PKG_CHECK_MODULES([HTML], [webkit2gtk-4.0], [have_html=yes], [have_html=no])
+    PKG_CHECK_MODULES([HTML], [webkit2gtk-4.1], [have_html=yes], [PKG_CHECK_MODULES([HTML], [webkit2gtk-4.0], [have_html=yes], [have_html=no])])
 else
     have_html=no
 fi


### PR DESCRIPTION
libwebkit2gtk-4.0 and libwebkit2gtk-4.1 are identical except for the fact that 4.1 uses libsoup3 instead of libsoup2. (the version change is needed since libsoup2 and libsoup3 cannot be loaded in to the same process at the same time)

Many distros including Debian and Fedora are dropping libwebkit2gtk-4.0, since it needs to be compiled separately (and takes a long time to compile) so this allows building with libwebkit2gtk-4.1.