### PR TITLE
feat(list): Add --select-row option for pre-selecting rows

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -526,6 +526,8 @@ static GOptionEntry list_options[] = {
     N_("Set columns alignment"), N_("STRING") },
   { "header-align", 0, 0, G_OPTION_ARG_STRING, &options.list_data.hdr_align,
     N_("Set headers alignment"), N_("STRING") },
+  { "select-row", 0, 0, G_OPTION_ARG_STRING, &options.list_data.select_row,
+    N_("Pre-select row by number (1-based, comma-separated for multiple)"), N_("ROW[,ROW...]") },
   { NULL }
 };
 
@@ -1885,6 +1887,7 @@ yad_options_init (void)
   options.list_data.header_tips = FALSE;
   options.list_data.col_align = NULL;
   options.list_data.hdr_align = NULL;
+  options.list_data.select_row = NULL;
 
   /* Initialize notebook data */
   options.notebook_data.tabs = NULL;

--- a/src/yad.h
+++ b/src/yad.h
@@ -417,6 +417,7 @@ typedef struct {
   gboolean header_tips;
   gchar *col_align;
   gchar *hdr_align;
+  gchar *select_row;
 } YadListData;
 
 typedef struct {


### PR DESCRIPTION
# Add `--select-row` Option for List Dialog Pre-selection

## Summary

Adds `--select-row=ROW[,ROW...]` option to list dialogs for pre-selecting rows by their 1-based index. Scripts can now restore previous user selections when reopening dialogs.

## Problem

List dialogs lack row pre-selection. Users cannot:
- Restore previous choices when reopening dialogs
- Set default selections in configuration interfaces  
- Highlight specific items on dialog open

Checklist/radiolist support pre-selection via TRUE/FALSE values, but regular lists do not.

## Solution

New option `--select-row=ROW[,ROW...]`:
- 1-based row numbers for readability
- Comma-separated values for multiple selections (with `--multiple`)
- Auto-scrolls to first selected row
- Blocks `select-action` during initial selection

## Examples

Single selection:
```bash
yad --list --column="Items" --select-row=3 \
    "Apple" "Banana" "Cherry" "Date"
```

Multiple selection:
```bash
yad --list --column="Items" --select-row=1,3,5 --multiple \
    "Apple" "Banana" "Cherry" "Date" "Elderberry"
```

Restore previous choice:
```bash
LAST=$(cat /tmp/last.txt 2>/dev/null || echo "1")
RESULT=$(yad --list --column="Option" --select-row=$LAST \
    "Option A" "Option B" "Option C")
echo "$RESULT" | grep -n . | cut -d: -f1 > /tmp/last.txt
```

## Changes

| File | Change |
|------|--------|
| `src/yad.h` | Add `select_row` field to `YadListData` |
| `src/option.c` | Register option, initialize to NULL |
| `src/list.c` | Selection logic after `fill_data()` |

## Implementation

Option registration (`option.c`):
- GOption entry with `G_OPTION_ARG_STRING` type

Selection logic (`list.c`):
- Parse comma-separated row numbers
- Convert 1-based to 0-based GTK tree paths
- Validate row existence before selecting
- Handle single vs multiple selection modes
- Block `select-action` handler during setup
- Scroll to first selected row

Safety:
- Skip invalid rows (0, negative, out of range)
- Respect `--no-selection` option
- Works with tree mode

## Testing

| Test | Command | Result |
|------|---------|--------|
| Single | `--select-row=2` | Row 2 highlighted |
| Multiple | `--select-row=1,3,5 --multiple` | Rows 1,3,5 highlighted |
| Invalid | `--select-row=999` | No selection |
| Mixed | `--select-row=1,999,3` | Rows 1,3 selected |
| Disabled | `--select-row=2 --no-selection` | No selection |

## Backward Compatibility

Fully compatible. Without `--select-row`, behavior unchanged.

## Related Issues

- #47 - RFE: option to pre-select row(s) in --list (2019, i30817)
- #131 - Set default selected entry in a --list dialog (2021, marcelpaulo)

