### PR TITLE
feat(form): Add footer placement and dynamic styling

### DIFF
--- a/src/form.c
+++ b/src/form.c
@@ -1087,12 +1087,12 @@ form_create_widget (GtkWidget * dlg)
                 }
               g_signal_connect (G_OBJECT (e), "toggled", G_CALLBACK (switch_changed_cb), GINT_TO_POINTER (i));
               
-              if (is_footer)
-                gtk_box_pack_start (GTK_BOX (main_box), e, FALSE, FALSE, 0);
-              else
-                gtk_grid_attach (GTK_GRID (tbl), e, col * 2, row, 2, 1);
-                
-              gtk_widget_set_hexpand (e, TRUE);
+              // Only add to grid if NOT a footer widget (footer widgets are packed later into button box)
+              if (!is_footer)
+                {
+                  gtk_grid_attach (GTK_GRID (tbl), e, col * 2, row, 2, 1);
+                  gtk_widget_set_hexpand (e, TRUE);
+                }
               fields = g_slist_append (fields, e);
               break;
 
@@ -1340,12 +1340,12 @@ form_create_widget (GtkWidget * dlg)
               if (fld->type == YAD_FIELD_BUTTON)
                 gtk_button_set_relief (GTK_BUTTON (e), GTK_RELIEF_NONE);
               
-              if (is_footer)
-                gtk_box_pack_start (GTK_BOX (main_box), e, FALSE, FALSE, 0);
-              else
-                gtk_grid_attach (GTK_GRID (tbl), e, col * 2, row, 2, 1);
-
-              gtk_widget_set_hexpand (e, TRUE);
+              // Only add to grid if NOT a footer widget (footer widgets are packed later into button box)
+              if (!is_footer)
+                {
+                  gtk_grid_attach (GTK_GRID (tbl), e, col * 2, row, 2, 1);
+                  gtk_widget_set_hexpand (e, TRUE);
+                }
               fields = g_slist_append (fields, e);
               break;
 


### PR DESCRIPTION
Addresses #219, #69, #188, #220

## New features

### 1. @footer@ tag
Place fields in the dialog button bar instead of the form grid:
```bash
yad --form --field="Name" "" --field="@footer@I agree:CHK" FALSE --button="OK:0"
```

### 2. @vexpand@ label
Create vertical spacing that expands.

### 3. Dynamic CHK background colors
Set checkbox background via CSS using value!color format:
```bash
echo "1:TRUE!red" | yad --form --field="Accept:CHK" --listen
```

### 4. Button field colors
Fourth parameter sets background color:
```bash
yad --form --field=":FBTN" "gtk-ok!Click!echo ok!#4CAF50"
```

## Changes

- src/form.c: Parse @footer@ tag, CSS styling for CHK and FBTN fields
- src/main.c: Footer widget integration

Existing scripts work unchanged. New features are opt-in via special syntax.