### PR TITLE
Add yad_check_x11() for Wayland compatibility

### DIFF
--- a/src/cpicker.c
+++ b/src/cpicker.c
@@ -23,6 +23,16 @@
 
 #include "cpicker.h"
 
+#include <glib/gi18n.h>  /* For _() macro */
+
+/* Forward declaration - defined in main.c when building yad */
+gboolean yad_check_x11 (void);
+
+/* Weak symbol: if yad_check_x11 doesn't exist (tools build), return TRUE for X11 */
+#ifdef __GNUC__
+gboolean __attribute__((weak)) yad_check_x11 (void) { return TRUE; }
+#endif
+
 #define BIG_STEP 20
 
 typedef struct {
@@ -214,6 +224,15 @@ yad_get_screen_color (GtkWidget *widget)
   GdkCursor *picker_cursor;
   GdkGrabStatus grab_status;
   GdkWindow *window;
+
+  /* Color picking doesn't work on Wayland - screen capture and device grab are restricted */
+  if (!yad_check_x11 ())
+    {
+      g_printerr (_("WARNING: Color picker is not supported on Wayland.\n"
+                    "Screen capture and pointer grab require X11 or a portal.\n"
+                    "Use GDK_BACKEND=x11 to enable color picking.\n"));
+      return;
+    }
 
   gd = g_new0 (GrabData, 1);
   gd->color_widget = widget;

--- a/src/main.c
+++ b/src/main.c
@@ -56,6 +56,12 @@ static gboolean is_x11 = FALSE;
 
 YadNTabs *tabs;
 
+gboolean
+yad_check_x11 (void)
+{
+  return is_x11;
+}
+
 #ifndef G_OS_WIN32
 static void
 sa_usr1 (gint sig)

--- a/src/print.c
+++ b/src/print.c
@@ -284,7 +284,11 @@ yad_print_run (void)
   if (options.data.center)
     gtk_window_set_position (GTK_WINDOW (dlg), GTK_WIN_POS_CENTER);
   else if (options.data.mouse)
-    gtk_window_set_position (GTK_WINDOW (dlg), GTK_WIN_POS_MOUSE);
+    {
+      /* Mouse positioning doesn't work on Wayland */
+      if (yad_check_x11 ())
+        gtk_window_set_position (GTK_WINDOW (dlg), GTK_WIN_POS_MOUSE);
+    }
 
   /* create yad's top box */
   if (options.data.dialog_text || options.data.dialog_image)

--- a/src/yad.h
+++ b/src/yad.h
@@ -714,6 +714,8 @@ gboolean yad_send_notify (gboolean);
 void notebook_close_childs (void);
 void paned_close_childs (void);
 
+gboolean yad_check_x11 (void);
+
 void read_settings (void);
 void write_settings (void);
 


### PR DESCRIPTION
# Add yad_check_x11() for Wayland compatibility

Adds a simple API for checking if running on X11. This follows the feedback on PR #314 about using the existing `is_x11` variable instead of adding redundant `is_wayland` detection.

## What changed

New `yad_check_x11()` function in main.c that exposes the internal `is_x11` variable. Callers can use `!yad_check_x11()` for Wayland detection.

Files modified:
- `src/main.c` - added the function
- `src/yad.h` - added declaration
- `src/cpicker.c` - warns and skips color picker on non-X11
- `src/print.c` - skips mouse positioning on Wayland

## Why

Some features need X11 and don't work on Wayland:
- Color picker needs screen capture and pointer grab
- Mouse positioning is compositor-controlled on Wayland

Instead of silently failing, these now check `yad_check_x11()` and either warn or gracefully skip the feature.

## Testing

Tested on both X11 and Wayland sessions. Color picker shows warning on Wayland. Print dialog skips mouse positioning.