### PR TITLE
fix(progress): Fix --pulsate --auto-close regression

### DIFF
--- a/src/progress.c
+++ b/src/progress.c
@@ -138,7 +138,20 @@ handle_stdin (GIOChannel *channel, GIOCondition condition, gpointer data)
           else
             {
               if (value[1] && b->type == YAD_PROGRESS_PULSE)
-                gtk_progress_bar_pulse (pb);
+                {
+                  /* Fix for issue #305: Check if this is a completion signal (100 or more) */
+                  if (g_ascii_isdigit (*value[1]))
+                    {
+                      gint val = atoi (value[1]);
+                      if (val >= 100 && options.progress_data.autoclose && options.plug == -1)
+                        {
+                          /* Treat 100+ as completion signal for pulsate bar */
+                          yad_exit (options.data.def_resp);
+                        }
+                    }
+                  /* Continue pulsating for values < 100 or non-numeric input */
+                  gtk_progress_bar_pulse (pb);
+                }
               else if (value[1] && b->type == YAD_PROGRESS_PERM)
                 {
                   guint id;


### PR DESCRIPTION
Fixes #305

## Problem

Since post-0.40.0, sending "100" to a pulsate progress bar with --auto-close doesn't close the window. The dialog ignores the completion signal.

## Root cause

In progress.c, pulsate bars were excluded from the auto-close check:
```c
if (cb->type != YAD_PROGRESS_PULSE)  // Skips pulsate bars
{
    need_close = TRUE;
    ...
}
```
Result: need_close was never set TRUE for pulsate-only dialogs.

## Fix

When a pulsate bar receives value >= 100 and --auto-close is enabled, exit immediately.

## Test

```bash
mkfifo fifo
tail -f fifo | yad --progress --pulsate --auto-close &
echo "10" >fifo    # Window stays open, pulses
echo "100" >fifo   # Window closes
```