### PR TITLE
feat: Wayland detection, text sizing fix, signal handling

### DIFF
--- a/src/cpicker.c
+++ b/src/cpicker.c
@@ -23,6 +23,16 @@
 
 #include "cpicker.h"
 
+#include <glib/gi18n.h>  /* For _() macro */
+
+/* Forward declaration - defined in main.c when building yad */
+gboolean yad_check_wayland (void);
+
+/* Weak symbol: if yad_check_wayland doesn't exist (tools build), return FALSE */
+#ifdef __GNUC__
+gboolean __attribute__((weak)) yad_check_wayland (void) { return FALSE; }
+#endif
+
 #define BIG_STEP 20
 
 typedef struct {
@@ -214,6 +224,15 @@ yad_get_screen_color (GtkWidget *widget)
   GdkCursor *picker_cursor;
   GdkGrabStatus grab_status;
   GdkWindow *window;
+
+  /* Color picking doesn't work on Wayland - screen capture and device grab are restricted */
+  if (yad_check_wayland ())
+    {
+      g_printerr (_("WARNING: Color picker is not supported on Wayland.\n"
+                    "Screen capture and pointer grab require X11 or a portal.\n"
+                    "Use GDK_BACKEND=x11 to enable color picking.\n"));
+      return;
+    }
 
   gd = g_new0 (GrabData, 1);
   gd->color_widget = widget;

--- a/src/print.c
+++ b/src/print.c
@@ -284,7 +284,11 @@ yad_print_run (void)
   if (options.data.center)
     gtk_window_set_position (GTK_WINDOW (dlg), GTK_WIN_POS_CENTER);
   else if (options.data.mouse)
-    gtk_window_set_position (GTK_WINDOW (dlg), GTK_WIN_POS_MOUSE);
+    {
+      /* Mouse positioning doesn't work on Wayland */
+      if (!yad_check_wayland ())
+        gtk_window_set_position (GTK_WINDOW (dlg), GTK_WIN_POS_MOUSE);
+    }
 
   /* create yad's top box */
   if (options.data.dialog_text || options.data.dialog_image)

--- a/src/yad.h
+++ b/src/yad.h
@@ -751,6 +751,9 @@ YadSearchBar *create_search_bar ();
 
 gboolean yad_confirm_dlg (GtkWindow *parent, gchar *txt);
 
+gboolean yad_check_x11 (void);
+gboolean yad_check_wayland (void);
+
 static inline void
 strip_new_line (gchar * str)
 {


### PR DESCRIPTION
## Combined improvements

This commit addresses multiple related issues:

### 1. Wayland backend detection and warnings
Addresses #159, #261, #158, #216, #49

On Wayland, X11-only features now show clear warnings instead of failing silently:
```
WARNING: --mouse option is not supported on Wayland.
WARNING: Window positioning (--posx/--posy) is controlled by the Wayland compositor.
```

### 2. Text sizing fix
Fixes #107, #140, #32, #297, #300

Dialog windows no longer grow excessively large when --text contains long content with --wrap enabled. The --width and --geometry options now properly constrain text.

### 3. Graceful signal handling
Addresses #181

SIGTERM/SIGINT now trigger graceful exit instead of abrupt termination.

## Files changed
- src/yad.h: Function declarations
- src/main.c: Detection logic, text sizing, signal handling
- src/cpicker.c, src/print.c: Wayland warnings
- src/notebook.c, src/paned.c: Timeout messages

## Test
```bash
# Text sizing
yad --text="Long text" --wrap --width=400

# Wayland warning
GDK_BACKEND=wayland yad --text="Test" --posx=100

# Signal handling
yad --form --field="Test" &
kill -TERM $!
```