### PR TITLE
Register indicator action as secondary activation target

### DIFF
--- a/data/yad.1
+++ b/data/yad.1
@@ -223,7 +223,7 @@ in EWMH specification. The behavior of dialog with this option is HIGHLY DEPENDS
 This option is deprecated. Use \fB--window-type\fP instead.
 .TP
 .B \-\-window-type=\fITYPE\fP
-Create a window with the specified window type. \fITYPE\fPCan be one of \fInormal\fP, \fIdialog\fP, \fIutility\fP, 
+Create a window with the specified window type. \fITYPE\fP can be one of \fInormal\fP, \fIdialog\fP, \fIutility\fP,
 \fIdock\fP, \fIdesktop\fP, \fItooltip\fP, \fInotification\fP or \fIsplash\fP.
 The behavior of each window type depends on your window manager. See EWMH specification for details.
 
@@ -840,7 +840,7 @@ See \fBNOTEBOOK and PANED\fP section for more about notebook dialog.
 .SS Notification options
 .TP
 .B \-\-command=\fICMD\fP
-Set the command running when clicked on the icon. Default action is \fIquit\fP if \fI\-\-listen\fP not specified.
+The command to run when clicking the icon. Default action is \fIquit\fP if \fI\-\-listen\fP not specified.
 .TP
 .B \-\-listen
 Listen for commands on stdin. See \fBNOTIFICATION\fP section.
@@ -867,6 +867,9 @@ See \fBNOTIFICATION\fP section for more about separators.
 
 .SS Appindicator options
 .TP
+.B \-\-command=\fICMD\fP
+The command to run when middle-clicking the icon. Default action is \fIquit\fP if \fI\-\-no-middle\fP not specified.
+.TP
 .B \-\-listen
 Listen for commands on stdin. See \fBNOTIFICATION\fP section.
 .TP
@@ -878,6 +881,9 @@ Set separator character for menu values. Default is \fI|\fP.
 .TP
 .B \-\-item-separator=\fISTRING\fP
 Set separator character for menu items. Default is \fI!\fP.
+.TP
+.B \-\-no-middle
+Disable exit on middle click when there's no other action defined.
 .TP
 .B \-\-hidden
 Doesn't show icon at startup.

--- a/src/appindicator.c
+++ b/src/appindicator.c
@@ -177,7 +177,7 @@ build_indicator_menu (void)
   indicator_menu = gtk_menu_new ();
 
   /* Register secondary (middle-click) action */
-  if (action && g_ascii_strcasecmp (action, "quit") != 0 && g_ascii_strcasecmp (action, "menu") != 0)
+  if (action && g_ascii_strcasecmp (action, "menu") != 0)
     {
       item = gtk_menu_item_new ();
       g_signal_connect (item, "activate", G_CALLBACK (activate_cb), NULL);
@@ -222,14 +222,6 @@ build_indicator_menu (void)
 
       gtk_menu_shell_append (GTK_MENU_SHELL (indicator_menu), item);
     }
-
-  /* Add quit item */
-  item = gtk_separator_menu_item_new ();
-  gtk_menu_shell_append (GTK_MENU_SHELL (indicator_menu), item);
-
-  item = gtk_menu_item_new_with_label (_("Quit"));
-  g_signal_connect (item, "activate", G_CALLBACK (popup_menu_item_activate_cb), "quit");
-  gtk_menu_shell_append (GTK_MENU_SHELL (indicator_menu), item);
 
   gtk_widget_show_all (indicator_menu);
   app_indicator_set_menu (app_indicator, GTK_MENU (indicator_menu));
@@ -359,6 +351,8 @@ yad_appindicator_run (void)
     icon = g_strdup (options.data.dialog_image);
   if (options.common_data.command)
     action = g_strdup (options.common_data.command);
+  else if (options.notification_data.middle)
+    action = "quit";
 
   if (options.notification_data.menu)
     parse_menu_str (options.notification_data.menu);


### PR DESCRIPTION
The new `--indicator` mode works great with Waybar, but it always creates an "Activate" and "Quit" item - even if you already have your own. This PR brings behaviour closer to the notification mode:

* Removes activate/quit menu items
* Sets the icon's *secondary activate target* to trigger action on middle click
* Defaults to `quit` if `action` and `--no-middle` are both undefined

If you'd rather *keep* a default Quit menu item, I have another commit to push - just say the word.  
It *would* avoid duplication (essentially `add-unless any d.action == ('quit' || 'kill *')`, but it *can't* support "no quit". For that it'd need a new option like `--no-quit-item` so it's probably easier to keep letting users add it.