### PR TITLE
Handle SIGTERM and SIGINT for clean exit

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -890,6 +890,8 @@ main (gint argc, gchar ** argv)
   /* set signal handlers */
   signal (SIGUSR1, sa_usr1);
   signal (SIGUSR2, sa_usr2);
+  signal (SIGTERM, sa_usr2);  /* Clean exit on SIGTERM */
+  signal (SIGINT, sa_usr2);   /* Clean exit on SIGINT (Ctrl+C) */
 #endif
 
   if (!is_x11 && options.plug != -1)


### PR DESCRIPTION
# Handle SIGTERM and SIGINT for clean exit

Adds signal handlers for SIGTERM and SIGINT using the existing `sa_usr2()` handler. Follows the feedback on PR #314 about reusing existing handlers.

## What changed

Two lines added to the signal handler setup:

```c
signal (SIGTERM, sa_usr2);  /* Clean exit on SIGTERM */
signal (SIGINT, sa_usr2);   /* Clean exit on SIGINT (Ctrl+C) */
```

The existing `sa_usr2()` handler exits with `YAD_RESPONSE_CANCEL`, which is the appropriate response for interrupted dialogs.

## Why

Scripts embedding YAD dialogs need to properly terminate them when interrupted or receiving signals from process managers. Without this, SIGTERM and SIGINT would use the default behavior (immediate termination) instead of the clean exit path.

## Testing

```bash
# Start dialog and send SIGTERM
yad --text="Test" &
kill $!
echo "Exit code: $?"  # Should be 1 (CANCEL)

# Start dialog and press Ctrl+C
yad --text="Test"  # Press Ctrl+C, should exit cleanly
```