### PR TITLE
feat(list): Add --enter-response option for separate Enter key exit code

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -67,21 +67,26 @@ list_activate_cb (GtkWidget *widget, GdkEventKey *event, gpointer data)
 {
   if (event->keyval == GDK_KEY_Return || event->keyval == GDK_KEY_KP_Enter)
     {
-      if (options.list_data.dclick_action)
+      if (event->state & GDK_CONTROL_MASK)
         {
-          /* FIXME: check this under gtk-3.0 */
-          if (event->state & GDK_CONTROL_MASK)
-            {
-              if (options.plug == -1)
-                yad_exit (options.data.def_resp);
-            }
-          else
-            return FALSE;
+          /* CTRL+ENTER: always exit with def_resp (--response value) */
+          if (options.plug == -1)
+            yad_exit (options.data.def_resp);
+          return TRUE;
+        }
+      else if (options.list_data.dclick_action)
+        {
+          /* ENTER with dclick_action: let double-click handler process it */
+          return FALSE;
         }
       else
         {
+          /* ENTER without dclick_action: use enter_resp if set, else def_resp */
           if (options.plug == -1)
-            yad_exit (options.data.def_resp);
+            {
+              gint resp = (options.data.enter_resp >= 0) ? options.data.enter_resp : options.data.def_resp;
+              yad_exit (resp);
+            }
         }
 
       return TRUE;

--- a/src/option.c
+++ b/src/option.c
@@ -141,6 +141,8 @@ static GOptionEntry general_options[] = {
     N_("Always print result"), NULL },
   { "response", 0, 0, G_OPTION_ARG_INT, &options.data.def_resp,
     N_("Set default return code"), N_("NUMBER") },
+  { "enter-response", 0, 0, G_OPTION_ARG_INT, &options.data.enter_resp,
+    N_("Set return code for Enter key (defaults to --response value)"), N_("NUMBER") },
   { "selectable-labels", 0, 0, G_OPTION_ARG_NONE, &options.data.selectable_labels,
     N_("Dialog text can be selected"), NULL },
   { "keep-icon-size", 0, 0, G_OPTION_ARG_NONE, &options.data.keep_icon_size,
@@ -1685,6 +1687,7 @@ yad_options_init (void)
   options.data.selectable_labels = FALSE;
   options.data.keep_icon_size = FALSE;
   options.data.def_resp = YAD_RESPONSE_OK;
+  options.data.enter_resp = -1;  /* -1 means use def_resp, for backward compatibility */
   options.data.use_interp = FALSE;
   options.data.interp = "bash -c \"%s\"";
 #ifndef STANDALONE

--- a/src/yad.h
+++ b/src/yad.h
@@ -258,6 +258,7 @@ typedef struct {
   gboolean keep_icon_size;
   GtkButtonBoxStyle buttons_layout;
   gint def_resp;
+  gint enter_resp;
   gboolean use_interp;
   gchar *interp;
   gchar *uri_handler;


### PR DESCRIPTION
## Summary

Adds `--enter-response` option allowing separate exit codes for Enter vs Ctrl+Enter in list dialogs.

## Use Case

When building interactive dialogs, it can be useful to have Enter and Ctrl+Enter trigger different actions:
- Enter opens a secondary dialog (e.g., edit mode)
- Ctrl+Enter confirms and submits

Currently both keys return the same `--response` value, making differentiation impossible.

## Implementation

Three files changed:
- `yad.h`: Added `enter_resp` field to `YadData` structure
- `option.c`: Added `--enter-response` option (defaults to -1)
- `list.c`: Modified `list_activate_cb` to use `enter_resp` for plain Enter

## Behavior Table

| Key | Behavior |
|-----|----------|
| Ctrl+Enter | Exits with `--response` value (unchanged) |
| Enter (no dclick-action) | Exits with `--enter-response` if set, otherwise `--response` |
| Enter (with dclick-action) | Triggers double-click action (unchanged) |

## Example

```bash
yad --list --response=10 --enter-response=0 --column=Option Item1 Item2
# Enter returns 0, Ctrl+Enter returns 10
```

## Backward Compatibility

`--enter-response` defaults to -1 (unset), so existing scripts continue to work unchanged.