### PR TITLE
Add --default-button option to set focus on dialog open

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: yad\n"
 "Report-Msgid-Bugs-To: victor@sanana.kiev.ua\n"
-"POT-Creation-Date: 2026-06-30 16:06+0300\n"
+"POT-Creation-Date: 2026-07-06 22:04-0400\n"
 "PO-Revision-Date: 2009-11-30 16:53+0100\n"
 "Last-Translator: Manfred Mueller aka Quax<mmueller@live-modules.org>\n"
 "Language-Team: German translations at Lin2Go <mmueller@live-modules.org>\n"
@@ -94,16 +94,16 @@ msgstr ""
 msgid "Select date"
 msgstr "Datei öffnen"
 
-#: src/form.c:1047
+#: src/form.c:1055
 #, fuzzy
 msgid "Select file"
 msgstr "Datei öffnen"
 
-#: src/form.c:1077
+#: src/form.c:1085
 msgid "Select folder"
 msgstr ""
 
-#: src/form.c:1245 src/form.c:1247
+#: src/form.c:1253 src/form.c:1255
 msgid "Link"
 msgstr ""
 
@@ -144,35 +144,35 @@ msgstr "Kann Befehlszeile nicht einlesen: %s\n"
 msgid "%d sec"
 msgstr ""
 
-#: src/main.c:748 src/main.c:755
+#: src/main.c:764 src/main.c:771
 #, fuzzy, c-format
 msgid "Unable to parse YAD_OPTIONS: %s\n"
 msgstr "Kann Befehlszeile nicht einlesen: %s\n"
 
-#: src/main.c:766
+#: src/main.c:782
 #, c-format
 msgid "Unable to parse command line: %s\n"
 msgstr "Kann Befehlszeile nicht einlesen: %s\n"
 
-#: src/main.c:780
+#: src/main.c:796
 msgid ""
 "WARNING: Using splash option is deprecated, please use --window-type instead"
 msgstr ""
 
-#: src/main.c:790
+#: src/main.c:806
 #, fuzzy, c-format
 msgid "Unable to change directory to %s: %s\n"
 msgstr "Kann Befehlszeile nicht einlesen: %s\n"
 
-#: src/main.c:819
+#: src/main.c:835
 msgid "WARNING: Using gtkrc option is deprecated, please use --css instead\n"
 msgstr ""
 
-#: src/main.c:893
+#: src/main.c:909
 msgid "WARNING: --plug mode not supported outside X11\n"
 msgstr ""
 
-#: src/main.c:913
+#: src/main.c:929
 msgid "WARNING: This mode not supported outside X11\n"
 msgstr ""
 
@@ -273,12 +273,12 @@ msgstr "HÖHE"
 msgid "Set the X position of a window"
 msgstr ""
 
-#: src/option.c:106 src/option.c:108 src/option.c:118 src/option.c:140
-#: src/option.c:144 src/option.c:189 src/option.c:203 src/option.c:342
-#: src/option.c:400 src/option.c:406 src/option.c:487 src/option.c:495
-#: src/option.c:497 src/option.c:499 src/option.c:501 src/option.c:503
-#: src/option.c:505 src/option.c:509 src/option.c:543 src/option.c:545
-#: src/option.c:599 src/option.c:633 src/option.c:702
+#: src/option.c:106 src/option.c:108 src/option.c:118 src/option.c:142
+#: src/option.c:146 src/option.c:191 src/option.c:205 src/option.c:344
+#: src/option.c:402 src/option.c:408 src/option.c:489 src/option.c:497
+#: src/option.c:499 src/option.c:501 src/option.c:503 src/option.c:505
+#: src/option.c:507 src/option.c:511 src/option.c:545 src/option.c:547
+#: src/option.c:601 src/option.c:635 src/option.c:704
 msgid "NUMBER"
 msgstr "ZAHL"
 
@@ -307,7 +307,7 @@ msgstr "ABLAUFZEIT"
 msgid "Show remaining time indicator (top, bottom, left, right)"
 msgstr ""
 
-#: src/option.c:114 src/option.c:587
+#: src/option.c:114 src/option.c:589
 msgid "POS"
 msgstr ""
 
@@ -315,8 +315,8 @@ msgstr ""
 msgid "Set the dialog text"
 msgstr "Dialogtext angeben"
 
-#: src/option.c:116 src/option.c:273 src/option.c:275 src/option.c:350
-#: src/option.c:352 src/option.c:386 src/option.c:507 src/option.c:637
+#: src/option.c:116 src/option.c:275 src/option.c:277 src/option.c:352
+#: src/option.c:354 src/option.c:388 src/option.c:509 src/option.c:639
 msgid "TEXT"
 msgstr "TEXT"
 
@@ -329,11 +329,11 @@ msgstr "Dialogtext angeben"
 msgid "Set the dialog text alignment (left, center, right, fill)"
 msgstr ""
 
-#: src/option.c:120 src/option.c:132 src/option.c:185 src/option.c:235
-#: src/option.c:241 src/option.c:243 src/option.c:398 src/option.c:481
-#: src/option.c:491 src/option.c:541 src/option.c:585 src/option.c:597
-#: src/option.c:609 src/option.c:621 src/option.c:635 src/option.c:698
-#: src/option.c:749 src/option.c:778 src/option.c:780 src/tools.c:86
+#: src/option.c:120 src/option.c:132 src/option.c:187 src/option.c:237
+#: src/option.c:243 src/option.c:245 src/option.c:400 src/option.c:483
+#: src/option.c:493 src/option.c:543 src/option.c:587 src/option.c:599
+#: src/option.c:611 src/option.c:623 src/option.c:637 src/option.c:700
+#: src/option.c:751 src/option.c:780 src/option.c:782 src/tools.c:86
 msgid "TYPE"
 msgstr ""
 
@@ -341,7 +341,7 @@ msgstr ""
 msgid "Set the dialog image"
 msgstr "Dialog-Symbol angeben"
 
-#: src/option.c:122 src/option.c:360 src/option.c:364
+#: src/option.c:122 src/option.c:362 src/option.c:366
 msgid "IMAGE"
 msgstr "SYMBOL"
 
@@ -349,7 +349,7 @@ msgstr "SYMBOL"
 msgid "Use specified icon theme instead of default"
 msgstr ""
 
-#: src/option.c:124 src/option.c:727 src/browser.c:220 src/tools.c:87
+#: src/option.c:124 src/option.c:729 src/browser.c:220 src/tools.c:87
 msgid "THEME"
 msgstr ""
 
@@ -357,7 +357,7 @@ msgstr ""
 msgid "Hide main widget with expander"
 msgstr ""
 
-#: src/option.c:126 src/option.c:378 src/option.c:654 src/option.c:718
+#: src/option.c:126 src/option.c:380 src/option.c:656 src/option.c:720
 #, fuzzy
 msgid "[TEXT]"
 msgstr "TEXT"
@@ -379,1645 +379,1655 @@ msgid "Set buttons layout type (spread, edge, start, end or center)"
 msgstr ""
 
 #: src/option.c:134
+#, fuzzy
+msgid "Set focus to the named button when dialog opens"
+msgstr "Fortschrittsbalken-Einstellungen anzeigen"
+
+#: src/option.c:134
+#, fuzzy
+msgid "NAME"
+msgstr "NAME:ID"
+
+#: src/option.c:136
 msgid "Don't use pango markup language in dialog's text"
 msgstr ""
 
-#: src/option.c:136
+#: src/option.c:138
 msgid "Don't close dialog if Escape was pressed"
 msgstr ""
 
-#: src/option.c:138
+#: src/option.c:140
 msgid "Escape acts like OK button"
 msgstr ""
 
-#: src/option.c:140
+#: src/option.c:142
 #, fuzzy
 msgid "Set window borders"
 msgstr "Fenster-Größe fixieren"
 
-#: src/option.c:142
+#: src/option.c:144
 msgid "Always print result"
 msgstr ""
 
-#: src/option.c:144
+#: src/option.c:146
 #, fuzzy
 msgid "Set default return code"
 msgstr "Format des angezeigten Datums angeben"
 
-#: src/option.c:146
+#: src/option.c:148
 msgid "Dialog text can be selected"
 msgstr ""
 
-#: src/option.c:148
+#: src/option.c:150
 #, fuzzy
 msgid "Don't scale icons"
 msgstr "Schieberegler-Einstellungen anzeigen"
 
-#: src/option.c:150
+#: src/option.c:152
 #, c-format
 msgid "Run commands under specified interpreter (default: bash -c '%s')"
 msgstr ""
 
-#: src/option.c:150 src/option.c:152 src/option.c:154 src/option.c:205
-#: src/option.c:312 src/option.c:362 src/option.c:366 src/option.c:412
-#: src/option.c:511 src/option.c:513 src/option.c:515 src/option.c:601
+#: src/option.c:152 src/option.c:154 src/option.c:156 src/option.c:207
+#: src/option.c:314 src/option.c:364 src/option.c:368 src/option.c:414
+#: src/option.c:513 src/option.c:515 src/option.c:517 src/option.c:603
 msgid "CMD"
 msgstr ""
 
-#: src/option.c:152
+#: src/option.c:154
 msgid "Set URI handler"
 msgstr ""
 
-#: src/option.c:154
+#: src/option.c:156
 msgid "Set command running when F1 was pressed"
 msgstr ""
 
-#: src/option.c:156
+#: src/option.c:158
 #, fuzzy
 msgid "Set working directory"
 msgstr "Fenster-Dekoration entfernen"
 
-#: src/option.c:156 src/option.c:782
+#: src/option.c:158 src/option.c:784
 #, fuzzy
 msgid "PATH"
 msgstr "SYMBOLPFAD"
 
-#: src/option.c:159
+#: src/option.c:161
 msgid "Set window sticky"
 msgstr "Fenster fixieren"
 
-#: src/option.c:161
+#: src/option.c:163
 msgid "Set window unresizable"
 msgstr "Fenster-Größe fixieren"
 
-#: src/option.c:163
+#: src/option.c:165
 msgid "Place window on top"
 msgstr "Als oberstes Fenster  anzeigen"
 
-#: src/option.c:165
+#: src/option.c:167
 msgid "Place window on center of screen"
 msgstr "Fenster auf Bildschirm zentrieren"
 
-#: src/option.c:167
+#: src/option.c:169
 #, fuzzy
 msgid "Place window at the mouse position"
 msgstr "Als oberstes Fenster  anzeigen"
 
-#: src/option.c:169
+#: src/option.c:171
 msgid "Set window undecorated"
 msgstr "Fenster-Dekoration entfernen"
 
-#: src/option.c:171
+#: src/option.c:173
 #, fuzzy
 msgid "Don't show window in taskbar"
 msgstr "Spalten-Bezeichnung angeben"
 
-#: src/option.c:173
+#: src/option.c:175
 #, fuzzy
 msgid "Set window maximized"
 msgstr "Fenster-Größe fixieren"
 
-#: src/option.c:175
+#: src/option.c:177
 #, fuzzy
 msgid "Set window fullscreen"
 msgstr "Fenster-Größe fixieren"
 
-#: src/option.c:177
+#: src/option.c:179
 #, fuzzy
 msgid "Don't focus dialog window"
 msgstr "Farb-Einstellungen anzeigen"
 
-#: src/option.c:179
+#: src/option.c:181
 msgid "Close window when it sets unfocused"
 msgstr ""
 
-#: src/option.c:182
+#: src/option.c:184
 msgid "Open window as a splashscreen (Deprecated, see man page for details)"
 msgstr ""
 
-#: src/option.c:185
+#: src/option.c:187
 msgid "Specify the window type for the dialog"
 msgstr ""
 
-#: src/option.c:187
+#: src/option.c:189
 msgid "Special type of dialog for XEMBED"
 msgstr ""
 
-#: src/option.c:187 src/option.c:239
+#: src/option.c:189 src/option.c:241
 msgid "KEY"
 msgstr ""
 
-#: src/option.c:189
+#: src/option.c:191
 msgid "Tab number of this dialog"
 msgstr ""
 
-#: src/option.c:192
+#: src/option.c:194
 msgid "Send SIGNAL to parent"
 msgstr ""
 
-#: src/option.c:192
+#: src/option.c:194
 msgid "[SIGNAL]"
 msgstr ""
 
-#: src/option.c:194
+#: src/option.c:196
 msgid "Print X Window Id to the file/stderr"
 msgstr ""
 
-#: src/option.c:194 src/option.c:324
+#: src/option.c:196 src/option.c:326
 #, fuzzy
 msgid "[FILENAME]"
 msgstr "DATEINAME"
 
-#: src/option.c:201
+#: src/option.c:203
 msgid "Set the format for the returned date"
 msgstr "Format des angezeigten Datums angeben"
 
-#: src/option.c:201 src/option.c:453
+#: src/option.c:203 src/option.c:455
 msgid "PATTERN"
 msgstr "FORMAT"
 
-#: src/option.c:203
+#: src/option.c:205
 msgid "Set presicion of floating numbers (default - 3)"
 msgstr ""
 
-#: src/option.c:205
+#: src/option.c:207
 msgid "Set command handler"
 msgstr ""
 
-#: src/option.c:207
+#: src/option.c:209
 #, fuzzy
 msgid "Listen for data on stdin"
 msgstr "Auf Befehle von stdin warten"
 
-#: src/option.c:209
+#: src/option.c:211
 #, fuzzy
 msgid "Set common separator character"
 msgstr "Ausgabe-Trennzeichen angeben"
 
-#: src/option.c:209 src/option.c:211
+#: src/option.c:211 src/option.c:213
 msgid "SEPARATOR"
 msgstr "Trennzeichen"
 
-#: src/option.c:211
+#: src/option.c:213
 #, fuzzy
 msgid "Set item separator character"
 msgstr "Ausgabe-Trennzeichen angeben"
 
-#: src/option.c:213
+#: src/option.c:215
 #, fuzzy
 msgid "Allow changes to text in some cases"
 msgstr "Text-Änderungen im Auswahlfeld erlauben"
 
-#: src/option.c:215
+#: src/option.c:217
 msgid "Autoscroll to end of text"
 msgstr ""
 
-#: src/option.c:217
+#: src/option.c:219
 msgid "Autoscroll to end of text (alias to tail)"
 msgstr ""
 
-#: src/option.c:219
+#: src/option.c:221
 #, fuzzy
 msgid "Quote dialogs output"
 msgstr "Dialogtext angeben"
 
-#: src/option.c:221
+#: src/option.c:223
 #, fuzzy
 msgid "Output number instead of text for combo-box"
 msgstr "Vervollständigen statt Auswahlfeld verwenden"
 
-#: src/option.c:223
+#: src/option.c:225
 msgid "Specify font name to use"
 msgstr ""
 
-#: src/option.c:223
+#: src/option.c:225
 msgid "FONTNAME"
 msgstr "SCHRIFTART"
 
-#: src/option.c:225
+#: src/option.c:227
 #, fuzzy
 msgid "Allow multiple selection"
 msgstr "Auswahl mehrerer Reihen erlauben"
 
-#: src/option.c:227
+#: src/option.c:229
 #, fuzzy
 msgid "Enable preview"
 msgstr "Text für Fortschrittsbalken angeben"
 
-#: src/option.c:229
+#: src/option.c:231
 #, fuzzy
 msgid "Use large preview"
 msgstr "Text für Fortschrittsbalken angeben"
 
-#: src/option.c:231
+#: src/option.c:233
 #, fuzzy
 msgid "Show hidden files in file selection dialogs"
 msgstr "Datei-Auswahlfeld"
 
-#: src/option.c:233
+#: src/option.c:235
 #, fuzzy
 msgid "Set source filename"
 msgstr "Dateinamen angeben"
 
-#: src/option.c:233 src/option.c:308 src/option.c:775 src/option.c:790
+#: src/option.c:235 src/option.c:310 src/option.c:777 src/option.c:792
 msgid "FILENAME"
 msgstr "DATEINAME"
 
-#: src/option.c:235
+#: src/option.c:237
 msgid "Set mime type of input data"
 msgstr ""
 
-#: src/option.c:237
+#: src/option.c:239
 #, fuzzy
 msgid "Set vertical orientation"
 msgstr "Anfangs-Prozentsatz angeben"
 
-#: src/option.c:239
+#: src/option.c:241
 msgid "Identifier of embedded dialogs"
 msgstr ""
 
-#: src/option.c:241
+#: src/option.c:243
 msgid "Set extended completion for entries (any, all, or regex)"
 msgstr ""
 
-#: src/option.c:243
+#: src/option.c:245
 msgid "Set type of output for boolean values (T, t, Y, y, O, o, 1)"
 msgstr ""
 
-#: src/option.c:245
+#: src/option.c:247
 msgid "Make main widget scrollable"
 msgstr ""
 
-#: src/option.c:247
+#: src/option.c:249
 msgid "Disable search in text and html dialogs"
 msgstr ""
 
-#: src/option.c:249
+#: src/option.c:251
 #, fuzzy
 msgid "Enable file operations"
 msgstr "Schieberegler-Einstellungen"
 
-#: src/option.c:252
+#: src/option.c:254
 msgid "Use IEC (base 1024) units with for size values"
 msgstr ""
 
-#: src/option.c:256
+#: src/option.c:258
 #, fuzzy
 msgid "Enable spell check for text"
 msgstr "Bestimmte Schriftart benutzen"
 
-#: src/option.c:258
+#: src/option.c:260
 msgid "Set spell checking language"
 msgstr ""
 
-#: src/option.c:258
+#: src/option.c:260
 msgid "LANGUAGE"
 msgstr ""
 
-#: src/option.c:265
+#: src/option.c:267
 #, fuzzy
 msgid "Display about dialog"
 msgstr "Listen-Dialog"
 
-#: src/option.c:267
+#: src/option.c:269
 msgid "Set application name"
 msgstr ""
 
-#: src/option.c:267 src/option.c:269 src/option.c:271 src/option.c:281
-#: src/option.c:429 src/option.c:431 src/option.c:529 src/option.c:531
-#: src/option.c:558 src/option.c:574 src/option.c:772
+#: src/option.c:269 src/option.c:271 src/option.c:273 src/option.c:283
+#: src/option.c:431 src/option.c:433 src/option.c:531 src/option.c:533
+#: src/option.c:560 src/option.c:576 src/option.c:774
 msgid "STRING"
 msgstr ""
 
-#: src/option.c:269
+#: src/option.c:271
 msgid "Set application version"
 msgstr ""
 
-#: src/option.c:271
+#: src/option.c:273
 msgid "Set application copyright string"
 msgstr ""
 
-#: src/option.c:273
+#: src/option.c:275
 msgid "Set application comments string"
 msgstr ""
 
-#: src/option.c:275
+#: src/option.c:277
 msgid "Set application license"
 msgstr ""
 
-#: src/option.c:277
+#: src/option.c:279
 msgid "Set application authors"
 msgstr ""
 
-#: src/option.c:277 src/option.c:485 src/option.c:489 src/option.c:493
+#: src/option.c:279 src/option.c:487 src/option.c:491 src/option.c:495
 msgid "LIST"
 msgstr ""
 
-#: src/option.c:279
+#: src/option.c:281
 #, fuzzy
 msgid "Set application website"
 msgstr "Abstände angeben"
 
-#: src/option.c:279
+#: src/option.c:281
 msgid "URI"
 msgstr ""
 
-#: src/option.c:281
+#: src/option.c:283
 msgid "Set application website label"
 msgstr ""
 
-#: src/option.c:287
+#: src/option.c:289
 #, fuzzy
 msgid "Display application selection dialog"
 msgstr "Datei-Auswahlfeld"
 
-#: src/option.c:289
+#: src/option.c:291
 #, fuzzy
 msgid "Show fallback applications"
 msgstr "Kalender-Einstellungen anzeigen"
 
-#: src/option.c:291
+#: src/option.c:293
 #, fuzzy
 msgid "Show other applications"
 msgstr "Formular-Einstellungen anzeigen"
 
-#: src/option.c:293
+#: src/option.c:295
 #, fuzzy
 msgid "Show all applications"
 msgstr "Schieberegler-Einstellungen anzeigen"
 
-#: src/option.c:295
+#: src/option.c:297
 msgid "Output all application data"
 msgstr ""
 
-#: src/option.c:300
+#: src/option.c:302
 msgid "Display calendar dialog"
 msgstr "Kalender-Dialog"
 
-#: src/option.c:302
+#: src/option.c:304
 msgid "Set the calendar day"
 msgstr "Kalender-Tag angeben"
 
-#: src/option.c:302
+#: src/option.c:304
 msgid "DAY"
 msgstr "TAG"
 
-#: src/option.c:304
+#: src/option.c:306
 msgid "Set the calendar month"
 msgstr "Kalender-Monat angeben"
 
-#: src/option.c:304
+#: src/option.c:306
 msgid "MONTH"
 msgstr "MONAT"
 
-#: src/option.c:306
+#: src/option.c:308
 msgid "Set the calendar year"
 msgstr "Kalender-Jahr angeben"
 
-#: src/option.c:306
+#: src/option.c:308
 msgid "YEAR"
 msgstr "Jahr"
 
-#: src/option.c:308
+#: src/option.c:310
 #, fuzzy
 msgid "Set the filename with dates details"
 msgstr "Dateinamen angeben"
 
-#: src/option.c:310
+#: src/option.c:312
 msgid "Show week numbers at the left side of calendar"
 msgstr ""
 
-#: src/option.c:312 src/option.c:513
+#: src/option.c:314 src/option.c:515
 #, fuzzy
 msgid "Set select action"
 msgstr "Dateiauswahl-Einstellungen"
 
-#: src/option.c:318
+#: src/option.c:320
 msgid "Display color selection dialog"
 msgstr "Farbwahl-Dialog"
 
-#: src/option.c:320
+#: src/option.c:322
 msgid "Set initial color value"
 msgstr "Wert der Anfangsfarbe angeben"
 
-#: src/option.c:320 src/option.c:704 src/option.c:706 src/option.c:712
-#: src/option.c:735 src/option.c:737
+#: src/option.c:322 src/option.c:706 src/option.c:708 src/option.c:714
+#: src/option.c:737 src/option.c:739
 msgid "COLOR"
 msgstr "FARBE"
 
-#: src/option.c:322
+#: src/option.c:324
 msgid "Show system palette in color dialog"
 msgstr ""
 
-#: src/option.c:324
+#: src/option.c:326
 msgid "Set path to palette file. Default - "
 msgstr ""
 
-#: src/option.c:326
+#: src/option.c:328
 msgid "Expand user palette"
 msgstr ""
 
-#: src/option.c:328
+#: src/option.c:330
 msgid "Show color picker"
 msgstr ""
 
-#: src/option.c:330
+#: src/option.c:332
 msgid "Set output mode to MODE. Values are hex (default) or rgb"
 msgstr ""
 
-#: src/option.c:330
+#: src/option.c:332
 msgid "MODE"
 msgstr ""
 
-#: src/option.c:332
+#: src/option.c:334
 msgid "Add opacity to output color value"
 msgstr ""
 
-#: src/option.c:338
+#: src/option.c:340
 #, fuzzy
 msgid "Display drag-n-drop box"
 msgstr "Kalender-Dialog"
 
-#: src/option.c:340
+#: src/option.c:342
 msgid "Use dialog text as tooltip"
 msgstr ""
 
-#: src/option.c:342
+#: src/option.c:344
 msgid "Exit after NUMBER of drops"
 msgstr ""
 
-#: src/option.c:348
+#: src/option.c:350
 msgid "Display text entry or combo-box dialog"
 msgstr "Texteingabefeld oder Auswahlfeld"
 
-#: src/option.c:350
+#: src/option.c:352
 msgid "Set the entry label"
 msgstr "Eintrags-Bezeichnung angeben"
 
-#: src/option.c:352
+#: src/option.c:354
 msgid "Set the entry text"
 msgstr "Eintrags-Text angeben"
 
-#: src/option.c:354
+#: src/option.c:356
 msgid "Hide the entry text"
 msgstr "Eintrags-Text verbergen"
 
-#: src/option.c:356
+#: src/option.c:358
 msgid "Use completion instead of combo-box"
 msgstr "Vervollständigen statt Auswahlfeld verwenden"
 
-#: src/option.c:358
+#: src/option.c:360
 #, fuzzy
 msgid "Use spin button for text entry"
 msgstr "Bestimmte Schriftart benutzen"
 
-#: src/option.c:360
+#: src/option.c:362
 #, fuzzy
 msgid "Set the left entry icon"
 msgstr "Eintrags-Text angeben"
 
-#: src/option.c:362
+#: src/option.c:364
 #, fuzzy
 msgid "Set the left entry icon action"
 msgstr "Textfeld-Einstellungen anzeigen"
 
-#: src/option.c:364
+#: src/option.c:366
 #, fuzzy
 msgid "Set the right entry icon"
 msgstr "Fenster-Symbol angeben"
 
-#: src/option.c:366
+#: src/option.c:368
 #, fuzzy
 msgid "Set the right entry icon action"
 msgstr "Textfeld-Einstellungen anzeigen"
 
-#: src/option.c:372
+#: src/option.c:374
 msgid "Display file selection dialog"
 msgstr "Datei-Auswahlfeld"
 
-#: src/option.c:374
+#: src/option.c:376
 msgid "Activate directory-only selection"
 msgstr "Nur Verzeichnis-Auswahl aktivieren"
 
-#: src/option.c:376
+#: src/option.c:378
 msgid "Activate save mode"
 msgstr "Sicheren Modus aktivieren"
 
-#: src/option.c:378
+#: src/option.c:380
 msgid "Confirm file selection if filename already exists"
 msgstr "Datei-Auswahl bei bestehender Datei bestätigen"
 
-#: src/option.c:384
+#: src/option.c:386
 #, fuzzy
 msgid "Display font selection dialog"
 msgstr "Datei-Auswahlfeld"
 
-#: src/option.c:386
+#: src/option.c:388
 msgid "Set text string for preview"
 msgstr ""
 
-#: src/option.c:388
+#: src/option.c:390
 msgid "Separate output of font description"
 msgstr ""
 
-#: src/option.c:394
+#: src/option.c:396
 msgid "Display form dialog"
 msgstr "Formular-Dialog"
 
-#: src/option.c:396
+#: src/option.c:398
 msgid "Add field to form (see man page for list of possible types)"
 msgstr ""
 
-#: src/option.c:396 src/option.c:631
+#: src/option.c:398 src/option.c:633
 msgid "LABEL[:TYPE]"
 msgstr ""
 
-#: src/option.c:398
+#: src/option.c:400
 msgid "Set alignment of filed labels (left, center or right)"
 msgstr ""
 
-#: src/option.c:400
+#: src/option.c:402
 msgid "Set number of columns in form"
 msgstr ""
 
-#: src/option.c:402
+#: src/option.c:404
 msgid "Make form fields height and columns width the same size"
 msgstr ""
 
-#: src/option.c:404
+#: src/option.c:406
 msgid "Order output fields by rows"
 msgstr ""
 
-#: src/option.c:406
+#: src/option.c:408
 #, fuzzy
 msgid "Set focused field"
 msgstr "Abstände angeben"
 
-#: src/option.c:408
+#: src/option.c:410
 msgid "Cycled reading of stdin data"
 msgstr ""
 
-#: src/option.c:410
+#: src/option.c:412
 msgid "Align labels on button fields"
 msgstr ""
 
-#: src/option.c:412
+#: src/option.c:414
 msgid "Set changed action"
 msgstr ""
 
-#: src/option.c:419
+#: src/option.c:421
 #, fuzzy
 msgid "Display HTML dialog"
 msgstr "Formular-Dialog"
 
-#: src/option.c:421
+#: src/option.c:423
 #, fuzzy
 msgid "Open specified location"
 msgstr "Bestimmte Schriftart benutzen"
 
-#: src/option.c:423
+#: src/option.c:425
 msgid "Turn on browser mode"
 msgstr ""
 
-#: src/option.c:425
+#: src/option.c:427
 msgid "Print clicked uri to stdout"
 msgstr ""
 
-#: src/option.c:427
+#: src/option.c:429
 msgid "Set encoding of input stream data"
 msgstr ""
 
-#: src/option.c:427
+#: src/option.c:429
 msgid "ENCODING"
 msgstr ""
 
-#: src/option.c:429
+#: src/option.c:431
 msgid "Set user agent string"
 msgstr ""
 
-#: src/option.c:431
+#: src/option.c:433
 msgid "Set custom user style"
 msgstr ""
 
-#: src/option.c:433
+#: src/option.c:435
 msgid "Set WebKit property"
 msgstr ""
 
-#: src/option.c:433
+#: src/option.c:435
 msgid "PROP"
 msgstr ""
 
-#: src/option.c:440
+#: src/option.c:442
 #, fuzzy
 msgid "Display icons box dialog"
 msgstr "Listen-Dialog"
 
-#: src/option.c:442
+#: src/option.c:444
 msgid "Read data from .desktop files in specified directory"
 msgstr ""
 
-#: src/option.c:442
+#: src/option.c:444
 msgid "DIR"
 msgstr ""
 
-#: src/option.c:444
+#: src/option.c:446
 msgid "Use compact (list) view"
 msgstr ""
 
-#: src/option.c:446
+#: src/option.c:448
 msgid "Use GenericName field instead of Name for icon label"
 msgstr ""
 
-#: src/option.c:448
+#: src/option.c:450
 #, fuzzy
 msgid "Set the width of dialog items"
 msgstr "Dialogtitel angeben"
 
-#: src/option.c:450
+#: src/option.c:452
 msgid "Force using specified icon size"
 msgstr ""
 
-#: src/option.c:450 src/option.c:564 src/option.c:700 src/tools.c:85
+#: src/option.c:452 src/option.c:566 src/option.c:702 src/tools.c:85
 msgid "SIZE"
 msgstr ""
 
-#: src/option.c:453
+#: src/option.c:455
 #, no-c-format
 msgid ""
 "Use specified pattern for launch command in terminal (default: xterm -e %s)"
 msgstr ""
 
-#: src/option.c:455
+#: src/option.c:457
 msgid "Sort items by name instead of filename"
 msgstr ""
 
-#: src/option.c:457
+#: src/option.c:459
 msgid "Sort items in descending order"
 msgstr ""
 
-#: src/option.c:459
+#: src/option.c:461
 msgid "Activate items by single click"
 msgstr ""
 
-#: src/option.c:461
+#: src/option.c:463
 msgid "Watch fot changes in directory"
 msgstr ""
 
-#: src/option.c:467
+#: src/option.c:469
 msgid "Display list dialog"
 msgstr "Listen-Dialog"
 
-#: src/option.c:469
+#: src/option.c:471
 msgid "Set the column header (see man page for list of possible types)"
 msgstr ""
 
-#: src/option.c:469
+#: src/option.c:471
 #, fuzzy
 msgid "COLUMN[:TYPE]"
 msgstr "SPALTE"
 
-#: src/option.c:471
+#: src/option.c:473
 msgid "Enbale tree mode"
 msgstr ""
 
-#: src/option.c:473
+#: src/option.c:475
 #, fuzzy
 msgid "Use checkboxes for first column"
 msgstr "Ankreuzfeld für erste Spalte benutzen"
 
-#: src/option.c:475
+#: src/option.c:477
 #, fuzzy
 msgid "Use radioboxes for first column"
 msgstr "Ankreuzfeld für erste Spalte benutzen"
 
-#: src/option.c:477
+#: src/option.c:479
 #, fuzzy
 msgid "Don't show column headers"
 msgstr "Spalten-Bezeichnung angeben"
 
-#: src/option.c:479
+#: src/option.c:481
 msgid "Disable clickable column headers"
 msgstr ""
 
-#: src/option.c:481
+#: src/option.c:483
 msgid "Set grid lines (hor[izontal], vert[ical] or both)"
 msgstr ""
 
-#: src/option.c:483
+#: src/option.c:485
 msgid "Print all data from list"
 msgstr "Alle Werte der Liste"
 
-#: src/option.c:485
+#: src/option.c:487
 #, fuzzy
 msgid "Set the list of editable columns"
 msgstr "Dialogtitel angeben"
 
-#: src/option.c:487
+#: src/option.c:489
 #, fuzzy
 msgid "Set the width of a column for start wrapping text"
 msgstr "Dialogtitel angeben"
 
-#: src/option.c:489
+#: src/option.c:491
 #, fuzzy
 msgid "Set the list of wrapped columns"
 msgstr "Dialogtitel angeben"
 
-#: src/option.c:491
+#: src/option.c:493
 msgid "Set ellipsize mode for text columns (none, start, middle or end)"
 msgstr ""
 
-#: src/option.c:493
+#: src/option.c:495
 #, fuzzy
 msgid "Set the list of ellipsized columns"
 msgstr "Dialogtitel angeben"
 
-#: src/option.c:495
+#: src/option.c:497
 #, fuzzy
 msgid ""
 "Print a specific column. By default or if 0 is specified will be printed all "
 "columns"
 msgstr "Bestimmte  Spalte ausgeben (Standard=1 - Alle=0)"
 
-#: src/option.c:497
+#: src/option.c:499
 msgid "Hide a specific column"
 msgstr "Bestimmte Spalte verbergen"
 
-#: src/option.c:499
+#: src/option.c:501
 msgid "Set the column expandable by default. 0 sets all columns expandable"
 msgstr ""
 
-#: src/option.c:501
+#: src/option.c:503
 msgid ""
 "Set the quick search column. Default is first column. Set it to 0 for "
 "disable searching"
 msgstr ""
 
-#: src/option.c:503
+#: src/option.c:505
 #, fuzzy
 msgid "Set the tooltip column"
 msgstr "Fenster-Symbol angeben"
 
-#: src/option.c:505
+#: src/option.c:507
 #, fuzzy
 msgid "Set the row separator column"
 msgstr "Fenster-Symbol angeben"
 
-#: src/option.c:507
+#: src/option.c:509
 #, fuzzy
 msgid "Set the row separator value"
 msgstr "Ausgabe-Trennzeichen angeben"
 
-#: src/option.c:509
+#: src/option.c:511
 #, fuzzy
 msgid "Set the limit of rows in list"
 msgstr "Dialogtitel angeben"
 
-#: src/option.c:511
+#: src/option.c:513
 msgid "Set double-click action"
 msgstr ""
 
-#: src/option.c:515
+#: src/option.c:517
 #, fuzzy
 msgid "Set row action"
 msgstr "Fenster-Symbol angeben"
 
-#: src/option.c:517
+#: src/option.c:519
 msgid "Expand all tree nodes"
 msgstr ""
 
-#: src/option.c:519
+#: src/option.c:521
 msgid "Use regex in search"
 msgstr ""
 
-#: src/option.c:521
+#: src/option.c:523
 #, fuzzy
 msgid "Disable selection"
 msgstr "Datei-Auswahlfeld"
 
-#: src/option.c:523
+#: src/option.c:525
 msgid "Add new records on the top of a list"
 msgstr ""
 
-#: src/option.c:525
+#: src/option.c:527
 msgid "Don't use markup in tooltips"
 msgstr ""
 
-#: src/option.c:527
+#: src/option.c:529
 msgid "Use column name as a header tooltip"
 msgstr ""
 
-#: src/option.c:529
+#: src/option.c:531
 msgid "Set columns alignment"
 msgstr ""
 
-#: src/option.c:531
+#: src/option.c:533
 #, fuzzy
 msgid "Set headers alignment"
 msgstr "Kalender-Monat angeben"
 
-#: src/option.c:537
+#: src/option.c:539
 #, fuzzy
 msgid "Display notebook dialog"
 msgstr "Listen-Dialog"
 
-#: src/option.c:539
+#: src/option.c:541
 msgid "Add a tab to notebook"
 msgstr ""
 
-#: src/option.c:539
+#: src/option.c:541
 msgid "LABEL"
 msgstr "BEZEICHNUNG"
 
-#: src/option.c:541
+#: src/option.c:543
 msgid "Set position of a notebook tabs (top, bottom, left or right)"
 msgstr ""
 
-#: src/option.c:543
+#: src/option.c:545
 #, fuzzy
 msgid "Set tab borders"
 msgstr "Fenster-Größe fixieren"
 
-#: src/option.c:545
+#: src/option.c:547
 #, fuzzy
 msgid "Set active tab"
 msgstr "Eintrags-Bezeichnung angeben"
 
-#: src/option.c:547
+#: src/option.c:549
 msgid "Expand tabs"
 msgstr ""
 
-#: src/option.c:549
+#: src/option.c:551
 msgid "Use stack mode"
 msgstr ""
 
-#: src/option.c:556
+#: src/option.c:558
 msgid "Display notification"
 msgstr "Benachrichtigung"
 
-#: src/option.c:558 src/option.c:574
+#: src/option.c:560 src/option.c:576
 #, fuzzy
 msgid "Set initial popup menu"
 msgstr "Anfangs-Prozentsatz angeben"
 
-#: src/option.c:560
+#: src/option.c:562
 msgid "Disable exit on middle click"
 msgstr ""
 
-#: src/option.c:562 src/option.c:576
+#: src/option.c:564 src/option.c:578
 #, fuzzy
 msgid "Doesn't show icon at startup"
 msgstr "Spalten-Bezeichnung angeben"
 
-#: src/option.c:564
+#: src/option.c:566
 msgid "Set icon size for fully specified icons (default - 16)"
 msgstr ""
 
-#: src/option.c:572
+#: src/option.c:574
 msgid "Display indicator icon (StatusNotifier/AppIndicator)"
 msgstr ""
 
-#: src/option.c:583
+#: src/option.c:585
 #, fuzzy
 msgid "Display paned dialog"
 msgstr "Schieberegler"
 
-#: src/option.c:585
+#: src/option.c:587
 msgid "Set orientation (hor[izontal] or vert[ical])"
 msgstr ""
 
-#: src/option.c:587
+#: src/option.c:589
 #, fuzzy
 msgid "Set initial splitter position"
 msgstr "Anfangs-Prozentsatz angeben"
 
-#: src/option.c:589
+#: src/option.c:591
 msgid "Set focused pane (1 or 2)"
 msgstr ""
 
-#: src/option.c:589
+#: src/option.c:591
 msgid "PANE"
 msgstr ""
 
-#: src/option.c:595
+#: src/option.c:597
 #, fuzzy
 msgid "Display picture dialog"
 msgstr "Listen-Dialog"
 
-#: src/option.c:597
+#: src/option.c:599
 #, fuzzy
 msgid "Set initial size (fit or orig)"
 msgstr "Anfangs-Prozentsatz angeben"
 
-#: src/option.c:599
+#: src/option.c:601
 msgid "Set increment for picture scaling (default - 5)"
 msgstr ""
 
-#: src/option.c:601
+#: src/option.c:603
 msgid "Set action on image changing"
 msgstr ""
 
-#: src/option.c:607
+#: src/option.c:609
 #, fuzzy
 msgid "Display popup dialog"
 msgstr "Listen-Dialog"
 
-#: src/option.c:609
+#: src/option.c:611
 msgid "Set alignment of title and text (left, center or right)"
 msgstr ""
 
-#: src/option.c:611
+#: src/option.c:613
 msgid "Set transparency"
 msgstr ""
 
-#: src/option.c:611
+#: src/option.c:613
 #, fuzzy
 msgid "PERCENT"
 msgstr "Prozentsatz"
 
-#: src/option.c:613
+#: src/option.c:615
 msgid "Don't close popup by timeout"
 msgstr ""
 
-#: src/option.c:619
+#: src/option.c:621
 #, fuzzy
 msgid "Display printing dialog"
 msgstr "Listen-Dialog"
 
-#: src/option.c:621
+#: src/option.c:623
 msgid "Set source type (text, image or raw)"
 msgstr ""
 
-#: src/option.c:623
+#: src/option.c:625
 msgid "Add headers to page"
 msgstr ""
 
-#: src/option.c:629
+#: src/option.c:631
 msgid "Display progress indication dialog"
 msgstr "Fortschrittsbalken"
 
-#: src/option.c:631
+#: src/option.c:633
 msgid "Add the progress bar (norm, rtl, pulse, cpulse or perm)"
 msgstr ""
 
-#: src/option.c:633
+#: src/option.c:635
 msgid "Watch for specific bar for auto close"
 msgstr ""
 
-#: src/option.c:635
+#: src/option.c:637
 msgid "Set alignment of bar labels (left, center or right)"
 msgstr ""
 
-#: src/option.c:637
+#: src/option.c:639
 msgid "Set progress text"
 msgstr "Text für Fortschrittsbalken angeben"
 
-#: src/option.c:639
+#: src/option.c:641
 #, fuzzy
 msgid "Hide text on progress bar"
 msgstr "Pulsierender Fortschrittsbalken"
 
-#: src/option.c:641
+#: src/option.c:643
 msgid "Pulsate progress bar"
 msgstr "Pulsierender Fortschrittsbalken"
 
-#: src/option.c:643
+#: src/option.c:645
 #, fuzzy
 msgid "Conlinuous pulsating progress bar"
 msgstr "Pulsierender Fortschrittsbalken"
 
-#: src/option.c:646
+#: src/option.c:648
 #, no-c-format
 msgid "Dismiss the dialog when 100% has been reached"
 msgstr "Dialog bei Erreichen von 100% beenden"
 
-#: src/option.c:649
+#: src/option.c:651
 msgid "Kill parent process if cancel button is pressed"
 msgstr "Hauptprozess bei Klick auf Abbrechen beenden"
 
-#: src/option.c:652
+#: src/option.c:654
 msgid "Right-To-Left progress bar direction"
 msgstr ""
 
-#: src/option.c:654
+#: src/option.c:656
 #, fuzzy
 msgid "Show log window"
 msgstr "Farb-Einstellungen anzeigen"
 
-#: src/option.c:656
+#: src/option.c:658
 msgid "Expand log window"
 msgstr ""
 
-#: src/option.c:658
+#: src/option.c:660
 #, fuzzy
 msgid "Place log window above progress bar"
 msgstr "Pulsierender Fortschrittsbalken"
 
-#: src/option.c:660
+#: src/option.c:662
 #, fuzzy
 msgid "Height of log window"
 msgstr "Farb-Einstellungen anzeigen"
 
-#: src/option.c:666
+#: src/option.c:668
 msgid "Display scale dialog"
 msgstr "Schieberegler"
 
-#: src/option.c:668
+#: src/option.c:670
 msgid "Set initial value"
 msgstr "Anfangswert angeben"
 
-#: src/option.c:668 src/option.c:670 src/option.c:672 src/option.c:674
-#: src/option.c:678 src/option.c:745 src/option.c:747
+#: src/option.c:670 src/option.c:672 src/option.c:674 src/option.c:676
+#: src/option.c:680 src/option.c:747 src/option.c:749
 msgid "VALUE"
 msgstr "WERT"
 
-#: src/option.c:670
+#: src/option.c:672
 msgid "Set minimum value"
 msgstr "Minimal-Wert angeben"
 
-#: src/option.c:672
+#: src/option.c:674
 msgid "Set maximum value"
 msgstr "Maximal-Wert angeben"
 
-#: src/option.c:674
+#: src/option.c:676
 msgid "Set step size"
 msgstr "Abstände angeben"
 
-#: src/option.c:676
+#: src/option.c:678
 msgid "Only allow values in step increments"
 msgstr ""
 
-#: src/option.c:678
+#: src/option.c:680
 #, fuzzy
 msgid "Set paging size"
 msgstr "Abstände angeben"
 
-#: src/option.c:680
+#: src/option.c:682
 msgid "Print partial values"
 msgstr "Teilwerte ausgeben"
 
-#: src/option.c:682
+#: src/option.c:684
 msgid "Hide value"
 msgstr "Wert verbergen"
 
-#: src/option.c:684
+#: src/option.c:686
 msgid "Invert direction"
 msgstr ""
 
-#: src/option.c:686
+#: src/option.c:688
 msgid "Show +/- buttons in scale"
 msgstr ""
 
-#: src/option.c:688
+#: src/option.c:690
 #, fuzzy
 msgid "Add mark to scale (may be used multiple times)"
 msgstr "Dialog-Schaltfläche hinzufügen (Auch mehrmals)"
 
-#: src/option.c:688
+#: src/option.c:690
 #, fuzzy
 msgid "NAME:VALUE"
 msgstr "WERT"
 
-#: src/option.c:694
+#: src/option.c:696
 msgid "Display text information dialog"
 msgstr "Textinformations-Dialog"
 
-#: src/option.c:696
+#: src/option.c:698
 #, fuzzy
 msgid "Enable text wrapping"
 msgstr "Textumbruch nicht aktivieren"
 
-#: src/option.c:698
+#: src/option.c:700
 msgid "Set justification (left, right, center or fill)"
 msgstr ""
 
-#: src/option.c:700
+#: src/option.c:702
 msgid "Set text margins"
 msgstr ""
 
-#: src/option.c:702
+#: src/option.c:704
 #, fuzzy
 msgid "Jump to specific line"
 msgstr "Bestimmte Spalte verbergen"
 
-#: src/option.c:704
+#: src/option.c:706
 #, fuzzy
 msgid "Use specified color for text"
 msgstr "Bestimmte Schriftart benutzen"
 
-#: src/option.c:706
+#: src/option.c:708
 #, fuzzy
 msgid "Use specified color for background"
 msgstr "Bestimmte Schriftart benutzen"
 
-#: src/option.c:708
+#: src/option.c:710
 msgid "Show cursor in read-only mode"
 msgstr ""
 
-#: src/option.c:710
+#: src/option.c:712
 msgid "Make URI clickable"
 msgstr ""
 
-#: src/option.c:712
+#: src/option.c:714
 #, fuzzy
 msgid "Use specified color for links"
 msgstr "Bestimmte Schriftart benutzen"
 
-#: src/option.c:714
+#: src/option.c:716
 msgid "Use pango markup"
 msgstr ""
 
-#: src/option.c:716
+#: src/option.c:718
 msgid "Save file instead of print on exit"
 msgstr ""
 
-#: src/option.c:718
+#: src/option.c:720
 msgid "Confirm save the file if text was changed"
-msgstr ""
-
-#: src/option.c:725
-#, fuzzy
-msgid "Use specified langauge for syntax highlighting"
-msgstr "Bestimmte Schriftart benutzen"
-
-#: src/option.c:725
-msgid "LANG"
 msgstr ""
 
 #: src/option.c:727
 #, fuzzy
+msgid "Use specified langauge for syntax highlighting"
+msgstr "Bestimmte Schriftart benutzen"
+
+#: src/option.c:727
+msgid "LANG"
+msgstr ""
+
+#: src/option.c:729
+#, fuzzy
 msgid "Use specified theme"
 msgstr "Bestimmte Schriftart benutzen"
 
-#: src/option.c:729
+#: src/option.c:731
 msgid "Show line numbers"
 msgstr ""
 
-#: src/option.c:731
+#: src/option.c:733
 msgid "Highlight current line"
 msgstr ""
 
-#: src/option.c:733
+#: src/option.c:735
 msgid "Enable line marks"
 msgstr ""
 
-#: src/option.c:735
+#: src/option.c:737
 msgid "Set color for first type marks"
 msgstr ""
 
-#: src/option.c:737
+#: src/option.c:739
 msgid "Set color for second type marks"
 msgstr ""
 
-#: src/option.c:739
+#: src/option.c:741
 msgid "Set position of right margin"
 msgstr ""
 
-#: src/option.c:739
+#: src/option.c:741
 msgid "[POS]"
 msgstr ""
 
-#: src/option.c:741
+#: src/option.c:743
 msgid "Highlight matching brackets"
 msgstr ""
 
-#: src/option.c:743
+#: src/option.c:745
 msgid "Use autoindent"
 msgstr ""
 
-#: src/option.c:745
+#: src/option.c:747
 #, fuzzy
 msgid "Set tabulation width"
 msgstr "Breite angeben"
 
-#: src/option.c:747
+#: src/option.c:749
 #, fuzzy
 msgid "Set indentation width"
 msgstr "Breite angeben"
 
-#: src/option.c:749
+#: src/option.c:751
 msgid "Set smart Home/End behavior"
 msgstr ""
 
-#: src/option.c:751
+#: src/option.c:753
 msgid "Enable smart backspace"
 msgstr ""
 
-#: src/option.c:753
+#: src/option.c:755
 msgid "Insert spaces instead of tabs"
 msgstr ""
 
-#: src/option.c:760
+#: src/option.c:762
 msgid "Sets a filename filter"
 msgstr "Dateinames-Filter angeben"
 
-#: src/option.c:760
+#: src/option.c:762
 msgid "NAME | PATTERN1 PATTERN2 ..."
 msgstr "NAME | MUSTER1 MUSTER2 ..."
 
-#: src/option.c:762
+#: src/option.c:764
 #, fuzzy
 msgid "Sets a mime-type filter"
 msgstr "Dateinames-Filter angeben"
 
-#: src/option.c:762
+#: src/option.c:764
 #, fuzzy
 msgid "NAME | MIME1 MIME2 ..."
 msgstr "NAME | MUSTER1 MUSTER2 ..."
 
-#: src/option.c:764
+#: src/option.c:766
 #, fuzzy
 msgid "Add filter for images"
 msgstr "Feld zu Formular hinzufügen"
 
-#: src/option.c:764
+#: src/option.c:766
 #, fuzzy
 msgid "[NAME]"
 msgstr "NAME:ID"
 
-#: src/option.c:770 src/tools.c:64
+#: src/option.c:772 src/tools.c:64
 msgid "Print version"
 msgstr "Version"
 
-#: src/option.c:772
+#: src/option.c:774
 msgid "Load additional CSS settings from file or string"
 msgstr ""
 
-#: src/option.c:775
+#: src/option.c:777
 msgid "Load additional CSS settings from file"
 msgstr ""
 
-#: src/option.c:778
+#: src/option.c:780
 msgid "Set policy for horizontal scrollbars (auto, always, never)"
 msgstr ""
 
-#: src/option.c:780
+#: src/option.c:782
 msgid "Set policy for vertical scrollbars (auto, always, never)"
 msgstr ""
 
-#: src/option.c:782
+#: src/option.c:784
 msgid "Add path for search icons by name"
 msgstr ""
 
-#: src/option.c:784
+#: src/option.c:786
 msgid "Write settings to file and exit"
 msgstr ""
 
-#: src/option.c:790
+#: src/option.c:792
 msgid "Load extra arguments from file"
 msgstr ""
 
-#: src/option.c:1001
+#: src/option.c:1003
 #, c-format
 msgid "Mark %s doesn't have a value\n"
 msgstr ""
 
-#: src/option.c:1048 src/picture.c:286
+#: src/option.c:1050 src/picture.c:286
 msgid "Images"
 msgstr ""
 
-#: src/option.c:1113
+#: src/option.c:1115
 #, fuzzy, c-format
 msgid "Unknown color mode: %s\n"
 msgstr "Befehl '%s' unbekannt\n"
 
-#: src/option.c:1132
+#: src/option.c:1134
 #, fuzzy, c-format
 msgid "Unknown buttons layout type: %s\n"
 msgstr "Befehl '%s' unbekannt\n"
 
-#: src/option.c:1147
+#: src/option.c:1149
 #, fuzzy, c-format
 msgid "Unknown align type: %s\n"
 msgstr "Befehl '%s' unbekannt\n"
 
-#: src/option.c:1171
+#: src/option.c:1173
 #, c-format
 msgid "Unknown justification type: %s\n"
 msgstr ""
 
-#: src/option.c:1188
+#: src/option.c:1190
 #, fuzzy, c-format
 msgid "Unknown tab position type: %s\n"
 msgstr "Befehl '%s' unbekannt\n"
 
-#: src/option.c:1225
+#: src/option.c:1227
 #, fuzzy, c-format
 msgid "Unknown ellipsize type: %s\n"
 msgstr "Befehl '%s' unbekannt\n"
 
-#: src/option.c:1238
+#: src/option.c:1240
 #, fuzzy, c-format
 msgid "Unknown orientation: %s\n"
 msgstr "Befehl '%s' unbekannt\n"
 
-#: src/option.c:1253
+#: src/option.c:1255
 #, fuzzy, c-format
 msgid "Unknown source type: %s\n"
 msgstr "Befehl '%s' unbekannt\n"
 
-#: src/option.c:1264
+#: src/option.c:1266
 #, fuzzy
 msgid "Progress log"
 msgstr "Fortschrittsbalken-Einstellungen"
 
-#: src/option.c:1277
+#: src/option.c:1279
 #, fuzzy, c-format
 msgid "Unknown size type: %s\n"
 msgstr "Befehl '%s' unbekannt\n"
 
-#: src/option.c:1321
+#: src/option.c:1323
 #, fuzzy, c-format
 msgid "Unknown completion type: %s\n"
 msgstr "Befehl '%s' unbekannt\n"
 
-#: src/option.c:1353
+#: src/option.c:1355
 #, fuzzy, c-format
 msgid "Unknown boolean format type: %s\n"
 msgstr "Befehl '%s' unbekannt\n"
 
-#: src/option.c:1369
+#: src/option.c:1371
 #, fuzzy, c-format
 msgid "Unknown grid lines type: %s\n"
 msgstr "Befehl '%s' unbekannt\n"
 
-#: src/option.c:1386
+#: src/option.c:1388
 #, fuzzy, c-format
 msgid "Unknown scrollbar policy type: %s\n"
 msgstr "Befehl '%s' unbekannt\n"
 
-#: src/option.c:1437
+#: src/option.c:1439
 #, fuzzy, c-format
 msgid "Unknown window type: %s\n"
 msgstr "Befehl '%s' unbekannt\n"
 
-#: src/option.c:1466
+#: src/option.c:1468
 #, fuzzy, c-format
 msgid "Unknown smart Home/End mode: %s\n"
 msgstr "Befehl '%s' unbekannt\n"
 
-#: src/option.c:1576
+#: src/option.c:1578
 #, fuzzy, c-format
 msgid "Unknown signal: %s\n"
 msgstr "Befehl '%s' unbekannt\n"
 
-#: src/option.c:1811
+#: src/option.c:1814
 msgid "File exist. Overwrite?"
 msgstr ""
 
-#: src/option.c:1953
+#: src/option.c:1956
 msgid "File was changed. Save it?"
 msgstr ""
 
-#: src/option.c:1984
+#: src/option.c:1987
 #, fuzzy
 msgid "- Yet another dialoging program"
 msgstr "Nur ein anderes Dialog-Programm"
 
-#: src/option.c:1988
+#: src/option.c:1991
 msgid "General options"
 msgstr "Allgemeine Einstellungen"
 
-#: src/option.c:1988
+#: src/option.c:1991
 msgid "Show general options"
 msgstr "Allgemeine Einstellungen anzeigen"
 
-#: src/option.c:1994
+#: src/option.c:1997
 #, fuzzy
 msgid "Common options"
 msgstr "Formular-Einstellungen"
 
-#: src/option.c:1994
+#: src/option.c:1997
 #, fuzzy
 msgid "Show common options"
 msgstr "Formular-Einstellungen anzeigen"
 
-#: src/option.c:2000
+#: src/option.c:2003
 #, fuzzy
 msgid "About dialog options"
 msgstr "Fortschrittsbalken-Einstellungen"
 
-#: src/option.c:2000
+#: src/option.c:2003
 #, fuzzy
 msgid "Show custom about dialog options"
 msgstr "Fortschrittsbalken-Einstellungen anzeigen"
 
-#: src/option.c:2006
+#: src/option.c:2009
 #, fuzzy
 msgid "Application selection options"
 msgstr "Dateiauswahl-Einstellungen"
 
-#: src/option.c:2006
+#: src/option.c:2009
 #, fuzzy
 msgid "Show application selection options"
 msgstr "Dateiauswahl-Einstellungen anzeigen"
 
-#: src/option.c:2012
+#: src/option.c:2015
 msgid "Calendar options"
 msgstr "Kalender-Einstellungen"
 
-#: src/option.c:2012
+#: src/option.c:2015
 msgid "Show calendar options"
 msgstr "Kalender-Einstellungen anzeigen"
 
-#: src/option.c:2018
+#: src/option.c:2021
 #, fuzzy
 msgid "Color selection options"
 msgstr "Dateiauswahl-Einstellungen"
 
-#: src/option.c:2018
+#: src/option.c:2021
 #, fuzzy
 msgid "Show color selection options"
 msgstr "Dateiauswahl-Einstellungen anzeigen"
 
-#: src/option.c:2024
+#: src/option.c:2027
 #, fuzzy
 msgid "DND options"
 msgstr "Formular-Einstellungen"
 
-#: src/option.c:2024
+#: src/option.c:2027
 #, fuzzy
 msgid "Show drag-n-drop options"
 msgstr "Kalender-Einstellungen anzeigen"
 
-#: src/option.c:2030
+#: src/option.c:2033
 msgid "Text entry options"
 msgstr "Textfeld-Einstellungen"
 
-#: src/option.c:2030
+#: src/option.c:2033
 msgid "Show text entry options"
 msgstr "Textfeld-Einstellungen anzeigen"
 
-#: src/option.c:2036
+#: src/option.c:2039
 msgid "File selection options"
 msgstr "Dateiauswahl-Einstellungen"
 
-#: src/option.c:2036
+#: src/option.c:2039
 msgid "Show file selection options"
 msgstr "Dateiauswahl-Einstellungen anzeigen"
 
-#: src/option.c:2042
+#: src/option.c:2045
 #, fuzzy
 msgid "Font selection options"
 msgstr "Dateiauswahl-Einstellungen"
 
-#: src/option.c:2042
+#: src/option.c:2045
 #, fuzzy
 msgid "Show font selection options"
 msgstr "Dateiauswahl-Einstellungen anzeigen"
 
-#: src/option.c:2048
+#: src/option.c:2051
 msgid "Form options"
 msgstr "Formular-Einstellungen"
 
-#: src/option.c:2048
+#: src/option.c:2051
 msgid "Show form options"
 msgstr "Formular-Einstellungen anzeigen"
 
-#: src/option.c:2055
+#: src/option.c:2058
 #, fuzzy
 msgid "HTML options"
 msgstr "Listen-Einstellungen"
 
-#: src/option.c:2055
+#: src/option.c:2058
 #, fuzzy
 msgid "Show HTML options"
 msgstr "Formular-Einstellungen anzeigen"
 
-#: src/option.c:2062
+#: src/option.c:2065
 #, fuzzy
 msgid "Icons box options"
 msgstr "Farb-Einstellungen"
 
-#: src/option.c:2062
+#: src/option.c:2065
 #, fuzzy
 msgid "Show icons box options"
 msgstr "Farb-Einstellungen anzeigen"
 
-#: src/option.c:2068
+#: src/option.c:2071
 msgid "List options"
 msgstr "Listen-Einstellungen"
 
-#: src/option.c:2068
+#: src/option.c:2071
 msgid "Show list options"
 msgstr "Listen-Einstellungen anzeigen"
 
-#: src/option.c:2074
+#: src/option.c:2077
 #, fuzzy
 msgid "Notebook options"
 msgstr "Farb-Einstellungen"
 
-#: src/option.c:2074
+#: src/option.c:2077
 #, fuzzy
 msgid "Show notebook dialog options"
 msgstr "Fortschrittsbalken-Einstellungen anzeigen"
 
-#: src/option.c:2081
+#: src/option.c:2084
 msgid "Notification icon options"
 msgstr "Benachrichtigungssymbol-Einstellungen"
 
-#: src/option.c:2082
+#: src/option.c:2085
 msgid "Show notification icon options"
 msgstr "Benachrichtigungssymbol-Einstellungen"
 
-#: src/option.c:2090
+#: src/option.c:2093
 #, fuzzy
 msgid "StatusNotifier/AppIndicator options"
 msgstr "Benachrichtigungssymbol-Einstellungen"
 
-#: src/option.c:2091
+#: src/option.c:2094
 #, fuzzy
 msgid "Show indicator options"
 msgstr "Fortschrittsbalken-Einstellungen anzeigen"
 
-#: src/option.c:2098
+#: src/option.c:2101
 #, fuzzy
 msgid "Paned dialog options"
 msgstr "Fortschrittsbalken-Einstellungen"
 
-#: src/option.c:2098
+#: src/option.c:2101
 #, fuzzy
 msgid "Show paned dialog options"
 msgstr "Fortschrittsbalken-Einstellungen anzeigen"
 
-#: src/option.c:2104
+#: src/option.c:2107
 #, fuzzy
 msgid "Picture dialog options"
 msgstr "Fortschrittsbalken-Einstellungen"
 
-#: src/option.c:2104
+#: src/option.c:2107
 #, fuzzy
 msgid "Show picture dialog options"
 msgstr "Fortschrittsbalken-Einstellungen anzeigen"
 
-#: src/option.c:2110
+#: src/option.c:2113
 #, fuzzy
 msgid "Popup dialog options"
 msgstr "Fortschrittsbalken-Einstellungen"
 
-#: src/option.c:2110
+#: src/option.c:2113
 #, fuzzy
 msgid "Show popup dialog options"
 msgstr "Fortschrittsbalken-Einstellungen anzeigen"
 
-#: src/option.c:2116
+#: src/option.c:2119
 #, fuzzy
 msgid "Print dialog options"
 msgstr "Fortschrittsbalken-Einstellungen"
 
-#: src/option.c:2116
+#: src/option.c:2119
 #, fuzzy
 msgid "Show print dialog options"
 msgstr "Fortschrittsbalken-Einstellungen anzeigen"
 
-#: src/option.c:2122
+#: src/option.c:2125
 msgid "Progress options"
 msgstr "Fortschrittsbalken-Einstellungen"
 
-#: src/option.c:2122
+#: src/option.c:2125
 msgid "Show progress options"
 msgstr "Fortschrittsbalken-Einstellungen anzeigen"
 
-#: src/option.c:2128
+#: src/option.c:2131
 msgid "Scale options"
 msgstr "Schieberegler-Einstellungen"
 
-#: src/option.c:2128
+#: src/option.c:2131
 msgid "Show scale options"
 msgstr "Schieberegler-Einstellungen anzeigen"
 
-#: src/option.c:2134
+#: src/option.c:2137
 msgid "Text information options"
 msgstr "Informationstext-Einstellungen"
 
-#: src/option.c:2134
+#: src/option.c:2137
 msgid "Show text information options"
 msgstr "Informationstext-Einstellungen anzeigen"
 
-#: src/option.c:2141
+#: src/option.c:2144
 #, fuzzy
 msgid "SourceView options"
 msgstr "Schieberegler-Einstellungen"
 
-#: src/option.c:2141
+#: src/option.c:2144
 #, fuzzy
 msgid "Show SourceView options"
 msgstr "Formular-Einstellungen anzeigen"
 
-#: src/option.c:2148
+#: src/option.c:2151
 #, fuzzy
 msgid "File filter options"
 msgstr "Dateiauswahl-Einstellungen"
 
-#: src/option.c:2148
+#: src/option.c:2151
 #, fuzzy
 msgid "Show file filter options"
 msgstr "Dateiauswahl-Einstellungen anzeigen"
 
-#: src/option.c:2154
+#: src/option.c:2157
 msgid "Miscellaneous options"
 msgstr "Verschiedene Einstellungen"
 
-#: src/option.c:2154
+#: src/option.c:2157
 msgid "Show miscellaneous options"
 msgstr "Verschiedene Einstellungen anzeigen"
 
@@ -2553,7 +2563,7 @@ msgstr ""
 msgid "Insert spaces instead of tabulation:CHK"
 msgstr ""
 
-#: src/yad-settings.sh:113 data/yad-settings.desktop.in:3
+#: src/yad-settings.sh:113 data/yad-settings.desktop.in:4
 msgid "YAD settings"
 msgstr ""
 
@@ -2573,15 +2583,15 @@ msgstr ""
 msgid "Editor"
 msgstr ""
 
-#: data/yad-icon-browser.desktop.in:3
+#: data/yad-icon-browser.desktop.in:4
 msgid "Icon Browser"
 msgstr ""
 
-#: data/yad-icon-browser.desktop.in:4
+#: data/yad-icon-browser.desktop.in:5
 msgid "Inspect GTK Icon Theme"
 msgstr ""
 
-#: data/yad-settings.desktop.in:4
+#: data/yad-settings.desktop.in:5
 msgid "Simple GUI for editing YAD settings"
 msgstr ""
 
@@ -2607,11 +2617,11 @@ msgstr ""
 #~ "Veröffentlichung dieses Programms erfolgt in der Hoffnung, dass es Ihnen "
 #~ "von Nutzen sein wird, aber OHNE IRGENDEINE GARANTIE, sogar ohne die "
 #~ "implizite Garantie der MARKTREIFE oder der VERWENDBARKEIT FÜR EINEN "
-#~ "BESTIMMTEN ZWECK. Details finden Sie in der GNU General Public "
-#~ "License.Sie sollten eine Kopie der GNU General Public License zusammen "
-#~ "mit diesem Programm erhalten haben. Falls nicht, schreiben Sie an die "
-#~ "Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, "
-#~ "MA 02110-1301 USA. "
+#~ "BESTIMMTEN ZWECK. Details finden Sie in der GNU General Public License."
+#~ "Sie sollten eine Kopie der GNU General Public License zusammen mit diesem "
+#~ "Programm erhalten haben. Falls nicht, schreiben Sie an die Free Software "
+#~ "Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 "
+#~ "USA. "
 
 #~ msgid "Add separator between dialog and buttons"
 #~ msgstr "Leerraum zwischen Dialog und Schaltflächen"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YAD\n"
 "Report-Msgid-Bugs-To: victor@sanana.kiev.ua\n"
-"POT-Creation-Date: 2026-06-30 16:06+0300\n"
+"POT-Creation-Date: 2026-07-06 22:04-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Guesst <guesst@gmail.com>\n"
 "Language-Team: Spanish\n"
@@ -91,15 +91,15 @@ msgstr "Seleccione o cree la carpeta"
 msgid "Select date"
 msgstr "Seleccione la fecha"
 
-#: src/form.c:1047
+#: src/form.c:1055
 msgid "Select file"
 msgstr "Seleccione el archivo"
 
-#: src/form.c:1077
+#: src/form.c:1085
 msgid "Select folder"
 msgstr "Seleccione la carpeta"
 
-#: src/form.c:1245 src/form.c:1247
+#: src/form.c:1253 src/form.c:1255
 msgid "Link"
 msgstr ""
 
@@ -140,35 +140,35 @@ msgstr "No se puede abrir la carpeta %s: %s\n"
 msgid "%d sec"
 msgstr "%d sec"
 
-#: src/main.c:748 src/main.c:755
+#: src/main.c:764 src/main.c:771
 #, fuzzy, c-format
 msgid "Unable to parse YAD_OPTIONS: %s\n"
 msgstr "No se puede analizar el archivo %s: %s\n"
 
-#: src/main.c:766
+#: src/main.c:782
 #, c-format
 msgid "Unable to parse command line: %s\n"
 msgstr "No se puede ejecutar la línea de comando %s\n"
 
-#: src/main.c:780
+#: src/main.c:796
 msgid ""
 "WARNING: Using splash option is deprecated, please use --window-type instead"
 msgstr ""
 
-#: src/main.c:790
+#: src/main.c:806
 #, fuzzy, c-format
 msgid "Unable to change directory to %s: %s\n"
 msgstr "No se puede abrir la carpeta %s: %s\n"
 
-#: src/main.c:819
+#: src/main.c:835
 msgid "WARNING: Using gtkrc option is deprecated, please use --css instead\n"
 msgstr ""
 
-#: src/main.c:893
+#: src/main.c:909
 msgid "WARNING: --plug mode not supported outside X11\n"
 msgstr ""
 
-#: src/main.c:913
+#: src/main.c:929
 msgid "WARNING: This mode not supported outside X11\n"
 msgstr ""
 
@@ -269,12 +269,12 @@ msgstr "ALTO"
 msgid "Set the X position of a window"
 msgstr ""
 
-#: src/option.c:106 src/option.c:108 src/option.c:118 src/option.c:140
-#: src/option.c:144 src/option.c:189 src/option.c:203 src/option.c:342
-#: src/option.c:400 src/option.c:406 src/option.c:487 src/option.c:495
-#: src/option.c:497 src/option.c:499 src/option.c:501 src/option.c:503
-#: src/option.c:505 src/option.c:509 src/option.c:543 src/option.c:545
-#: src/option.c:599 src/option.c:633 src/option.c:702
+#: src/option.c:106 src/option.c:108 src/option.c:118 src/option.c:142
+#: src/option.c:146 src/option.c:191 src/option.c:205 src/option.c:344
+#: src/option.c:402 src/option.c:408 src/option.c:489 src/option.c:497
+#: src/option.c:499 src/option.c:501 src/option.c:503 src/option.c:505
+#: src/option.c:507 src/option.c:511 src/option.c:545 src/option.c:547
+#: src/option.c:601 src/option.c:635 src/option.c:704
 msgid "NUMBER"
 msgstr "NUMERO"
 
@@ -303,7 +303,7 @@ msgid "Show remaining time indicator (top, bottom, left, right)"
 msgstr ""
 "Mostrar indicador de tiempo restante (arriba, abajo, izquierda, derecha)"
 
-#: src/option.c:114 src/option.c:587
+#: src/option.c:114 src/option.c:589
 msgid "POS"
 msgstr "POS"
 
@@ -311,8 +311,8 @@ msgstr "POS"
 msgid "Set the dialog text"
 msgstr "Configurar el texto del diálogo"
 
-#: src/option.c:116 src/option.c:273 src/option.c:275 src/option.c:350
-#: src/option.c:352 src/option.c:386 src/option.c:507 src/option.c:637
+#: src/option.c:116 src/option.c:275 src/option.c:277 src/option.c:352
+#: src/option.c:354 src/option.c:388 src/option.c:509 src/option.c:639
 msgid "TEXT"
 msgstr "TEXTO"
 
@@ -328,11 +328,11 @@ msgstr ""
 "Configurar el alineado de texto del diálogo(izquierda, centrado, derecha, "
 "justificado)"
 
-#: src/option.c:120 src/option.c:132 src/option.c:185 src/option.c:235
-#: src/option.c:241 src/option.c:243 src/option.c:398 src/option.c:481
-#: src/option.c:491 src/option.c:541 src/option.c:585 src/option.c:597
-#: src/option.c:609 src/option.c:621 src/option.c:635 src/option.c:698
-#: src/option.c:749 src/option.c:778 src/option.c:780 src/tools.c:86
+#: src/option.c:120 src/option.c:132 src/option.c:187 src/option.c:237
+#: src/option.c:243 src/option.c:245 src/option.c:400 src/option.c:483
+#: src/option.c:493 src/option.c:543 src/option.c:587 src/option.c:599
+#: src/option.c:611 src/option.c:623 src/option.c:637 src/option.c:700
+#: src/option.c:751 src/option.c:780 src/option.c:782 src/tools.c:86
 msgid "TYPE"
 msgstr "TIPO"
 
@@ -340,7 +340,7 @@ msgstr "TIPO"
 msgid "Set the dialog image"
 msgstr "Configurar la imágen del diálogo"
 
-#: src/option.c:122 src/option.c:360 src/option.c:364
+#: src/option.c:122 src/option.c:362 src/option.c:366
 msgid "IMAGE"
 msgstr "IMAGEN"
 
@@ -348,7 +348,7 @@ msgstr "IMAGEN"
 msgid "Use specified icon theme instead of default"
 msgstr "Utilizar un tema de íconos específico en lugar del predeterminado"
 
-#: src/option.c:124 src/option.c:727 src/browser.c:220 src/tools.c:87
+#: src/option.c:124 src/option.c:729 src/browser.c:220 src/tools.c:87
 msgid "THEME"
 msgstr "TEMA"
 
@@ -356,7 +356,7 @@ msgstr "TEMA"
 msgid "Hide main widget with expander"
 msgstr "Esconder el widget principal con el expansor"
 
-#: src/option.c:126 src/option.c:378 src/option.c:654 src/option.c:718
+#: src/option.c:126 src/option.c:380 src/option.c:656 src/option.c:720
 msgid "[TEXT]"
 msgstr "[TEXTO]"
 
@@ -378,664 +378,674 @@ msgstr ""
 "Configurar el diseño del boton (distribuido, borde, inicio, fin o centro)"
 
 #: src/option.c:134
+#, fuzzy
+msgid "Set focus to the named button when dialog opens"
+msgstr "Mostrar opciones del diálogo libro de notas"
+
+#: src/option.c:134
+#, fuzzy
+msgid "NAME"
+msgstr "NOMBRE:ID"
+
+#: src/option.c:136
 msgid "Don't use pango markup language in dialog's text"
 msgstr "No usar el lenguaje de formato pango en los textos de diálogo"
 
-#: src/option.c:136
+#: src/option.c:138
 msgid "Don't close dialog if Escape was pressed"
 msgstr ""
 
-#: src/option.c:138
+#: src/option.c:140
 msgid "Escape acts like OK button"
 msgstr ""
 
-#: src/option.c:140
+#: src/option.c:142
 msgid "Set window borders"
 msgstr "Configurar bordes de ventana"
 
-#: src/option.c:142
+#: src/option.c:144
 msgid "Always print result"
 msgstr "Siempre imprimir resultado"
 
-#: src/option.c:144
+#: src/option.c:146
 #, fuzzy
 msgid "Set default return code"
 msgstr "Configurar el formato para la fecha obtenida"
 
-#: src/option.c:146
+#: src/option.c:148
 msgid "Dialog text can be selected"
 msgstr "El texto de los diálogos puede ser seleccionado"
 
-#: src/option.c:148
+#: src/option.c:150
 #, fuzzy
 msgid "Don't scale icons"
 msgstr "Mostrar opciones de escala"
 
-#: src/option.c:150
+#: src/option.c:152
 #, c-format
 msgid "Run commands under specified interpreter (default: bash -c '%s')"
 msgstr ""
 
-#: src/option.c:150 src/option.c:152 src/option.c:154 src/option.c:205
-#: src/option.c:312 src/option.c:362 src/option.c:366 src/option.c:412
-#: src/option.c:511 src/option.c:513 src/option.c:515 src/option.c:601
+#: src/option.c:152 src/option.c:154 src/option.c:156 src/option.c:207
+#: src/option.c:314 src/option.c:364 src/option.c:368 src/option.c:414
+#: src/option.c:513 src/option.c:515 src/option.c:517 src/option.c:603
 msgid "CMD"
 msgstr "CMD"
 
-#: src/option.c:152
+#: src/option.c:154
 msgid "Set URI handler"
 msgstr ""
 
-#: src/option.c:154
+#: src/option.c:156
 msgid "Set command running when F1 was pressed"
 msgstr ""
 
-#: src/option.c:156
+#: src/option.c:158
 #, fuzzy
 msgid "Set working directory"
 msgstr "Configurar la ventana sin decoraciones"
 
-#: src/option.c:156 src/option.c:782
+#: src/option.c:158 src/option.c:784
 #, fuzzy
 msgid "PATH"
 msgstr "ICONPATH"
 
-#: src/option.c:159
+#: src/option.c:161
 msgid "Set window sticky"
 msgstr "Configurar ventanas pegajosas"
 
-#: src/option.c:161
+#: src/option.c:163
 msgid "Set window unresizable"
 msgstr "Configurar la ventana como no redimensionable"
 
-#: src/option.c:163
+#: src/option.c:165
 msgid "Place window on top"
 msgstr "Colocar la ventana al frente"
 
-#: src/option.c:165
+#: src/option.c:167
 msgid "Place window on center of screen"
 msgstr "Colocar la ventana al centro de la pantalla"
 
-#: src/option.c:167
+#: src/option.c:169
 msgid "Place window at the mouse position"
 msgstr "Colocar la ventana en la posición del mouse"
 
-#: src/option.c:169
+#: src/option.c:171
 msgid "Set window undecorated"
 msgstr "Configurar la ventana sin decoraciones"
 
-#: src/option.c:171
+#: src/option.c:173
 msgid "Don't show window in taskbar"
 msgstr "No mostrar la ventana en la barra de tareas"
 
-#: src/option.c:173
+#: src/option.c:175
 #, fuzzy
 msgid "Set window maximized"
 msgstr "Configurar la ventana maximizada"
 
-#: src/option.c:175
+#: src/option.c:177
 #, fuzzy
 msgid "Set window fullscreen"
 msgstr "Configurar la ventana como pantalla completa"
 
-#: src/option.c:177
+#: src/option.c:179
 #, fuzzy
 msgid "Don't focus dialog window"
 msgstr "Alto de la ventana de log"
 
-#: src/option.c:179
+#: src/option.c:181
 msgid "Close window when it sets unfocused"
 msgstr ""
 
-#: src/option.c:182
+#: src/option.c:184
 msgid "Open window as a splashscreen (Deprecated, see man page for details)"
 msgstr ""
 
-#: src/option.c:185
+#: src/option.c:187
 msgid "Specify the window type for the dialog"
 msgstr ""
 
-#: src/option.c:187
+#: src/option.c:189
 msgid "Special type of dialog for XEMBED"
 msgstr "Tipo speciale di finestra di dialogo per XEMBED"
 
-#: src/option.c:187 src/option.c:239
+#: src/option.c:189 src/option.c:241
 msgid "KEY"
 msgstr "LLAVE"
 
-#: src/option.c:189
+#: src/option.c:191
 #, fuzzy
 msgid "Tab number of this dialog"
 msgstr "Número de pestaña de este diálogo"
 
-#: src/option.c:192
+#: src/option.c:194
 msgid "Send SIGNAL to parent"
 msgstr "Enviar SIGNAL al padre"
 
-#: src/option.c:192
+#: src/option.c:194
 #, fuzzy
 msgid "[SIGNAL]"
 msgstr "SIGNAL"
 
-#: src/option.c:194
+#: src/option.c:196
 #, fuzzy
 msgid "Print X Window Id to the file/stderr"
 msgstr "Imprimir el Id del X Window a stderr"
 
-#: src/option.c:194 src/option.c:324
+#: src/option.c:196 src/option.c:326
 #, fuzzy
 msgid "[FILENAME]"
 msgstr "FILENAME"
 
-#: src/option.c:201
+#: src/option.c:203
 msgid "Set the format for the returned date"
 msgstr "Configurar el formato para la fecha obtenida"
 
-#: src/option.c:201 src/option.c:453
+#: src/option.c:203 src/option.c:455
 msgid "PATTERN"
 msgstr "PATRON"
 
-#: src/option.c:203
+#: src/option.c:205
 msgid "Set presicion of floating numbers (default - 3)"
 msgstr ""
 
-#: src/option.c:205
+#: src/option.c:207
 msgid "Set command handler"
 msgstr ""
 
-#: src/option.c:207
+#: src/option.c:209
 #, fuzzy
 msgid "Listen for data on stdin"
 msgstr "Esperar por comandos por stdin"
 
-#: src/option.c:209
+#: src/option.c:211
 #, fuzzy
 msgid "Set common separator character"
 msgstr "Configurar caracter separador de la salida"
 
-#: src/option.c:209 src/option.c:211
+#: src/option.c:211 src/option.c:213
 msgid "SEPARATOR"
 msgstr "SEPARADOR"
 
-#: src/option.c:211
+#: src/option.c:213
 #, fuzzy
 msgid "Set item separator character"
 msgstr "Configurar caracter separador de la salida"
 
-#: src/option.c:213
+#: src/option.c:215
 #, fuzzy
 msgid "Allow changes to text in some cases"
 msgstr "Permitir cambios de texto en la caja-combo"
 
-#: src/option.c:215
-msgid "Autoscroll to end of text"
-msgstr "Scroll automático hasta el final del texto"
-
 #: src/option.c:217
-#, fuzzy
-msgid "Autoscroll to end of text (alias to tail)"
+msgid "Autoscroll to end of text"
 msgstr "Scroll automático hasta el final del texto"
 
 #: src/option.c:219
 #, fuzzy
+msgid "Autoscroll to end of text (alias to tail)"
+msgstr "Scroll automático hasta el final del texto"
+
+#: src/option.c:221
+#, fuzzy
 msgid "Quote dialogs output"
 msgstr "Citar la salida de los diálogos"
 
-#: src/option.c:221
+#: src/option.c:223
 #, fuzzy
 msgid "Output number instead of text for combo-box"
 msgstr "Usar completado en lugar de caja-combo"
 
-#: src/option.c:223
+#: src/option.c:225
 msgid "Specify font name to use"
 msgstr ""
 
-#: src/option.c:223
+#: src/option.c:225
 msgid "FONTNAME"
 msgstr "NOMBREDEFUENTE"
 
-#: src/option.c:225
+#: src/option.c:227
 #, fuzzy
 msgid "Allow multiple selection"
 msgstr "Permitir la selección múltiple de filas"
 
-#: src/option.c:227
-msgid "Enable preview"
-msgstr "Habilitar vista previa"
-
 #: src/option.c:229
-#, fuzzy
-msgid "Use large preview"
+msgid "Enable preview"
 msgstr "Habilitar vista previa"
 
 #: src/option.c:231
 #, fuzzy
+msgid "Use large preview"
+msgstr "Habilitar vista previa"
+
+#: src/option.c:233
+#, fuzzy
 msgid "Show hidden files in file selection dialogs"
 msgstr "Mostrar el diálogo de selección de archivo"
 
-#: src/option.c:233
+#: src/option.c:235
 #, fuzzy
 msgid "Set source filename"
 msgstr "Nombre del archivo fuente"
 
-#: src/option.c:233 src/option.c:308 src/option.c:775 src/option.c:790
+#: src/option.c:235 src/option.c:310 src/option.c:777 src/option.c:792
 msgid "FILENAME"
 msgstr "FILENAME"
 
-#: src/option.c:235
+#: src/option.c:237
 msgid "Set mime type of input data"
 msgstr ""
 
-#: src/option.c:237
+#: src/option.c:239
 #, fuzzy
 msgid "Set vertical orientation"
 msgstr "Configurar la acción del clic izquierdo"
 
-#: src/option.c:239
+#: src/option.c:241
 msgid "Identifier of embedded dialogs"
 msgstr "Identificador de diálogos integrados"
 
-#: src/option.c:241
+#: src/option.c:243
 msgid "Set extended completion for entries (any, all, or regex)"
 msgstr ""
 
-#: src/option.c:243
+#: src/option.c:245
 msgid "Set type of output for boolean values (T, t, Y, y, O, o, 1)"
 msgstr ""
 
-#: src/option.c:245
+#: src/option.c:247
 #, fuzzy
 msgid "Make main widget scrollable"
 msgstr "Habilitar scroll en el formulario"
 
-#: src/option.c:247
+#: src/option.c:249
 msgid "Disable search in text and html dialogs"
 msgstr ""
 
-#: src/option.c:249
+#: src/option.c:251
 #, fuzzy
 msgid "Enable file operations"
 msgstr "Opciones de escala"
 
-#: src/option.c:252
+#: src/option.c:254
 msgid "Use IEC (base 1024) units with for size values"
 msgstr ""
 
-#: src/option.c:256
+#: src/option.c:258
 #, fuzzy
 msgid "Enable spell check for text"
 msgstr "Usar un color de texto específico"
 
-#: src/option.c:258
+#: src/option.c:260
 msgid "Set spell checking language"
 msgstr ""
 
-#: src/option.c:258
+#: src/option.c:260
 msgid "LANGUAGE"
 msgstr ""
 
-#: src/option.c:265
+#: src/option.c:267
 #, fuzzy
 msgid "Display about dialog"
 msgstr "Mostrar diálogo de lista"
 
-#: src/option.c:267
+#: src/option.c:269
 msgid "Set application name"
 msgstr ""
 
-#: src/option.c:267 src/option.c:269 src/option.c:271 src/option.c:281
-#: src/option.c:429 src/option.c:431 src/option.c:529 src/option.c:531
-#: src/option.c:558 src/option.c:574 src/option.c:772
+#: src/option.c:269 src/option.c:271 src/option.c:273 src/option.c:283
+#: src/option.c:431 src/option.c:433 src/option.c:531 src/option.c:533
+#: src/option.c:560 src/option.c:576 src/option.c:774
 msgid "STRING"
 msgstr "STRING"
 
-#: src/option.c:269
+#: src/option.c:271
 msgid "Set application version"
 msgstr ""
 
-#: src/option.c:271
+#: src/option.c:273
 msgid "Set application copyright string"
 msgstr ""
 
-#: src/option.c:273
+#: src/option.c:275
 msgid "Set application comments string"
 msgstr ""
 
-#: src/option.c:275
+#: src/option.c:277
 msgid "Set application license"
 msgstr ""
 
-#: src/option.c:277
+#: src/option.c:279
 msgid "Set application authors"
 msgstr ""
 
-#: src/option.c:277 src/option.c:485 src/option.c:489 src/option.c:493
+#: src/option.c:279 src/option.c:487 src/option.c:491 src/option.c:495
 msgid "LIST"
 msgstr ""
 
-#: src/option.c:279
+#: src/option.c:281
 #, fuzzy
 msgid "Set application website"
 msgstr "Configurar tamaño de paginación"
 
-#: src/option.c:279
+#: src/option.c:281
 msgid "URI"
 msgstr ""
 
-#: src/option.c:281
+#: src/option.c:283
 msgid "Set application website label"
 msgstr ""
 
-#: src/option.c:287
+#: src/option.c:289
 #, fuzzy
 msgid "Display application selection dialog"
 msgstr "Mostrar el diálogo de selección de fuente"
 
-#: src/option.c:289
+#: src/option.c:291
 #, fuzzy
 msgid "Show fallback applications"
 msgstr "Mostrar opciones de calendario"
 
-#: src/option.c:291
+#: src/option.c:293
 #, fuzzy
 msgid "Show other applications"
 msgstr "Mostrar opciones de formulario"
 
-#: src/option.c:293
+#: src/option.c:295
 #, fuzzy
 msgid "Show all applications"
 msgstr "Mostrar opciones de escala"
 
-#: src/option.c:295
+#: src/option.c:297
 msgid "Output all application data"
 msgstr ""
 
-#: src/option.c:300
+#: src/option.c:302
 msgid "Display calendar dialog"
 msgstr "Desplegar diálogo del calendario"
 
-#: src/option.c:302
+#: src/option.c:304
 msgid "Set the calendar day"
 msgstr "Configurar el día del calendario"
 
-#: src/option.c:302
+#: src/option.c:304
 msgid "DAY"
 msgstr "DIA"
 
-#: src/option.c:304
+#: src/option.c:306
 msgid "Set the calendar month"
 msgstr "Configurar el mes del calendario"
 
-#: src/option.c:304
+#: src/option.c:306
 msgid "MONTH"
 msgstr "MES"
 
-#: src/option.c:306
+#: src/option.c:308
 msgid "Set the calendar year"
 msgstr "Configurar el año del calendario"
 
-#: src/option.c:306
+#: src/option.c:308
 msgid "YEAR"
 msgstr "ANO"
 
-#: src/option.c:308
+#: src/option.c:310
 msgid "Set the filename with dates details"
 msgstr "Configurar el archivo con detalles de las fechas"
 
-#: src/option.c:310
+#: src/option.c:312
 msgid "Show week numbers at the left side of calendar"
 msgstr ""
 
-#: src/option.c:312 src/option.c:513
+#: src/option.c:314 src/option.c:515
 #, fuzzy
 msgid "Set select action"
 msgstr "Configurar la acción del clic izquierdo"
 
-#: src/option.c:318
+#: src/option.c:320
 msgid "Display color selection dialog"
 msgstr "Mostrar el diálogo de selección de color"
 
-#: src/option.c:320
+#: src/option.c:322
 msgid "Set initial color value"
 msgstr "Configurar el valor del color inicial"
 
-#: src/option.c:320 src/option.c:704 src/option.c:706 src/option.c:712
-#: src/option.c:735 src/option.c:737
+#: src/option.c:322 src/option.c:706 src/option.c:708 src/option.c:714
+#: src/option.c:737 src/option.c:739
 msgid "COLOR"
 msgstr "COLOR"
 
-#: src/option.c:322
+#: src/option.c:324
 msgid "Show system palette in color dialog"
 msgstr ""
 
-#: src/option.c:324
+#: src/option.c:326
 msgid "Set path to palette file. Default - "
 msgstr "Configurar la ruta al archivo de paleta. Predeterminado -"
 
-#: src/option.c:326
+#: src/option.c:328
 msgid "Expand user palette"
 msgstr ""
 
-#: src/option.c:328
+#: src/option.c:330
 msgid "Show color picker"
 msgstr ""
 
-#: src/option.c:330
+#: src/option.c:332
 msgid "Set output mode to MODE. Values are hex (default) or rgb"
 msgstr ""
 
-#: src/option.c:330
+#: src/option.c:332
 msgid "MODE"
 msgstr ""
 
-#: src/option.c:332
+#: src/option.c:334
 msgid "Add opacity to output color value"
 msgstr ""
 
-#: src/option.c:338
+#: src/option.c:340
 msgid "Display drag-n-drop box"
 msgstr "Mostrar la caja arrastrar-y-soltar"
 
-#: src/option.c:340
+#: src/option.c:342
 msgid "Use dialog text as tooltip"
 msgstr "Usar el texto del diálogo como tooltip"
 
-#: src/option.c:342
+#: src/option.c:344
 msgid "Exit after NUMBER of drops"
 msgstr ""
 
-#: src/option.c:348
+#: src/option.c:350
 msgid "Display text entry or combo-box dialog"
 msgstr "Mostrar entrada de texto o diálogo de caja-combo"
 
-#: src/option.c:350
+#: src/option.c:352
 msgid "Set the entry label"
 msgstr "Configurar la etiqueta de la entrada"
 
-#: src/option.c:352
+#: src/option.c:354
 msgid "Set the entry text"
 msgstr "Configurar el texto de la entrada"
 
-#: src/option.c:354
+#: src/option.c:356
 msgid "Hide the entry text"
 msgstr "Ocultar el texto de la entrada"
 
-#: src/option.c:356
+#: src/option.c:358
 msgid "Use completion instead of combo-box"
 msgstr "Usar completado en lugar de caja-combo"
 
-#: src/option.c:358
+#: src/option.c:360
 msgid "Use spin button for text entry"
 msgstr "Usar botón spin para entrada de texto"
 
-#: src/option.c:360
+#: src/option.c:362
 msgid "Set the left entry icon"
 msgstr "Configurar el ícono de la entrada izquierda"
 
-#: src/option.c:362
+#: src/option.c:364
 msgid "Set the left entry icon action"
 msgstr "Configurar la acción del ícono de la entrada izquierda"
 
-#: src/option.c:364
+#: src/option.c:366
 msgid "Set the right entry icon"
 msgstr "Configurar el ícono de la entrada derecha"
 
-#: src/option.c:366
+#: src/option.c:368
 msgid "Set the right entry icon action"
 msgstr "Configurar la acción del ícono de la entrada derecha"
 
-#: src/option.c:372
+#: src/option.c:374
 msgid "Display file selection dialog"
 msgstr "Mostrar el diálogo de selección de archivo"
 
-#: src/option.c:374
+#: src/option.c:376
 msgid "Activate directory-only selection"
 msgstr "Activar selección únicamente de carpeta"
 
-#: src/option.c:376
+#: src/option.c:378
 msgid "Activate save mode"
 msgstr "Activar modo guardar"
 
-#: src/option.c:378
+#: src/option.c:380
 msgid "Confirm file selection if filename already exists"
 msgstr "Confirmar selección del archivo si el nombre de archivo ya existe"
 
-#: src/option.c:384
+#: src/option.c:386
 msgid "Display font selection dialog"
 msgstr "Mostrar el diálogo de selección de fuente"
 
-#: src/option.c:386
+#: src/option.c:388
 msgid "Set text string for preview"
 msgstr ""
 
-#: src/option.c:388
+#: src/option.c:390
 msgid "Separate output of font description"
 msgstr ""
 
-#: src/option.c:394
+#: src/option.c:396
 msgid "Display form dialog"
 msgstr "Mostrar diálogo de formulario"
 
-#: src/option.c:396
+#: src/option.c:398
 msgid "Add field to form (see man page for list of possible types)"
 msgstr ""
 
-#: src/option.c:396 src/option.c:631
+#: src/option.c:398 src/option.c:633
 msgid "LABEL[:TYPE]"
 msgstr "ETIQUETA[:TIPO]"
 
-#: src/option.c:398
+#: src/option.c:400
 msgid "Set alignment of filed labels (left, center or right)"
 msgstr ""
 "Configurar alineación de las etiquetas de los campos (izquierda, centro o "
 "derecha)"
 
-#: src/option.c:400
+#: src/option.c:402
 msgid "Set number of columns in form"
 msgstr "Configurar el número de columnas en un formulario"
 
-#: src/option.c:402
+#: src/option.c:404
 msgid "Make form fields height and columns width the same size"
 msgstr ""
 
-#: src/option.c:404
+#: src/option.c:406
 msgid "Order output fields by rows"
 msgstr ""
 
-#: src/option.c:406
+#: src/option.c:408
 #, fuzzy
 msgid "Set focused field"
 msgstr "Configurar tamaño de paso"
 
-#: src/option.c:408
+#: src/option.c:410
 msgid "Cycled reading of stdin data"
 msgstr ""
 
-#: src/option.c:410
+#: src/option.c:412
 msgid "Align labels on button fields"
 msgstr ""
 
-#: src/option.c:412
+#: src/option.c:414
 #, fuzzy
 msgid "Set changed action"
 msgstr "Configurar la acción del clic izquierdo"
 
-#: src/option.c:419
+#: src/option.c:421
 #, fuzzy
 msgid "Display HTML dialog"
 msgstr "Mostrar diálogo de formulario"
 
-#: src/option.c:421
+#: src/option.c:423
 #, fuzzy
 msgid "Open specified location"
 msgstr "Usar una fuente de texto específicia"
 
-#: src/option.c:423
+#: src/option.c:425
 #, fuzzy
 msgid "Turn on browser mode"
 msgstr "- Explorador de iconos"
 
-#: src/option.c:425
+#: src/option.c:427
 msgid "Print clicked uri to stdout"
 msgstr ""
 
-#: src/option.c:427
+#: src/option.c:429
 msgid "Set encoding of input stream data"
 msgstr ""
 
-#: src/option.c:427
+#: src/option.c:429
 msgid "ENCODING"
 msgstr ""
 
-#: src/option.c:429
+#: src/option.c:431
 msgid "Set user agent string"
 msgstr ""
 
-#: src/option.c:431
+#: src/option.c:433
 msgid "Set custom user style"
 msgstr ""
 
-#: src/option.c:433
+#: src/option.c:435
 msgid "Set WebKit property"
 msgstr ""
 
-#: src/option.c:433
+#: src/option.c:435
 msgid "PROP"
 msgstr ""
 
-#: src/option.c:440
+#: src/option.c:442
 msgid "Display icons box dialog"
 msgstr "Mostrar el diálogo de caja de íconos"
 
-#: src/option.c:442
+#: src/option.c:444
 msgid "Read data from .desktop files in specified directory"
 msgstr "Leer datos de archivos .desktop en el directorio designado"
 
-#: src/option.c:442
+#: src/option.c:444
 msgid "DIR"
 msgstr ""
 
-#: src/option.c:444
+#: src/option.c:446
 msgid "Use compact (list) view"
 msgstr "Usar vista (de lista) compacta"
 
-#: src/option.c:446
+#: src/option.c:448
 msgid "Use GenericName field instead of Name for icon label"
 msgstr "Usar el campo GenericName en lugar de la etiqueta nombre para ícono"
 
-#: src/option.c:448
+#: src/option.c:450
 msgid "Set the width of dialog items"
 msgstr "Configurar el ancho de los ítems del diálogo"
 
-#: src/option.c:450
+#: src/option.c:452
 msgid "Force using specified icon size"
 msgstr ""
 
-#: src/option.c:450 src/option.c:564 src/option.c:700 src/tools.c:85
+#: src/option.c:452 src/option.c:566 src/option.c:702 src/tools.c:85
 msgid "SIZE"
 msgstr "DIMENSION"
 
-#: src/option.c:453
+#: src/option.c:455
 #, no-c-format
 msgid ""
 "Use specified pattern for launch command in terminal (default: xterm -e %s)"
@@ -1043,90 +1053,90 @@ msgstr ""
 "Usar una ruta específica para lanzar el comando en terminal (predeterminado: "
 "xterm-e% s)"
 
-#: src/option.c:455
+#: src/option.c:457
 msgid "Sort items by name instead of filename"
 msgstr "Organizar los ítems por nombre en lugar de nombre de archivo"
 
-#: src/option.c:457
+#: src/option.c:459
 msgid "Sort items in descending order"
 msgstr "Organizar los ítems en orden descendente"
 
-#: src/option.c:459
+#: src/option.c:461
 msgid "Activate items by single click"
 msgstr "Activar los ítems con un solo clic"
 
-#: src/option.c:461
+#: src/option.c:463
 msgid "Watch fot changes in directory"
 msgstr ""
 
-#: src/option.c:467
+#: src/option.c:469
 msgid "Display list dialog"
 msgstr "Mostrar diálogo de lista"
 
-#: src/option.c:469
+#: src/option.c:471
 msgid "Set the column header (see man page for list of possible types)"
 msgstr ""
 
-#: src/option.c:469
+#: src/option.c:471
 msgid "COLUMN[:TYPE]"
 msgstr "COLUMNA[:TIPO]"
 
-#: src/option.c:471
+#: src/option.c:473
 msgid "Enbale tree mode"
 msgstr ""
 
-#: src/option.c:473
+#: src/option.c:475
 msgid "Use checkboxes for first column"
 msgstr "Usar cajas de verificación como primer columna"
 
-#: src/option.c:475
+#: src/option.c:477
 msgid "Use radioboxes for first column"
 msgstr "Usar cajas de selección como primer columna"
 
-#: src/option.c:477
+#: src/option.c:479
 msgid "Don't show column headers"
 msgstr "No mostrar el encabezamiento de las columnas"
 
-#: src/option.c:479
+#: src/option.c:481
 msgid "Disable clickable column headers"
 msgstr "Deshabilitar clic en los encabezados de columna"
 
-#: src/option.c:481
+#: src/option.c:483
 msgid "Set grid lines (hor[izontal], vert[ical] or both)"
 msgstr ""
 
-#: src/option.c:483
+#: src/option.c:485
 msgid "Print all data from list"
 msgstr "Imprimir todos los datos como lista"
 
-#: src/option.c:485
+#: src/option.c:487
 #, fuzzy
 msgid "Set the list of editable columns"
 msgstr "Configurar el ancho de los ítems del diálogo"
 
-#: src/option.c:487
+#: src/option.c:489
 #, fuzzy
 msgid "Set the width of a column for start wrapping text"
 msgstr "Configurar el ancho de los ítems del diálogo"
 
-#: src/option.c:489
+#: src/option.c:491
 #, fuzzy
 msgid "Set the list of wrapped columns"
 msgstr "Configurar el límite de filas en la lista"
 
-#: src/option.c:491
+#: src/option.c:493
 #, fuzzy
 msgid "Set ellipsize mode for text columns (none, start, middle or end)"
 msgstr ""
 "Configurar modo de tamaño elipse para el texto de las columnas (START, "
 "MIDDLE o END)"
 
-#: src/option.c:493
+#: src/option.c:495
 #, fuzzy
 msgid "Set the list of ellipsized columns"
 msgstr "Configurar el límite de filas en la lista"
 
-#: src/option.c:495
+#: src/option.c:497
 msgid ""
 "Print a specific column. By default or if 0 is specified will be printed all "
 "columns"
@@ -1134,17 +1144,17 @@ msgstr ""
 "Imprimir una columna específica. De manera predeterminada o si ha sido "
 "especificado 0 todo será impreso"
 
-#: src/option.c:497
+#: src/option.c:499
 msgid "Hide a specific column"
 msgstr "Esconder una columna específica"
 
-#: src/option.c:499
+#: src/option.c:501
 msgid "Set the column expandable by default. 0 sets all columns expandable"
 msgstr ""
 "Configurar la columna como expandible de manera predeterminada. 0 establece "
 "todas las columnas como expandibles"
 
-#: src/option.c:501
+#: src/option.c:503
 msgid ""
 "Set the quick search column. Default is first column. Set it to 0 for "
 "disable searching"
@@ -1152,863 +1162,863 @@ msgstr ""
 "Configurar la columna de búsqueda rápida. La primer columna espredterminada. "
 "Establecer 0 para deshabilitar la búsqueda"
 
-#: src/option.c:503
+#: src/option.c:505
 #, fuzzy
 msgid "Set the tooltip column"
 msgstr "Configurar el ícono de la ventana"
 
-#: src/option.c:505
+#: src/option.c:507
 #, fuzzy
 msgid "Set the row separator column"
 msgstr "Configurar el ícono de la entrada derecha"
 
-#: src/option.c:507
+#: src/option.c:509
 #, fuzzy
 msgid "Set the row separator value"
 msgstr "Configurar caracter separador de la salida"
 
-#: src/option.c:509
+#: src/option.c:511
 msgid "Set the limit of rows in list"
 msgstr "Configurar el límite de filas en la lista"
 
-#: src/option.c:511
+#: src/option.c:513
 msgid "Set double-click action"
 msgstr "Configurar acción doble-clic"
 
-#: src/option.c:515
+#: src/option.c:517
 #, fuzzy
 msgid "Set row action"
 msgstr "Configurar acción doble-clic"
 
-#: src/option.c:517
+#: src/option.c:519
 msgid "Expand all tree nodes"
 msgstr ""
 
-#: src/option.c:519
+#: src/option.c:521
 msgid "Use regex in search"
 msgstr "Usar expresiones regulares en la búsqueda"
 
-#: src/option.c:521
+#: src/option.c:523
 #, fuzzy
 msgid "Disable selection"
 msgstr "Mostrar el diálogo de selección de archivo"
 
-#: src/option.c:523
+#: src/option.c:525
 msgid "Add new records on the top of a list"
 msgstr ""
 
-#: src/option.c:525
+#: src/option.c:527
 msgid "Don't use markup in tooltips"
 msgstr ""
 
-#: src/option.c:527
+#: src/option.c:529
 msgid "Use column name as a header tooltip"
 msgstr ""
 
-#: src/option.c:529
+#: src/option.c:531
 #, fuzzy
 msgid "Set columns alignment"
 msgstr "Configurar el número de columnas en un formulario"
 
-#: src/option.c:531
+#: src/option.c:533
 #, fuzzy
 msgid "Set headers alignment"
 msgstr "Configurar el mes del calendario"
 
-#: src/option.c:537
+#: src/option.c:539
 #, fuzzy
 msgid "Display notebook dialog"
 msgstr "Mostrar diálogo libro de notas"
 
-#: src/option.c:539
+#: src/option.c:541
 msgid "Add a tab to notebook"
 msgstr "Agregar una pestaña al libro de notas"
 
-#: src/option.c:539
+#: src/option.c:541
 msgid "LABEL"
 msgstr "ETIQUETA"
 
-#: src/option.c:541
+#: src/option.c:543
 #, fuzzy
 msgid "Set position of a notebook tabs (top, bottom, left or right)"
 msgstr ""
 "Configurar la posisión de las pestañas del libro de notas (top, bottom, left "
 "o right)"
 
-#: src/option.c:543
+#: src/option.c:545
 msgid "Set tab borders"
 msgstr "Configurar los bordes de pestaña"
 
-#: src/option.c:545
+#: src/option.c:547
 #, fuzzy
 msgid "Set active tab"
 msgstr "Configurar la etiqueta de la entrada"
 
-#: src/option.c:547
+#: src/option.c:549
 msgid "Expand tabs"
 msgstr ""
 
-#: src/option.c:549
+#: src/option.c:551
 msgid "Use stack mode"
 msgstr ""
 
-#: src/option.c:556
+#: src/option.c:558
 msgid "Display notification"
 msgstr "Mostrar notificaciones"
 
-#: src/option.c:558 src/option.c:574
+#: src/option.c:560 src/option.c:576
 #, fuzzy
 msgid "Set initial popup menu"
 msgstr "Configurar un menú emergente inicial"
 
-#: src/option.c:560
+#: src/option.c:562
 msgid "Disable exit on middle click"
 msgstr "Deshabilitar cerrar con el clic en medio"
 
-#: src/option.c:562 src/option.c:576
+#: src/option.c:564 src/option.c:578
 #, fuzzy
 msgid "Doesn't show icon at startup"
 msgstr "No mostrar la ventana en la barra de tareas"
 
-#: src/option.c:564
+#: src/option.c:566
 msgid "Set icon size for fully specified icons (default - 16)"
 msgstr ""
 
-#: src/option.c:572
+#: src/option.c:574
 msgid "Display indicator icon (StatusNotifier/AppIndicator)"
 msgstr ""
 
-#: src/option.c:583
+#: src/option.c:585
 #, fuzzy
 msgid "Display paned dialog"
 msgstr "Mostrar dialogo de escala"
 
-#: src/option.c:585
+#: src/option.c:587
 msgid "Set orientation (hor[izontal] or vert[ical])"
 msgstr ""
 
-#: src/option.c:587
+#: src/option.c:589
 #, fuzzy
 msgid "Set initial splitter position"
 msgstr "Configurar porcentaje inicial"
 
-#: src/option.c:589
+#: src/option.c:591
 msgid "Set focused pane (1 or 2)"
 msgstr ""
 
-#: src/option.c:589
+#: src/option.c:591
 msgid "PANE"
 msgstr ""
 
-#: src/option.c:595
+#: src/option.c:597
 #, fuzzy
 msgid "Display picture dialog"
 msgstr "Mostrar diálogo de lista"
 
-#: src/option.c:597
+#: src/option.c:599
 #, fuzzy
 msgid "Set initial size (fit or orig)"
 msgstr "Configurar fuente inicial"
 
-#: src/option.c:599
+#: src/option.c:601
 msgid "Set increment for picture scaling (default - 5)"
 msgstr ""
 
-#: src/option.c:601
+#: src/option.c:603
 msgid "Set action on image changing"
 msgstr ""
 
-#: src/option.c:607
+#: src/option.c:609
 #, fuzzy
 msgid "Display popup dialog"
 msgstr "Mostrar diálogo de lista"
 
-#: src/option.c:609
+#: src/option.c:611
 #, fuzzy
 msgid "Set alignment of title and text (left, center or right)"
 msgstr ""
 "Configurar alineación de las etiquetas de los campos (izquierda, centro o "
 "derecha)"
 
-#: src/option.c:611
+#: src/option.c:613
 msgid "Set transparency"
 msgstr ""
 
-#: src/option.c:611
+#: src/option.c:613
 #, fuzzy
 msgid "PERCENT"
 msgstr "PORCENTAJE"
 
-#: src/option.c:613
+#: src/option.c:615
 msgid "Don't close popup by timeout"
 msgstr ""
 
-#: src/option.c:619
+#: src/option.c:621
 msgid "Display printing dialog"
 msgstr "Mostrar el díalogo de impresión"
 
-#: src/option.c:621
+#: src/option.c:623
 #, fuzzy
 msgid "Set source type (text, image or raw)"
 msgstr "Configurar el tipo de fuente (TIPO - TEXT, IMAGE o RAW)"
 
-#: src/option.c:623
+#: src/option.c:625
 msgid "Add headers to page"
 msgstr "Agregar encabezado a la página"
 
-#: src/option.c:629
+#: src/option.c:631
 msgid "Display progress indication dialog"
 msgstr "Mostrar el diálogo de indicador de progreso"
 
-#: src/option.c:631
+#: src/option.c:633
 #, fuzzy
 msgid "Add the progress bar (norm, rtl, pulse, cpulse or perm)"
 msgstr "Agregar la barra de progreso (TIPO - NORM, RTL o PULSE)"
 
-#: src/option.c:633
+#: src/option.c:635
 msgid "Watch for specific bar for auto close"
 msgstr ""
 
-#: src/option.c:635
+#: src/option.c:637
 #, fuzzy
 msgid "Set alignment of bar labels (left, center or right)"
 msgstr ""
 "Configurar la alineación de las etiquetas de la barra (left, center o right)"
 
-#: src/option.c:637
+#: src/option.c:639
 msgid "Set progress text"
 msgstr "Configurar texto de progreso"
 
-#: src/option.c:639
+#: src/option.c:641
 #, fuzzy
 msgid "Hide text on progress bar"
 msgstr "Barra de progreso intermitente"
 
-#: src/option.c:641
+#: src/option.c:643
 msgid "Pulsate progress bar"
 msgstr "Barra de progreso intermitente"
 
-#: src/option.c:643
+#: src/option.c:645
 #, fuzzy
 msgid "Conlinuous pulsating progress bar"
 msgstr "Barra de progreso intermitente"
 
-#: src/option.c:646
+#: src/option.c:648
 #, no-c-format
 msgid "Dismiss the dialog when 100% has been reached"
 msgstr "Descartar el diálogo cuando se alcance el 100%"
 
-#: src/option.c:649
+#: src/option.c:651
 msgid "Kill parent process if cancel button is pressed"
 msgstr "Matar el proceso padre si el botón cancelar es presionado"
 
-#: src/option.c:652
+#: src/option.c:654
 msgid "Right-To-Left progress bar direction"
 msgstr "Dirección de la barra de progreso Derecha-a-Izquierda"
 
-#: src/option.c:654
+#: src/option.c:656
 msgid "Show log window"
 msgstr "Mostrar ventana de log"
 
-#: src/option.c:656
+#: src/option.c:658
 msgid "Expand log window"
 msgstr "Expandir ventana de log"
 
-#: src/option.c:658
+#: src/option.c:660
 #, fuzzy
 msgid "Place log window above progress bar"
 msgstr "Colocar la ventana de log sobre la barra de progreso"
 
-#: src/option.c:660
+#: src/option.c:662
 msgid "Height of log window"
 msgstr "Alto de la ventana de log"
 
-#: src/option.c:666
+#: src/option.c:668
 msgid "Display scale dialog"
 msgstr "Mostrar dialogo de escala"
 
-#: src/option.c:668
+#: src/option.c:670
 msgid "Set initial value"
 msgstr "Configurar valor inicial"
 
-#: src/option.c:668 src/option.c:670 src/option.c:672 src/option.c:674
-#: src/option.c:678 src/option.c:745 src/option.c:747
+#: src/option.c:670 src/option.c:672 src/option.c:674 src/option.c:676
+#: src/option.c:680 src/option.c:747 src/option.c:749
 msgid "VALUE"
 msgstr "VALOR"
 
-#: src/option.c:670
+#: src/option.c:672
 msgid "Set minimum value"
 msgstr "Configurar valor mínimo"
 
-#: src/option.c:672
+#: src/option.c:674
 msgid "Set maximum value"
 msgstr "Configurar valor máximo"
 
-#: src/option.c:674
+#: src/option.c:676
 msgid "Set step size"
 msgstr "Configurar tamaño de paso"
 
-#: src/option.c:676
+#: src/option.c:678
 msgid "Only allow values in step increments"
 msgstr ""
 
-#: src/option.c:678
+#: src/option.c:680
 msgid "Set paging size"
 msgstr "Configurar tamaño de paginación"
 
-#: src/option.c:680
+#: src/option.c:682
 msgid "Print partial values"
 msgstr "Imprimir valores parciales"
 
-#: src/option.c:682
+#: src/option.c:684
 msgid "Hide value"
 msgstr "Ocultar valores"
 
-#: src/option.c:684
+#: src/option.c:686
 msgid "Invert direction"
 msgstr "Invertir dirección"
 
-#: src/option.c:686
+#: src/option.c:688
 msgid "Show +/- buttons in scale"
 msgstr ""
 
-#: src/option.c:688
+#: src/option.c:690
 msgid "Add mark to scale (may be used multiple times)"
 msgstr "Agregar marca para escalar (podría usarse multiples veces)"
 
-#: src/option.c:688
+#: src/option.c:690
 msgid "NAME:VALUE"
 msgstr "NOMBRE:VALOR"
 
-#: src/option.c:694
+#: src/option.c:696
 msgid "Display text information dialog"
 msgstr "Mostrar diálogo de texto de información"
 
-#: src/option.c:696
+#: src/option.c:698
 msgid "Enable text wrapping"
 msgstr "Habilitar ajuste de texto"
 
-#: src/option.c:698
+#: src/option.c:700
 #, fuzzy
 msgid "Set justification (left, right, center or fill)"
 msgstr "Configurar justificación (TIPO - left, right, center o fill)"
 
-#: src/option.c:700
+#: src/option.c:702
 msgid "Set text margins"
 msgstr "Configurar márgenes de texto"
 
-#: src/option.c:702
+#: src/option.c:704
 #, fuzzy
 msgid "Jump to specific line"
 msgstr "Esconder una columna específica"
 
-#: src/option.c:704
+#: src/option.c:706
 msgid "Use specified color for text"
 msgstr "Usar un color de texto específico"
 
-#: src/option.c:706
+#: src/option.c:708
 msgid "Use specified color for background"
 msgstr "Usar un color fondo específico"
 
-#: src/option.c:708
+#: src/option.c:710
 msgid "Show cursor in read-only mode"
 msgstr ""
 
-#: src/option.c:710
+#: src/option.c:712
 msgid "Make URI clickable"
 msgstr "Hacer clicable la URI"
 
-#: src/option.c:712
+#: src/option.c:714
 #, fuzzy
 msgid "Use specified color for links"
 msgstr "Usar un color de texto específico"
 
-#: src/option.c:714
+#: src/option.c:716
 msgid "Use pango markup"
 msgstr ""
 
-#: src/option.c:716
+#: src/option.c:718
 msgid "Save file instead of print on exit"
 msgstr ""
 
-#: src/option.c:718
+#: src/option.c:720
 msgid "Confirm save the file if text was changed"
-msgstr ""
-
-#: src/option.c:725
-#, fuzzy
-msgid "Use specified langauge for syntax highlighting"
-msgstr "Usar un color de texto específico"
-
-#: src/option.c:725
-msgid "LANG"
 msgstr ""
 
 #: src/option.c:727
 #, fuzzy
+msgid "Use specified langauge for syntax highlighting"
+msgstr "Usar un color de texto específico"
+
+#: src/option.c:727
+msgid "LANG"
+msgstr ""
+
+#: src/option.c:729
+#, fuzzy
 msgid "Use specified theme"
 msgstr "Usar una fuente de texto específicia"
 
-#: src/option.c:729
+#: src/option.c:731
 msgid "Show line numbers"
 msgstr ""
 
-#: src/option.c:731
+#: src/option.c:733
 msgid "Highlight current line"
 msgstr ""
 
-#: src/option.c:733
+#: src/option.c:735
 msgid "Enable line marks"
 msgstr ""
 
-#: src/option.c:735
+#: src/option.c:737
 msgid "Set color for first type marks"
 msgstr ""
 
-#: src/option.c:737
+#: src/option.c:739
 msgid "Set color for second type marks"
 msgstr ""
 
-#: src/option.c:739
+#: src/option.c:741
 msgid "Set position of right margin"
 msgstr ""
 
-#: src/option.c:739
+#: src/option.c:741
 msgid "[POS]"
 msgstr ""
 
-#: src/option.c:741
+#: src/option.c:743
 msgid "Highlight matching brackets"
 msgstr ""
 
-#: src/option.c:743
+#: src/option.c:745
 msgid "Use autoindent"
 msgstr ""
 
-#: src/option.c:745
+#: src/option.c:747
 #, fuzzy
 msgid "Set tabulation width"
 msgstr "Configurar el ancho"
 
-#: src/option.c:747
+#: src/option.c:749
 #, fuzzy
 msgid "Set indentation width"
 msgstr "Configurar el ancho"
 
-#: src/option.c:749
+#: src/option.c:751
 msgid "Set smart Home/End behavior"
 msgstr ""
 
-#: src/option.c:751
+#: src/option.c:753
 msgid "Enable smart backspace"
 msgstr ""
 
-#: src/option.c:753
+#: src/option.c:755
 msgid "Insert spaces instead of tabs"
 msgstr ""
 
-#: src/option.c:760
+#: src/option.c:762
 msgid "Sets a filename filter"
 msgstr "Configurar filtro de nombre de archivo"
 
-#: src/option.c:760
+#: src/option.c:762
 msgid "NAME | PATTERN1 PATTERN2 ..."
 msgstr "NOMBRE | PATRON1 PATRON2 ..."
 
-#: src/option.c:762
+#: src/option.c:764
 #, fuzzy
 msgid "Sets a mime-type filter"
 msgstr "Configurar filtro de nombre de archivo"
 
-#: src/option.c:762
+#: src/option.c:764
 #, fuzzy
 msgid "NAME | MIME1 MIME2 ..."
 msgstr "NOMBRE | PATRON1 PATRON2 ..."
 
-#: src/option.c:764
+#: src/option.c:766
 #, fuzzy
 msgid "Add filter for images"
 msgstr "Agregar encabezado a la página"
 
-#: src/option.c:764
+#: src/option.c:766
 #, fuzzy
 msgid "[NAME]"
 msgstr "NOMBRE:ID"
 
-#: src/option.c:770 src/tools.c:64
+#: src/option.c:772 src/tools.c:64
 msgid "Print version"
 msgstr "Imprimir versión"
 
-#: src/option.c:772
+#: src/option.c:774
 msgid "Load additional CSS settings from file or string"
 msgstr ""
 
-#: src/option.c:775
+#: src/option.c:777
 #, fuzzy
 msgid "Load additional CSS settings from file"
 msgstr "Cargar argumentos extra del archivo"
 
-#: src/option.c:778
+#: src/option.c:780
 msgid "Set policy for horizontal scrollbars (auto, always, never)"
 msgstr ""
 
-#: src/option.c:780
+#: src/option.c:782
 msgid "Set policy for vertical scrollbars (auto, always, never)"
 msgstr ""
 
-#: src/option.c:782
+#: src/option.c:784
 msgid "Add path for search icons by name"
 msgstr "Agregar ruta para buscar iconos por nombre"
 
-#: src/option.c:784
+#: src/option.c:786
 msgid "Write settings to file and exit"
 msgstr ""
 
-#: src/option.c:790
+#: src/option.c:792
 msgid "Load extra arguments from file"
 msgstr "Cargar argumentos extra del archivo"
 
-#: src/option.c:1001
+#: src/option.c:1003
 #, c-format
 msgid "Mark %s doesn't have a value\n"
 msgstr "El marcador %s no cuenta con valor\n"
 
-#: src/option.c:1048 src/picture.c:286
+#: src/option.c:1050 src/picture.c:286
 msgid "Images"
 msgstr ""
 
-#: src/option.c:1113
+#: src/option.c:1115
 #, fuzzy, c-format
 msgid "Unknown color mode: %s\n"
 msgstr "Comando desconocido: '%s'\n"
 
-#: src/option.c:1132
+#: src/option.c:1134
 #, c-format
 msgid "Unknown buttons layout type: %s\n"
 msgstr "Tipo de diseño de botones desconocido: %s\n"
 
-#: src/option.c:1147
+#: src/option.c:1149
 #, c-format
 msgid "Unknown align type: %s\n"
 msgstr "Tipo de alineación desconocida: %s\n"
 
-#: src/option.c:1171
+#: src/option.c:1173
 #, c-format
 msgid "Unknown justification type: %s\n"
 msgstr "Tipo de justificación desconocida: %s\n"
 
-#: src/option.c:1188
+#: src/option.c:1190
 #, fuzzy, c-format
 msgid "Unknown tab position type: %s\n"
 msgstr "Tipo de posición de pestaña desconocido: %s\n"
 
-#: src/option.c:1225
+#: src/option.c:1227
 #, c-format
 msgid "Unknown ellipsize type: %s\n"
 msgstr "Tipo de tamaño elipse desconocida: %s\n"
 
-#: src/option.c:1238
+#: src/option.c:1240
 #, fuzzy, c-format
 msgid "Unknown orientation: %s\n"
 msgstr "Señal desconocida: %s\n"
 
-#: src/option.c:1253
+#: src/option.c:1255
 #, c-format
 msgid "Unknown source type: %s\n"
 msgstr "Tipo de fuente desconocida: %s\n"
 
-#: src/option.c:1264
+#: src/option.c:1266
 #, fuzzy
 msgid "Progress log"
 msgstr "Log del progreso"
 
-#: src/option.c:1277
+#: src/option.c:1279
 #, fuzzy, c-format
 msgid "Unknown size type: %s\n"
 msgstr "Tipo de tamaño elipse desconocida: %s\n"
 
-#: src/option.c:1321
+#: src/option.c:1323
 #, fuzzy, c-format
 msgid "Unknown completion type: %s\n"
 msgstr "Tipo de alineación desconocida: %s\n"
 
-#: src/option.c:1353
+#: src/option.c:1355
 #, fuzzy, c-format
 msgid "Unknown boolean format type: %s\n"
 msgstr "Tipo de diseño de botones desconocido: %s\n"
 
-#: src/option.c:1369
+#: src/option.c:1371
 #, fuzzy, c-format
 msgid "Unknown grid lines type: %s\n"
 msgstr "Tipo de alineación desconocida: %s\n"
 
-#: src/option.c:1386
+#: src/option.c:1388
 #, fuzzy, c-format
 msgid "Unknown scrollbar policy type: %s\n"
 msgstr "Tipo de fuente desconocida: %s\n"
 
-#: src/option.c:1437
+#: src/option.c:1439
 #, fuzzy, c-format
 msgid "Unknown window type: %s\n"
 msgstr "Tipo de alineación desconocida: %s\n"
 
-#: src/option.c:1466
+#: src/option.c:1468
 #, fuzzy, c-format
 msgid "Unknown smart Home/End mode: %s\n"
 msgstr "Tipo de fuente desconocida: %s\n"
 
-#: src/option.c:1576
+#: src/option.c:1578
 #, c-format
 msgid "Unknown signal: %s\n"
 msgstr "Señal desconocida: %s\n"
 
-#: src/option.c:1811
+#: src/option.c:1814
 msgid "File exist. Overwrite?"
 msgstr "Si el archivo existe. Sobreescribir?"
 
-#: src/option.c:1953
+#: src/option.c:1956
 msgid "File was changed. Save it?"
 msgstr ""
 
-#: src/option.c:1984
+#: src/option.c:1987
 #, fuzzy
 msgid "- Yet another dialoging program"
 msgstr "Yet another dialoging program"
 
-#: src/option.c:1988
+#: src/option.c:1991
 msgid "General options"
 msgstr "Opciones generales"
 
-#: src/option.c:1988
+#: src/option.c:1991
 msgid "Show general options"
 msgstr "Mostrar opciones generales"
 
-#: src/option.c:1994
+#: src/option.c:1997
 #, fuzzy
 msgid "Common options"
 msgstr "Opciones de formulario"
 
-#: src/option.c:1994
+#: src/option.c:1997
 #, fuzzy
 msgid "Show common options"
 msgstr "Mostrar opciones de formulario"
 
-#: src/option.c:2000
+#: src/option.c:2003
 #, fuzzy
 msgid "About dialog options"
 msgstr "Opciones del diálogo de impresión"
 
-#: src/option.c:2000
+#: src/option.c:2003
 #, fuzzy
 msgid "Show custom about dialog options"
 msgstr "Mostrar opciones del diálogo libro de notas"
 
-#: src/option.c:2006
+#: src/option.c:2009
 #, fuzzy
 msgid "Application selection options"
 msgstr "Opciones de selección de fuente de texto"
 
-#: src/option.c:2006
+#: src/option.c:2009
 #, fuzzy
 msgid "Show application selection options"
 msgstr "Mostrar opciones de selección de fuente de texto"
 
-#: src/option.c:2012
+#: src/option.c:2015
 msgid "Calendar options"
 msgstr "Opciones de calendario"
 
-#: src/option.c:2012
+#: src/option.c:2015
 msgid "Show calendar options"
 msgstr "Mostrar opciones de calendario"
 
-#: src/option.c:2018
+#: src/option.c:2021
 msgid "Color selection options"
 msgstr "Opciones de selección de color"
 
-#: src/option.c:2018
+#: src/option.c:2021
 msgid "Show color selection options"
 msgstr "Mostrar opciones de selección de color"
 
-#: src/option.c:2024
+#: src/option.c:2027
 msgid "DND options"
 msgstr "Opciones de arrastrar-y-soltar"
 
-#: src/option.c:2024
+#: src/option.c:2027
 msgid "Show drag-n-drop options"
 msgstr "Mostrar opciones de arrastrar-y-soltar"
 
-#: src/option.c:2030
+#: src/option.c:2033
 msgid "Text entry options"
 msgstr "Opciones de entrada de texto"
 
-#: src/option.c:2030
+#: src/option.c:2033
 msgid "Show text entry options"
 msgstr "Mostrar opciones de entrada de texto"
 
-#: src/option.c:2036
+#: src/option.c:2039
 msgid "File selection options"
 msgstr "Opciones de selección de archivos"
 
-#: src/option.c:2036
+#: src/option.c:2039
 msgid "Show file selection options"
 msgstr "Mostrar opciones de selección de archivo"
 
-#: src/option.c:2042
+#: src/option.c:2045
 msgid "Font selection options"
 msgstr "Opciones de selección de fuente de texto"
 
-#: src/option.c:2042
+#: src/option.c:2045
 msgid "Show font selection options"
 msgstr "Mostrar opciones de selección de fuente de texto"
 
-#: src/option.c:2048
+#: src/option.c:2051
 msgid "Form options"
 msgstr "Opciones de formulario"
 
-#: src/option.c:2048
+#: src/option.c:2051
 msgid "Show form options"
 msgstr "Mostrar opciones de formulario"
 
-#: src/option.c:2055
+#: src/option.c:2058
 #, fuzzy
 msgid "HTML options"
 msgstr "Opciones de lista"
 
-#: src/option.c:2055
+#: src/option.c:2058
 #, fuzzy
 msgid "Show HTML options"
 msgstr "Mostrar opciones de formulario"
 
-#: src/option.c:2062
+#: src/option.c:2065
 msgid "Icons box options"
 msgstr "Opciones de caja de íconos"
 
-#: src/option.c:2062
+#: src/option.c:2065
 msgid "Show icons box options"
 msgstr "Mostrar opciones de la caja de íconos"
 
-#: src/option.c:2068
+#: src/option.c:2071
 msgid "List options"
 msgstr "Opciones de lista"
 
-#: src/option.c:2068
+#: src/option.c:2071
 msgid "Show list options"
 msgstr "Mostrar opciones de lista"
 
-#: src/option.c:2074
+#: src/option.c:2077
 msgid "Notebook options"
 msgstr "Opciones del libro de notas"
 
-#: src/option.c:2074
+#: src/option.c:2077
 msgid "Show notebook dialog options"
 msgstr "Mostrar opciones del diálogo libro de notas"
 
-#: src/option.c:2081
+#: src/option.c:2084
 msgid "Notification icon options"
 msgstr "Opciones del ícono de notificación"
 
-#: src/option.c:2082
+#: src/option.c:2085
 msgid "Show notification icon options"
 msgstr "Mostrar opciones de ícono de notifiación"
 
-#: src/option.c:2090
+#: src/option.c:2093
 #, fuzzy
 msgid "StatusNotifier/AppIndicator options"
 msgstr "Opciones del ícono de notificación"
 
-#: src/option.c:2091
+#: src/option.c:2094
 #, fuzzy
 msgid "Show indicator options"
 msgstr "Mostrar opciones del diálogo de impresión"
 
-#: src/option.c:2098
+#: src/option.c:2101
 #, fuzzy
 msgid "Paned dialog options"
 msgstr "Opciones del diálogo de impresión"
 
-#: src/option.c:2098
+#: src/option.c:2101
 #, fuzzy
 msgid "Show paned dialog options"
 msgstr "Mostrar opciones del diálogo de impresión"
 
-#: src/option.c:2104
+#: src/option.c:2107
 #, fuzzy
 msgid "Picture dialog options"
 msgstr "Opciones del diálogo de impresión"
 
-#: src/option.c:2104
+#: src/option.c:2107
 #, fuzzy
 msgid "Show picture dialog options"
 msgstr "Mostrar opciones del diálogo de impresión"
 
-#: src/option.c:2110
+#: src/option.c:2113
 #, fuzzy
 msgid "Popup dialog options"
 msgstr "Opciones del diálogo de impresión"
 
-#: src/option.c:2110
+#: src/option.c:2113
 #, fuzzy
 msgid "Show popup dialog options"
 msgstr "Mostrar opciones del diálogo de impresión"
 
-#: src/option.c:2116
+#: src/option.c:2119
 msgid "Print dialog options"
 msgstr "Opciones del diálogo de impresión"
 
-#: src/option.c:2116
+#: src/option.c:2119
 #, fuzzy
 msgid "Show print dialog options"
 msgstr "Mostrar opciones del diálogo de impresión"
 
-#: src/option.c:2122
+#: src/option.c:2125
 msgid "Progress options"
 msgstr "Opciones de progreso"
 
-#: src/option.c:2122
+#: src/option.c:2125
 msgid "Show progress options"
 msgstr "Mostrar opciones de progreso"
 
-#: src/option.c:2128
+#: src/option.c:2131
 msgid "Scale options"
 msgstr "Opciones de escala"
 
-#: src/option.c:2128
+#: src/option.c:2131
 msgid "Show scale options"
 msgstr "Mostrar opciones de escala"
 
-#: src/option.c:2134
+#: src/option.c:2137
 msgid "Text information options"
 msgstr "Opciones de información de texto"
 
-#: src/option.c:2134
+#: src/option.c:2137
 msgid "Show text information options"
 msgstr "Mostrar opciones de información de texto"
 
-#: src/option.c:2141
+#: src/option.c:2144
 #, fuzzy
 msgid "SourceView options"
 msgstr "Opciones de escala"
 
-#: src/option.c:2141
+#: src/option.c:2144
 #, fuzzy
 msgid "Show SourceView options"
 msgstr "Mostrar opciones de formulario"
 
-#: src/option.c:2148
+#: src/option.c:2151
 #, fuzzy
 msgid "File filter options"
 msgstr "Opciones de selección de archivos"
 
-#: src/option.c:2148
+#: src/option.c:2151
 #, fuzzy
 msgid "Show file filter options"
 msgstr "Mostrar opciones de selección de archivo"
 
-#: src/option.c:2154
+#: src/option.c:2157
 msgid "Miscellaneous options"
 msgstr "Opciones misceláneas"
 
-#: src/option.c:2154
+#: src/option.c:2157
 msgid "Show miscellaneous options"
 msgstr "Mostrar opciones misceláneas"
 
@@ -2551,7 +2561,7 @@ msgstr ""
 msgid "Insert spaces instead of tabulation:CHK"
 msgstr ""
 
-#: src/yad-settings.sh:113 data/yad-settings.desktop.in:3
+#: src/yad-settings.sh:113 data/yad-settings.desktop.in:4
 msgid "YAD settings"
 msgstr ""
 
@@ -2571,15 +2581,15 @@ msgstr ""
 msgid "Editor"
 msgstr ""
 
-#: data/yad-icon-browser.desktop.in:3
+#: data/yad-icon-browser.desktop.in:4
 msgid "Icon Browser"
 msgstr "Explorador de Iconos"
 
-#: data/yad-icon-browser.desktop.in:4
+#: data/yad-icon-browser.desktop.in:5
 msgid "Inspect GTK Icon Theme"
 msgstr "Inspeccionar tema de íconos GTK"
 
-#: data/yad-settings.desktop.in:4
+#: data/yad-settings.desktop.in:5
 msgid "Simple GUI for editing YAD settings"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YAD\n"
 "Report-Msgid-Bugs-To: victor@sanana.kiev.ua\n"
-"POT-Creation-Date: 2026-06-30 16:06+0300\n"
+"POT-Creation-Date: 2026-07-06 22:04-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Yannou90 <windaube.non.merci@gmail.com>\n"
 "Language-Team: Français\n"
@@ -98,15 +98,15 @@ msgstr "Sélectionner ou créer le dossier"
 msgid "Select date"
 msgstr "Sélectionner une date"
 
-#: src/form.c:1047
+#: src/form.c:1055
 msgid "Select file"
 msgstr "Sélectionner le fichier"
 
-#: src/form.c:1077
+#: src/form.c:1085
 msgid "Select folder"
 msgstr "Choisir un répertoire"
 
-#: src/form.c:1245 src/form.c:1247
+#: src/form.c:1253 src/form.c:1255
 msgid "Link"
 msgstr ""
 
@@ -147,35 +147,35 @@ msgstr "Impossible d'ouvrir le répertoire  %s: %s\n"
 msgid "%d sec"
 msgstr "%d sec"
 
-#: src/main.c:748 src/main.c:755
+#: src/main.c:764 src/main.c:771
 #, fuzzy, c-format
 msgid "Unable to parse YAD_OPTIONS: %s\n"
 msgstr "Impossible d'analyser le fichier %s: %s\n"
 
-#: src/main.c:766
+#: src/main.c:782
 #, c-format
 msgid "Unable to parse command line: %s\n"
 msgstr "Impossible d'analyser la ligne de commande: %s\n"
 
-#: src/main.c:780
+#: src/main.c:796
 msgid ""
 "WARNING: Using splash option is deprecated, please use --window-type instead"
 msgstr ""
 
-#: src/main.c:790
+#: src/main.c:806
 #, fuzzy, c-format
 msgid "Unable to change directory to %s: %s\n"
 msgstr "Impossible d'ouvrir le répertoire  %s: %s\n"
 
-#: src/main.c:819
+#: src/main.c:835
 msgid "WARNING: Using gtkrc option is deprecated, please use --css instead\n"
 msgstr ""
 
-#: src/main.c:893
+#: src/main.c:909
 msgid "WARNING: --plug mode not supported outside X11\n"
 msgstr ""
 
-#: src/main.c:913
+#: src/main.c:929
 msgid "WARNING: This mode not supported outside X11\n"
 msgstr ""
 
@@ -276,12 +276,12 @@ msgstr "HAUTEUR"
 msgid "Set the X position of a window"
 msgstr ""
 
-#: src/option.c:106 src/option.c:108 src/option.c:118 src/option.c:140
-#: src/option.c:144 src/option.c:189 src/option.c:203 src/option.c:342
-#: src/option.c:400 src/option.c:406 src/option.c:487 src/option.c:495
-#: src/option.c:497 src/option.c:499 src/option.c:501 src/option.c:503
-#: src/option.c:505 src/option.c:509 src/option.c:543 src/option.c:545
-#: src/option.c:599 src/option.c:633 src/option.c:702
+#: src/option.c:106 src/option.c:108 src/option.c:118 src/option.c:142
+#: src/option.c:146 src/option.c:191 src/option.c:205 src/option.c:344
+#: src/option.c:402 src/option.c:408 src/option.c:489 src/option.c:497
+#: src/option.c:499 src/option.c:501 src/option.c:503 src/option.c:505
+#: src/option.c:507 src/option.c:511 src/option.c:545 src/option.c:547
+#: src/option.c:601 src/option.c:635 src/option.c:704
 msgid "NUMBER"
 msgstr "NOMBRE"
 
@@ -309,7 +309,7 @@ msgstr "EXPIRATION"
 msgid "Show remaining time indicator (top, bottom, left, right)"
 msgstr "Voir indicateur de temps restant (haut, bas, gauche, droite)"
 
-#: src/option.c:114 src/option.c:587
+#: src/option.c:114 src/option.c:589
 msgid "POS"
 msgstr "POS"
 
@@ -317,8 +317,8 @@ msgstr "POS"
 msgid "Set the dialog text"
 msgstr "Définir le texte"
 
-#: src/option.c:116 src/option.c:273 src/option.c:275 src/option.c:350
-#: src/option.c:352 src/option.c:386 src/option.c:507 src/option.c:637
+#: src/option.c:116 src/option.c:275 src/option.c:277 src/option.c:352
+#: src/option.c:354 src/option.c:388 src/option.c:509 src/option.c:639
 msgid "TEXT"
 msgstr "TEXTE"
 
@@ -333,11 +333,11 @@ msgid "Set the dialog text alignment (left, center, right, fill)"
 msgstr ""
 "Définir l'alignement des étiquettes de champs (gauche, centre ou droite)"
 
-#: src/option.c:120 src/option.c:132 src/option.c:185 src/option.c:235
-#: src/option.c:241 src/option.c:243 src/option.c:398 src/option.c:481
-#: src/option.c:491 src/option.c:541 src/option.c:585 src/option.c:597
-#: src/option.c:609 src/option.c:621 src/option.c:635 src/option.c:698
-#: src/option.c:749 src/option.c:778 src/option.c:780 src/tools.c:86
+#: src/option.c:120 src/option.c:132 src/option.c:187 src/option.c:237
+#: src/option.c:243 src/option.c:245 src/option.c:400 src/option.c:483
+#: src/option.c:493 src/option.c:543 src/option.c:587 src/option.c:599
+#: src/option.c:611 src/option.c:623 src/option.c:637 src/option.c:700
+#: src/option.c:751 src/option.c:780 src/option.c:782 src/tools.c:86
 msgid "TYPE"
 msgstr "TYPE"
 
@@ -345,7 +345,7 @@ msgstr "TYPE"
 msgid "Set the dialog image"
 msgstr "Définir l'image"
 
-#: src/option.c:122 src/option.c:360 src/option.c:364
+#: src/option.c:122 src/option.c:362 src/option.c:366
 msgid "IMAGE"
 msgstr "IMAGE"
 
@@ -353,7 +353,7 @@ msgstr "IMAGE"
 msgid "Use specified icon theme instead of default"
 msgstr "Utiliser un thème d'icône spécifique"
 
-#: src/option.c:124 src/option.c:727 src/browser.c:220 src/tools.c:87
+#: src/option.c:124 src/option.c:729 src/browser.c:220 src/tools.c:87
 msgid "THEME"
 msgstr "THEME"
 
@@ -361,7 +361,7 @@ msgstr "THEME"
 msgid "Hide main widget with expander"
 msgstr "Cacher le widget principal avec un extenseur"
 
-#: src/option.c:126 src/option.c:378 src/option.c:654 src/option.c:718
+#: src/option.c:126 src/option.c:380 src/option.c:656 src/option.c:720
 msgid "[TEXT]"
 msgstr "[TEXTE]"
 
@@ -384,665 +384,675 @@ msgstr ""
 "centre)"
 
 #: src/option.c:134
+#, fuzzy
+msgid "Set focus to the named button when dialog opens"
+msgstr "Afficher les options de la barre de progression"
+
+#: src/option.c:134
+#, fuzzy
+msgid "NAME"
+msgstr "NOM:ID"
+
+#: src/option.c:136
 msgid "Don't use pango markup language in dialog's text"
 msgstr ""
 "Ne pas utiliser le langage de balisage Pango dans une boite de dialogue texte"
 
-#: src/option.c:136
+#: src/option.c:138
 msgid "Don't close dialog if Escape was pressed"
 msgstr ""
 
-#: src/option.c:138
+#: src/option.c:140
 msgid "Escape acts like OK button"
 msgstr ""
 
-#: src/option.c:140
+#: src/option.c:142
 msgid "Set window borders"
 msgstr "Définir les bordures de fenêtre"
 
-#: src/option.c:142
+#: src/option.c:144
 msgid "Always print result"
 msgstr "Toujours afficher le résultat"
 
-#: src/option.c:144
+#: src/option.c:146
 #, fuzzy
 msgid "Set default return code"
 msgstr "Régler le format de la date de retour"
 
-#: src/option.c:146
+#: src/option.c:148
 msgid "Dialog text can be selected"
 msgstr "Le texte peut être sélectionné"
 
-#: src/option.c:148
+#: src/option.c:150
 #, fuzzy
 msgid "Don't scale icons"
 msgstr "Afficher les options de la boîte échelle"
 
-#: src/option.c:150
+#: src/option.c:152
 #, c-format
 msgid "Run commands under specified interpreter (default: bash -c '%s')"
 msgstr ""
 
-#: src/option.c:150 src/option.c:152 src/option.c:154 src/option.c:205
-#: src/option.c:312 src/option.c:362 src/option.c:366 src/option.c:412
-#: src/option.c:511 src/option.c:513 src/option.c:515 src/option.c:601
+#: src/option.c:152 src/option.c:154 src/option.c:156 src/option.c:207
+#: src/option.c:314 src/option.c:364 src/option.c:368 src/option.c:414
+#: src/option.c:513 src/option.c:515 src/option.c:517 src/option.c:603
 msgid "CMD"
 msgstr "CMD"
 
-#: src/option.c:152
+#: src/option.c:154
 msgid "Set URI handler"
 msgstr ""
 
-#: src/option.c:154
+#: src/option.c:156
 msgid "Set command running when F1 was pressed"
 msgstr ""
 
-#: src/option.c:156
+#: src/option.c:158
 #, fuzzy
 msgid "Set working directory"
 msgstr "Ne pas décorer la fenêtre"
 
-#: src/option.c:156 src/option.c:782
+#: src/option.c:158 src/option.c:784
 #, fuzzy
 msgid "PATH"
 msgstr "ICONPATH"
 
-#: src/option.c:159
+#: src/option.c:161
 msgid "Set window sticky"
 msgstr "Définir la fenêtre comme inamovible"
 
-#: src/option.c:161
+#: src/option.c:163
 msgid "Set window unresizable"
 msgstr "Rendre la fenêtre non redimensionnable"
 
-#: src/option.c:163
+#: src/option.c:165
 msgid "Place window on top"
 msgstr "Placer la fenêtre au dessus"
 
-#: src/option.c:165
+#: src/option.c:167
 msgid "Place window on center of screen"
 msgstr "Centrer la fenêtre"
 
-#: src/option.c:167
+#: src/option.c:169
 msgid "Place window at the mouse position"
 msgstr "Placer la fenêtre à la position de la souris"
 
-#: src/option.c:169
+#: src/option.c:171
 msgid "Set window undecorated"
 msgstr "Ne pas décorer la fenêtre"
 
-#: src/option.c:171
+#: src/option.c:173
 msgid "Don't show window in taskbar"
 msgstr "Ne pas montrer la fenêtre dans la barre de tâches"
 
-#: src/option.c:173
+#: src/option.c:175
 #, fuzzy
 msgid "Set window maximized"
 msgstr "Rendre la fenêtre maximisée"
 
-#: src/option.c:175
+#: src/option.c:177
 #, fuzzy
 msgid "Set window fullscreen"
 msgstr "Rendre la fenêtre en plein-écran"
 
-#: src/option.c:177
+#: src/option.c:179
 msgid "Don't focus dialog window"
 msgstr ""
 
-#: src/option.c:179
+#: src/option.c:181
 msgid "Close window when it sets unfocused"
 msgstr ""
 
-#: src/option.c:182
+#: src/option.c:184
 msgid "Open window as a splashscreen (Deprecated, see man page for details)"
 msgstr ""
 
-#: src/option.c:185
+#: src/option.c:187
 msgid "Specify the window type for the dialog"
 msgstr ""
 
-#: src/option.c:187
+#: src/option.c:189
 msgid "Special type of dialog for XEMBED"
 msgstr ""
 
-#: src/option.c:187 src/option.c:239
+#: src/option.c:189 src/option.c:241
 msgid "KEY"
 msgstr ""
 
-#: src/option.c:189
+#: src/option.c:191
 msgid "Tab number of this dialog"
-msgstr ""
-
-#: src/option.c:192
-#, fuzzy
-msgid "Send SIGNAL to parent"
-msgstr "Envoyer le signal TERM au parent"
-
-#: src/option.c:192
-msgid "[SIGNAL]"
 msgstr ""
 
 #: src/option.c:194
 #, fuzzy
+msgid "Send SIGNAL to parent"
+msgstr "Envoyer le signal TERM au parent"
+
+#: src/option.c:194
+msgid "[SIGNAL]"
+msgstr ""
+
+#: src/option.c:196
+#, fuzzy
 msgid "Print X Window Id to the file/stderr"
 msgstr "Afficher l'ID de la fenêtre sur stderr"
 
-#: src/option.c:194 src/option.c:324
+#: src/option.c:196 src/option.c:326
 #, fuzzy
 msgid "[FILENAME]"
 msgstr "NOMDEFICHIER"
 
-#: src/option.c:201
+#: src/option.c:203
 msgid "Set the format for the returned date"
 msgstr "Régler le format de la date de retour"
 
-#: src/option.c:201 src/option.c:453
+#: src/option.c:203 src/option.c:455
 msgid "PATTERN"
 msgstr "MOTIF"
 
-#: src/option.c:203
+#: src/option.c:205
 msgid "Set presicion of floating numbers (default - 3)"
 msgstr ""
 
-#: src/option.c:205
+#: src/option.c:207
 msgid "Set command handler"
 msgstr ""
 
-#: src/option.c:207
+#: src/option.c:209
 #, fuzzy
 msgid "Listen for data on stdin"
 msgstr "Écouter les commandes sur stdin"
 
-#: src/option.c:209
+#: src/option.c:211
 #, fuzzy
 msgid "Set common separator character"
 msgstr "Définir le caractère séparateur en sortie"
 
-#: src/option.c:209 src/option.c:211
+#: src/option.c:211 src/option.c:213
 msgid "SEPARATOR"
 msgstr "SÉPARATEUR"
 
-#: src/option.c:211
+#: src/option.c:213
 #, fuzzy
 msgid "Set item separator character"
 msgstr "Définir le caractère séparateur en sortie"
 
-#: src/option.c:213
+#: src/option.c:215
 #, fuzzy
 msgid "Allow changes to text in some cases"
 msgstr "Autoriser les modifications du texte dans la liste déroulante"
 
-#: src/option.c:215
-msgid "Autoscroll to end of text"
-msgstr "Sauter en fin de texte"
-
 #: src/option.c:217
-#, fuzzy
-msgid "Autoscroll to end of text (alias to tail)"
+msgid "Autoscroll to end of text"
 msgstr "Sauter en fin de texte"
 
 #: src/option.c:219
 #, fuzzy
+msgid "Autoscroll to end of text (alias to tail)"
+msgstr "Sauter en fin de texte"
+
+#: src/option.c:221
+#, fuzzy
 msgid "Quote dialogs output"
 msgstr "Mettre entre guillemets la sortie"
 
-#: src/option.c:221
+#: src/option.c:223
 #, fuzzy
 msgid "Output number instead of text for combo-box"
 msgstr "Utiliser l'autocomplétion plutôt qu'une liste déroulante"
 
-#: src/option.c:223
+#: src/option.c:225
 msgid "Specify font name to use"
 msgstr ""
 
-#: src/option.c:223
+#: src/option.c:225
 msgid "FONTNAME"
 msgstr "NOMDEPOLICE"
 
-#: src/option.c:225
+#: src/option.c:227
 #, fuzzy
 msgid "Allow multiple selection"
 msgstr "Autoriser plusieurs lignes à être sélectionnés"
 
-#: src/option.c:227
+#: src/option.c:229
 #, fuzzy
 msgid "Enable preview"
 msgstr "Activer la prévisualisation"
 
-#: src/option.c:229
+#: src/option.c:231
 #, fuzzy
 msgid "Use large preview"
 msgstr "Activer la prévisualisation"
 
-#: src/option.c:231
+#: src/option.c:233
 #, fuzzy
 msgid "Show hidden files in file selection dialogs"
 msgstr "Afficher la boîte de sélection de fichier"
 
-#: src/option.c:233
+#: src/option.c:235
 #, fuzzy
 msgid "Set source filename"
 msgstr "Définir le nom de fichier"
 
-#: src/option.c:233 src/option.c:308 src/option.c:775 src/option.c:790
+#: src/option.c:235 src/option.c:310 src/option.c:777 src/option.c:792
 msgid "FILENAME"
 msgstr "NOMDEFICHIER"
 
-#: src/option.c:235
+#: src/option.c:237
 msgid "Set mime type of input data"
 msgstr ""
 
-#: src/option.c:237
+#: src/option.c:239
 #, fuzzy
 msgid "Set vertical orientation"
 msgstr "Action sur un clic gauche"
 
-#: src/option.c:239
+#: src/option.c:241
 msgid "Identifier of embedded dialogs"
 msgstr ""
 
-#: src/option.c:241
+#: src/option.c:243
 msgid "Set extended completion for entries (any, all, or regex)"
 msgstr ""
 
-#: src/option.c:243
+#: src/option.c:245
 msgid "Set type of output for boolean values (T, t, Y, y, O, o, 1)"
 msgstr ""
 
-#: src/option.c:245
+#: src/option.c:247
 #, fuzzy
 msgid "Make main widget scrollable"
 msgstr "Rendre les URI clickable"
 
-#: src/option.c:247
+#: src/option.c:249
 msgid "Disable search in text and html dialogs"
 msgstr ""
 
-#: src/option.c:249
+#: src/option.c:251
 #, fuzzy
 msgid "Enable file operations"
 msgstr "Options de la boîte échelle"
 
-#: src/option.c:252
+#: src/option.c:254
 msgid "Use IEC (base 1024) units with for size values"
 msgstr ""
 
-#: src/option.c:256
+#: src/option.c:258
 #, fuzzy
 msgid "Enable spell check for text"
 msgstr "Utiliser une couleur spécifiée pour le texte"
 
-#: src/option.c:258
+#: src/option.c:260
 msgid "Set spell checking language"
 msgstr ""
 
-#: src/option.c:258
+#: src/option.c:260
 msgid "LANGUAGE"
 msgstr ""
 
-#: src/option.c:265
+#: src/option.c:267
 #, fuzzy
 msgid "Display about dialog"
 msgstr "Afficher une boîte de type liste"
 
-#: src/option.c:267
+#: src/option.c:269
 msgid "Set application name"
 msgstr ""
 
-#: src/option.c:267 src/option.c:269 src/option.c:271 src/option.c:281
-#: src/option.c:429 src/option.c:431 src/option.c:529 src/option.c:531
-#: src/option.c:558 src/option.c:574 src/option.c:772
+#: src/option.c:269 src/option.c:271 src/option.c:273 src/option.c:283
+#: src/option.c:431 src/option.c:433 src/option.c:531 src/option.c:533
+#: src/option.c:560 src/option.c:576 src/option.c:774
 msgid "STRING"
 msgstr ""
 
-#: src/option.c:269
+#: src/option.c:271
 msgid "Set application version"
 msgstr ""
 
-#: src/option.c:271
+#: src/option.c:273
 msgid "Set application copyright string"
 msgstr ""
 
-#: src/option.c:273
+#: src/option.c:275
 msgid "Set application comments string"
 msgstr ""
 
-#: src/option.c:275
+#: src/option.c:277
 msgid "Set application license"
 msgstr ""
 
-#: src/option.c:277
+#: src/option.c:279
 msgid "Set application authors"
 msgstr ""
 
-#: src/option.c:277 src/option.c:485 src/option.c:489 src/option.c:493
+#: src/option.c:279 src/option.c:487 src/option.c:491 src/option.c:495
 msgid "LIST"
 msgstr ""
 
-#: src/option.c:279
+#: src/option.c:281
 #, fuzzy
 msgid "Set application website"
 msgstr "Définir les dimensions de la page"
 
-#: src/option.c:279
+#: src/option.c:281
 msgid "URI"
 msgstr ""
 
-#: src/option.c:281
+#: src/option.c:283
 msgid "Set application website label"
 msgstr ""
 
-#: src/option.c:287
+#: src/option.c:289
 #, fuzzy
 msgid "Display application selection dialog"
 msgstr "Afficher une boîte de dialogue de sélection de police d'écriture"
 
-#: src/option.c:289
+#: src/option.c:291
 #, fuzzy
 msgid "Show fallback applications"
 msgstr "Afficher les options du calendrier"
 
-#: src/option.c:291
+#: src/option.c:293
 #, fuzzy
 msgid "Show other applications"
 msgstr "Afficher les options de types form"
 
-#: src/option.c:293
+#: src/option.c:295
 #, fuzzy
 msgid "Show all applications"
 msgstr "Afficher les options de la boîte échelle"
 
-#: src/option.c:295
+#: src/option.c:297
 msgid "Output all application data"
 msgstr ""
 
-#: src/option.c:300
+#: src/option.c:302
 msgid "Display calendar dialog"
 msgstr "Afficher une boîte de dialogue de calendrier"
 
-#: src/option.c:302
+#: src/option.c:304
 msgid "Set the calendar day"
 msgstr "Définir le jour du calendrier"
 
-#: src/option.c:302
+#: src/option.c:304
 msgid "DAY"
 msgstr "JOUR"
 
-#: src/option.c:304
+#: src/option.c:306
 msgid "Set the calendar month"
 msgstr "Définir le mois du calendrier"
 
-#: src/option.c:304
+#: src/option.c:306
 msgid "MONTH"
 msgstr "MOIS"
 
-#: src/option.c:306
+#: src/option.c:308
 msgid "Set the calendar year"
 msgstr "Définir l'année du calendrier"
 
-#: src/option.c:306
+#: src/option.c:308
 msgid "YEAR"
 msgstr "ANNÉE"
 
-#: src/option.c:308
+#: src/option.c:310
 msgid "Set the filename with dates details"
 msgstr "Régler le  fichier avec les détails de dates"
 
-#: src/option.c:310
+#: src/option.c:312
 msgid "Show week numbers at the left side of calendar"
 msgstr ""
 
-#: src/option.c:312 src/option.c:513
+#: src/option.c:314 src/option.c:515
 #, fuzzy
 msgid "Set select action"
 msgstr "Action sur un clic gauche"
 
-#: src/option.c:318
+#: src/option.c:320
 msgid "Display color selection dialog"
 msgstr "Afficher la boîte de sélection de couleur"
 
-#: src/option.c:320
+#: src/option.c:322
 msgid "Set initial color value"
 msgstr "Définir la valeur initial de la couleur"
 
-#: src/option.c:320 src/option.c:704 src/option.c:706 src/option.c:712
-#: src/option.c:735 src/option.c:737
+#: src/option.c:322 src/option.c:706 src/option.c:708 src/option.c:714
+#: src/option.c:737 src/option.c:739
 msgid "COLOR"
 msgstr "COULEUR"
 
-#: src/option.c:322
+#: src/option.c:324
 msgid "Show system palette in color dialog"
 msgstr ""
 
-#: src/option.c:324
+#: src/option.c:326
 msgid "Set path to palette file. Default - "
 msgstr "Définir le chemin du fichier palette . Par défaut -"
 
-#: src/option.c:326
+#: src/option.c:328
 msgid "Expand user palette"
 msgstr ""
 
-#: src/option.c:328
+#: src/option.c:330
 msgid "Show color picker"
 msgstr ""
 
-#: src/option.c:330
+#: src/option.c:332
 msgid "Set output mode to MODE. Values are hex (default) or rgb"
 msgstr ""
 
-#: src/option.c:330
+#: src/option.c:332
 msgid "MODE"
 msgstr ""
 
-#: src/option.c:332
+#: src/option.c:334
 msgid "Add opacity to output color value"
 msgstr ""
 
-#: src/option.c:338
+#: src/option.c:340
 msgid "Display drag-n-drop box"
 msgstr "Afficher une boîte de glisser-déposer"
 
-#: src/option.c:340
+#: src/option.c:342
 msgid "Use dialog text as tooltip"
 msgstr "Utiliser une boîte de dialogue texte comme tooltip"
 
-#: src/option.c:342
+#: src/option.c:344
 msgid "Exit after NUMBER of drops"
 msgstr ""
 
-#: src/option.c:348
+#: src/option.c:350
 msgid "Display text entry or combo-box dialog"
 msgstr "Afficher une entrée de texte ou une liste déroulante"
 
-#: src/option.c:350
+#: src/option.c:352
 msgid "Set the entry label"
 msgstr "Définir l’étiquette d'entrée"
 
-#: src/option.c:352
+#: src/option.c:354
 msgid "Set the entry text"
 msgstr "Définir l'entrée"
 
-#: src/option.c:354
+#: src/option.c:356
 msgid "Hide the entry text"
 msgstr "Cacher l'entrée"
 
-#: src/option.c:356
+#: src/option.c:358
 msgid "Use completion instead of combo-box"
 msgstr "Utiliser l'autocomplétion plutôt qu'une liste déroulante"
 
-#: src/option.c:358
+#: src/option.c:360
 msgid "Use spin button for text entry"
 msgstr "Utiliser un bouton pour l'entré de texte"
 
-#: src/option.c:360
+#: src/option.c:362
 msgid "Set the left entry icon"
 msgstr "Définir l'étiquette de l'entrée gauche de l'icône"
 
-#: src/option.c:362
+#: src/option.c:364
 msgid "Set the left entry icon action"
 msgstr "Définir l'action de icône de gauche"
 
-#: src/option.c:364
+#: src/option.c:366
 msgid "Set the right entry icon"
 msgstr "Définir l'étiquette de l'entrée droite de l'icône"
 
-#: src/option.c:366
+#: src/option.c:368
 msgid "Set the right entry icon action"
 msgstr "Définir l'action de l'iône de droite"
 
-#: src/option.c:372
+#: src/option.c:374
 msgid "Display file selection dialog"
 msgstr "Afficher la boîte de sélection de fichier"
 
-#: src/option.c:374
+#: src/option.c:376
 msgid "Activate directory-only selection"
 msgstr "Activer seulement la sélection de répertoire"
 
-#: src/option.c:376
+#: src/option.c:378
 msgid "Activate save mode"
 msgstr "Activer le mode sauvegarde"
 
-#: src/option.c:378
+#: src/option.c:380
 msgid "Confirm file selection if filename already exists"
 msgstr "Confirmer la sélection de fichier si le fichier existe"
 
-#: src/option.c:384
+#: src/option.c:386
 msgid "Display font selection dialog"
 msgstr "Afficher une boîte de dialogue de sélection de police d'écriture"
 
-#: src/option.c:386
+#: src/option.c:388
 msgid "Set text string for preview"
 msgstr ""
 
-#: src/option.c:388
+#: src/option.c:390
 msgid "Separate output of font description"
 msgstr ""
 
-#: src/option.c:394
+#: src/option.c:396
 msgid "Display form dialog"
 msgstr "Afficher une boîte de type form"
 
-#: src/option.c:396
+#: src/option.c:398
 msgid "Add field to form (see man page for list of possible types)"
 msgstr ""
 
-#: src/option.c:396 src/option.c:631
+#: src/option.c:398 src/option.c:633
 msgid "LABEL[:TYPE]"
 msgstr "ETIQUETTE[:TYPE]"
 
-#: src/option.c:398
+#: src/option.c:400
 #, fuzzy
 msgid "Set alignment of filed labels (left, center or right)"
 msgstr ""
 "Définir l'alignement des étiquettes de champs (gauche, centre ou droite)"
 
-#: src/option.c:400
+#: src/option.c:402
 msgid "Set number of columns in form"
 msgstr "Définir le nombre de colonnes dans la boîte form"
 
-#: src/option.c:402
+#: src/option.c:404
 msgid "Make form fields height and columns width the same size"
 msgstr ""
 
-#: src/option.c:404
+#: src/option.c:406
 msgid "Order output fields by rows"
 msgstr ""
 
-#: src/option.c:406
+#: src/option.c:408
 #, fuzzy
 msgid "Set focused field"
 msgstr "Définir le pas"
 
-#: src/option.c:408
+#: src/option.c:410
 msgid "Cycled reading of stdin data"
 msgstr ""
 
-#: src/option.c:410
+#: src/option.c:412
 msgid "Align labels on button fields"
 msgstr ""
 
-#: src/option.c:412
+#: src/option.c:414
 #, fuzzy
 msgid "Set changed action"
 msgstr "Action sur un clic gauche"
 
-#: src/option.c:419
+#: src/option.c:421
 #, fuzzy
 msgid "Display HTML dialog"
 msgstr "Afficher une boîte de type form"
 
-#: src/option.c:421
+#: src/option.c:423
 #, fuzzy
 msgid "Open specified location"
 msgstr "Utiliser une police spécifiée"
 
-#: src/option.c:423
+#: src/option.c:425
 #, fuzzy
 msgid "Turn on browser mode"
 msgstr "Navigateur d'icône"
 
-#: src/option.c:425
+#: src/option.c:427
 msgid "Print clicked uri to stdout"
 msgstr ""
 
-#: src/option.c:427
+#: src/option.c:429
 msgid "Set encoding of input stream data"
 msgstr ""
 
-#: src/option.c:427
+#: src/option.c:429
 msgid "ENCODING"
 msgstr ""
 
-#: src/option.c:429
+#: src/option.c:431
 msgid "Set user agent string"
 msgstr ""
 
-#: src/option.c:431
+#: src/option.c:433
 msgid "Set custom user style"
 msgstr ""
 
-#: src/option.c:433
+#: src/option.c:435
 msgid "Set WebKit property"
 msgstr ""
 
-#: src/option.c:433
+#: src/option.c:435
 msgid "PROP"
 msgstr ""
 
-#: src/option.c:440
+#: src/option.c:442
 msgid "Display icons box dialog"
 msgstr "Afficher une boîte de type icône"
 
-#: src/option.c:442
+#: src/option.c:444
 msgid "Read data from .desktop files in specified directory"
 msgstr "Lire les données des fichiers .desktop dans le répertoire spécifié"
 
-#: src/option.c:442
+#: src/option.c:444
 msgid "DIR"
 msgstr ""
 
-#: src/option.c:444
+#: src/option.c:446
 msgid "Use compact (list) view"
 msgstr "Utiliser la vue compacte (liste)"
 
-#: src/option.c:446
+#: src/option.c:448
 msgid "Use GenericName field instead of Name for icon label"
 msgstr ""
 "Utiliser le nom générique plutôt que le nom pour l'étiquette de l'icône"
 
-#: src/option.c:448
+#: src/option.c:450
 msgid "Set the width of dialog items"
 msgstr "Définir la largeur du champs"
 
-#: src/option.c:450
+#: src/option.c:452
 msgid "Force using specified icon size"
 msgstr ""
 
-#: src/option.c:450 src/option.c:564 src/option.c:700 src/tools.c:85
+#: src/option.c:452 src/option.c:566 src/option.c:702 src/tools.c:85
 msgid "SIZE"
 msgstr "TAILLE"
 
-#: src/option.c:453
+#: src/option.c:455
 #, no-c-format
 msgid ""
 "Use specified pattern for launch command in terminal (default: xterm -e %s)"
@@ -1050,92 +1060,92 @@ msgstr ""
 "Utiliser un motif spécifié pour la commande de lancement dans le terminal "
 "(par défaut: xterm-e% s)"
 
-#: src/option.c:455
+#: src/option.c:457
 msgid "Sort items by name instead of filename"
 msgstr "Trier les éléments par nom plutôt que par fichier"
 
-#: src/option.c:457
+#: src/option.c:459
 msgid "Sort items in descending order"
 msgstr "Trier les éléments par ordre décroissant"
 
-#: src/option.c:459
+#: src/option.c:461
 msgid "Activate items by single click"
 msgstr "Activer les items par un simple clic"
 
-#: src/option.c:461
+#: src/option.c:463
 msgid "Watch fot changes in directory"
 msgstr ""
 
-#: src/option.c:467
+#: src/option.c:469
 msgid "Display list dialog"
 msgstr "Afficher une boîte de type liste"
 
-#: src/option.c:469
+#: src/option.c:471
 msgid "Set the column header (see man page for list of possible types)"
 msgstr ""
 
-#: src/option.c:469
+#: src/option.c:471
 msgid "COLUMN[:TYPE]"
 msgstr "COLONNE[:TYPE]"
 
-#: src/option.c:471
+#: src/option.c:473
 msgid "Enbale tree mode"
 msgstr ""
 
-#: src/option.c:473
+#: src/option.c:475
 #, fuzzy
 msgid "Use checkboxes for first column"
 msgstr "Utiliser des cases à cocher pour la première colonne"
 
-#: src/option.c:475
+#: src/option.c:477
 #, fuzzy
 msgid "Use radioboxes for first column"
 msgstr "Utiliser des cases radio pour la première colonne"
 
-#: src/option.c:477
+#: src/option.c:479
 msgid "Don't show column headers"
 msgstr "Ne pas afficher les entêtes de colonnes"
 
-#: src/option.c:479
+#: src/option.c:481
 msgid "Disable clickable column headers"
 msgstr "Désactiver les entêtes de colonnes cliquables"
 
-#: src/option.c:481
+#: src/option.c:483
 msgid "Set grid lines (hor[izontal], vert[ical] or both)"
 msgstr ""
 
-#: src/option.c:483
+#: src/option.c:485
 msgid "Print all data from list"
 msgstr "Afficher toute les données de la liste"
 
-#: src/option.c:485
+#: src/option.c:487
 #, fuzzy
 msgid "Set the list of editable columns"
 msgstr "Définir la largeur du champs"
 
-#: src/option.c:487
+#: src/option.c:489
 #, fuzzy
 msgid "Set the width of a column for start wrapping text"
 msgstr "Définir la largeur du champs"
 
-#: src/option.c:489
+#: src/option.c:491
 #, fuzzy
 msgid "Set the list of wrapped columns"
 msgstr "Définir la limite de lignes dans une liste"
 
-#: src/option.c:491
+#: src/option.c:493
 #, fuzzy
 msgid "Set ellipsize mode for text columns (none, start, middle or end)"
 msgstr ""
 "Définir le mode défilement automatique pour les colonnes  texte (TYPE - "
 "NONE, START, MIDDLE or END)"
 
-#: src/option.c:493
+#: src/option.c:495
 #, fuzzy
 msgid "Set the list of ellipsized columns"
 msgstr "Définir la limite de lignes dans une liste"
 
-#: src/option.c:495
+#: src/option.c:497
 msgid ""
 "Print a specific column. By default or if 0 is specified will be printed all "
 "columns"
@@ -1143,17 +1153,17 @@ msgstr ""
 "Renvoyer une colonne spécifique. Par défaut ou si 0 est spécifié toutes les "
 "colonnes sont renvoyées"
 
-#: src/option.c:497
+#: src/option.c:499
 msgid "Hide a specific column"
 msgstr "Cacher une colonne spécifique"
 
-#: src/option.c:499
+#: src/option.c:501
 msgid "Set the column expandable by default. 0 sets all columns expandable"
 msgstr ""
 "Définir la colonne extensible par défaut. 0 définit toutes les colonnes "
 "comme extensible"
 
-#: src/option.c:501
+#: src/option.c:503
 msgid ""
 "Set the quick search column. Default is first column. Set it to 0 for "
 "disable searching"
@@ -1161,863 +1171,863 @@ msgstr ""
 "Définir la colonne de recherche rapide. Par défaut :  la première colonne. "
 "Réglez à 0 pour désactiver la recherche"
 
-#: src/option.c:503
+#: src/option.c:505
 #, fuzzy
 msgid "Set the tooltip column"
 msgstr "Définir l'icône de la fenêtre"
 
-#: src/option.c:505
+#: src/option.c:507
 #, fuzzy
 msgid "Set the row separator column"
 msgstr "Définir l'étiquette de l'entrée droite de l'icône"
 
-#: src/option.c:507
+#: src/option.c:509
 #, fuzzy
 msgid "Set the row separator value"
 msgstr "Définir le caractère séparateur en sortie"
 
-#: src/option.c:509
+#: src/option.c:511
 msgid "Set the limit of rows in list"
 msgstr "Définir la limite de lignes dans une liste"
 
-#: src/option.c:511
+#: src/option.c:513
 msgid "Set double-click action"
 msgstr "Action sur un double clic"
 
-#: src/option.c:515
+#: src/option.c:517
 #, fuzzy
 msgid "Set row action"
 msgstr "Action sur un double clic"
 
-#: src/option.c:517
+#: src/option.c:519
 msgid "Expand all tree nodes"
 msgstr ""
 
-#: src/option.c:519
+#: src/option.c:521
 msgid "Use regex in search"
 msgstr "Utiliser regex dans les recherches"
 
-#: src/option.c:521
+#: src/option.c:523
 #, fuzzy
 msgid "Disable selection"
 msgstr "Afficher la boîte de sélection de fichier"
 
-#: src/option.c:523
+#: src/option.c:525
 msgid "Add new records on the top of a list"
 msgstr ""
 
-#: src/option.c:525
+#: src/option.c:527
 msgid "Don't use markup in tooltips"
 msgstr ""
 
-#: src/option.c:527
+#: src/option.c:529
 msgid "Use column name as a header tooltip"
 msgstr ""
 
-#: src/option.c:529
+#: src/option.c:531
 #, fuzzy
 msgid "Set columns alignment"
 msgstr "Définir le nombre de colonnes dans la boîte form"
 
-#: src/option.c:531
+#: src/option.c:533
 #, fuzzy
 msgid "Set headers alignment"
 msgstr "Définir le mois du calendrier"
 
-#: src/option.c:537
+#: src/option.c:539
 #, fuzzy
 msgid "Display notebook dialog"
 msgstr "Afficher une boîte de type notebook"
 
-#: src/option.c:539
+#: src/option.c:541
 msgid "Add a tab to notebook"
 msgstr "Ajouter un onglet au notebook"
 
-#: src/option.c:539
+#: src/option.c:541
 msgid "LABEL"
 msgstr ""
 
-#: src/option.c:541
+#: src/option.c:543
 #, fuzzy
 msgid "Set position of a notebook tabs (top, bottom, left or right)"
 msgstr "Voir indicateur de temps restant (haut, bas, gauche, droite)"
 
-#: src/option.c:543
+#: src/option.c:545
 #, fuzzy
 msgid "Set tab borders"
 msgstr "Définir les bordures d'onglet"
 
-#: src/option.c:545
+#: src/option.c:547
 #, fuzzy
 msgid "Set active tab"
 msgstr "Définir l’étiquette d'entrée"
 
-#: src/option.c:547
+#: src/option.c:549
 msgid "Expand tabs"
 msgstr ""
 
-#: src/option.c:549
+#: src/option.c:551
 msgid "Use stack mode"
 msgstr ""
 
-#: src/option.c:556
+#: src/option.c:558
 msgid "Display notification"
 msgstr "Afficher la notification"
 
-#: src/option.c:558 src/option.c:574
+#: src/option.c:560 src/option.c:576
 #, fuzzy
 msgid "Set initial popup menu"
 msgstr "Affecter le menu de popup initial"
 
-#: src/option.c:560
+#: src/option.c:562
 msgid "Disable exit on middle click"
 msgstr "Désactiver quitter lors d'un clic milieu"
 
-#: src/option.c:562 src/option.c:576
+#: src/option.c:564 src/option.c:578
 #, fuzzy
 msgid "Doesn't show icon at startup"
 msgstr "Ne pas montrer la fenêtre dans la barre de tâches"
 
-#: src/option.c:564
+#: src/option.c:566
 msgid "Set icon size for fully specified icons (default - 16)"
 msgstr ""
 
-#: src/option.c:572
+#: src/option.c:574
 msgid "Display indicator icon (StatusNotifier/AppIndicator)"
 msgstr ""
 
-#: src/option.c:583
+#: src/option.c:585
 #, fuzzy
 msgid "Display paned dialog"
 msgstr "Afficher une boîte de type échelle"
 
-#: src/option.c:585
+#: src/option.c:587
 msgid "Set orientation (hor[izontal] or vert[ical])"
 msgstr ""
 
-#: src/option.c:587
+#: src/option.c:589
 #, fuzzy
 msgid "Set initial splitter position"
 msgstr "Définir le pourcentage initial"
 
-#: src/option.c:589
+#: src/option.c:591
 msgid "Set focused pane (1 or 2)"
 msgstr ""
 
-#: src/option.c:589
+#: src/option.c:591
 msgid "PANE"
 msgstr ""
 
-#: src/option.c:595
+#: src/option.c:597
 #, fuzzy
 msgid "Display picture dialog"
 msgstr "Afficher une boîte de type liste"
 
-#: src/option.c:597
+#: src/option.c:599
 #, fuzzy
 msgid "Set initial size (fit or orig)"
 msgstr "Définir la police d'écriture"
 
-#: src/option.c:599
+#: src/option.c:601
 msgid "Set increment for picture scaling (default - 5)"
 msgstr ""
 
-#: src/option.c:601
+#: src/option.c:603
 msgid "Set action on image changing"
 msgstr ""
 
-#: src/option.c:607
+#: src/option.c:609
 #, fuzzy
 msgid "Display popup dialog"
 msgstr "Afficher une boîte de type liste"
 
-#: src/option.c:609
+#: src/option.c:611
 #, fuzzy
 msgid "Set alignment of title and text (left, center or right)"
 msgstr ""
 "Définir l'alignement des étiquettes de champs (gauche, centre ou droite)"
 
-#: src/option.c:611
+#: src/option.c:613
 msgid "Set transparency"
 msgstr ""
 
-#: src/option.c:611
+#: src/option.c:613
 #, fuzzy
 msgid "PERCENT"
 msgstr "POURCENTAGE"
 
-#: src/option.c:613
+#: src/option.c:615
 msgid "Don't close popup by timeout"
 msgstr ""
 
-#: src/option.c:619
+#: src/option.c:621
 #, fuzzy
 msgid "Display printing dialog"
 msgstr "Afficher une boîte de type liste"
 
-#: src/option.c:621
+#: src/option.c:623
 msgid "Set source type (text, image or raw)"
 msgstr ""
 
-#: src/option.c:623
+#: src/option.c:625
 msgid "Add headers to page"
 msgstr "Ajouter des entêtes à la page"
 
-#: src/option.c:629
+#: src/option.c:631
 msgid "Display progress indication dialog"
 msgstr "Afficher l'indication de progression"
 
-#: src/option.c:631
+#: src/option.c:633
 #, fuzzy
 msgid "Add the progress bar (norm, rtl, pulse, cpulse or perm)"
 msgstr "Ajouter une barre de progression (TYPE - NORM, RTL or PULSE)"
 
-#: src/option.c:633
+#: src/option.c:635
 msgid "Watch for specific bar for auto close"
 msgstr ""
 
-#: src/option.c:635
+#: src/option.c:637
 #, fuzzy
 msgid "Set alignment of bar labels (left, center or right)"
 msgstr ""
 "Définir l'alignement des étiquettes de champs (gauche, centre ou droite)"
 
-#: src/option.c:637
+#: src/option.c:639
 msgid "Set progress text"
 msgstr "Définir le texte de progression"
 
-#: src/option.c:639
+#: src/option.c:641
 #, fuzzy
 msgid "Hide text on progress bar"
 msgstr "Barre de progression pulsative"
 
-#: src/option.c:641
+#: src/option.c:643
 msgid "Pulsate progress bar"
 msgstr "Barre de progression pulsative"
 
-#: src/option.c:643
+#: src/option.c:645
 #, fuzzy
 msgid "Conlinuous pulsating progress bar"
 msgstr "Barre de progression pulsative"
 
-#: src/option.c:646
+#: src/option.c:648
 #, no-c-format
 msgid "Dismiss the dialog when 100% has been reached"
 msgstr "Fermer la boîte de dialogue quand 100% sont atteint"
 
-#: src/option.c:649
+#: src/option.c:651
 msgid "Kill parent process if cancel button is pressed"
 msgstr "Tuer le processus parent quand le bouton quitter est pressé"
 
-#: src/option.c:652
+#: src/option.c:654
 msgid "Right-To-Left progress bar direction"
 msgstr "Barre de progression altérnante"
 
-#: src/option.c:654
+#: src/option.c:656
 msgid "Show log window"
 msgstr ""
 
-#: src/option.c:656
+#: src/option.c:658
 msgid "Expand log window"
 msgstr ""
 
-#: src/option.c:658
+#: src/option.c:660
 #, fuzzy
 msgid "Place log window above progress bar"
 msgstr "Barre de progression pulsative"
 
-#: src/option.c:660
+#: src/option.c:662
 msgid "Height of log window"
 msgstr ""
 
-#: src/option.c:666
+#: src/option.c:668
 msgid "Display scale dialog"
 msgstr "Afficher une boîte de type échelle"
 
-#: src/option.c:668
+#: src/option.c:670
 msgid "Set initial value"
 msgstr "Définir la valeur initial"
 
-#: src/option.c:668 src/option.c:670 src/option.c:672 src/option.c:674
-#: src/option.c:678 src/option.c:745 src/option.c:747
+#: src/option.c:670 src/option.c:672 src/option.c:674 src/option.c:676
+#: src/option.c:680 src/option.c:747 src/option.c:749
 msgid "VALUE"
 msgstr "VALEUR"
 
-#: src/option.c:670
+#: src/option.c:672
 msgid "Set minimum value"
 msgstr "Définir la valeur minimale"
 
-#: src/option.c:672
+#: src/option.c:674
 msgid "Set maximum value"
 msgstr "Définir la valeur maximale"
 
-#: src/option.c:674
+#: src/option.c:676
 msgid "Set step size"
 msgstr "Définir le pas"
 
-#: src/option.c:676
+#: src/option.c:678
 msgid "Only allow values in step increments"
 msgstr ""
 
-#: src/option.c:678
+#: src/option.c:680
 msgid "Set paging size"
 msgstr "Définir les dimensions de la page"
 
-#: src/option.c:680
+#: src/option.c:682
 msgid "Print partial values"
 msgstr "Afficher des valeurs partielles"
 
-#: src/option.c:682
+#: src/option.c:684
 msgid "Hide value"
 msgstr "Cacher la valeur"
 
-#: src/option.c:684
+#: src/option.c:686
 msgid "Invert direction"
 msgstr "Inverser la direction"
 
-#: src/option.c:686
+#: src/option.c:688
 msgid "Show +/- buttons in scale"
 msgstr ""
 
-#: src/option.c:688
+#: src/option.c:690
 msgid "Add mark to scale (may be used multiple times)"
 msgstr "Ajouter un marqueur à l'ascenseur (peut être utilisée plusieurs fois)"
 
-#: src/option.c:688
+#: src/option.c:690
 msgid "NAME:VALUE"
 msgstr "NOM: VALEUR"
 
-#: src/option.c:694
+#: src/option.c:696
 msgid "Display text information dialog"
 msgstr "Afficher une boîte d'information"
 
-#: src/option.c:696
+#: src/option.c:698
 msgid "Enable text wrapping"
 msgstr "Activer les sauts de ligne automatiques"
 
-#: src/option.c:698
+#: src/option.c:700
 #, fuzzy
 msgid "Set justification (left, right, center or fill)"
 msgstr "Définir le type (TYPE - gauche, droite, centre ou de remplissage)"
 
-#: src/option.c:700
+#: src/option.c:702
 msgid "Set text margins"
 msgstr "Définir la marge du texte"
 
-#: src/option.c:702
+#: src/option.c:704
 #, fuzzy
 msgid "Jump to specific line"
 msgstr "Cacher une colonne spécifique"
 
-#: src/option.c:704
+#: src/option.c:706
 msgid "Use specified color for text"
 msgstr "Utiliser une couleur spécifiée pour le texte"
 
-#: src/option.c:706
+#: src/option.c:708
 msgid "Use specified color for background"
 msgstr "Utiliser une couleur spécifiée pour le fond"
 
-#: src/option.c:708
+#: src/option.c:710
 msgid "Show cursor in read-only mode"
 msgstr ""
 
-#: src/option.c:710
+#: src/option.c:712
 msgid "Make URI clickable"
 msgstr "Rendre les URI clickable"
 
-#: src/option.c:712
+#: src/option.c:714
 #, fuzzy
 msgid "Use specified color for links"
 msgstr "Utiliser une couleur spécifiée pour le texte"
 
-#: src/option.c:714
+#: src/option.c:716
 msgid "Use pango markup"
 msgstr ""
 
-#: src/option.c:716
+#: src/option.c:718
 msgid "Save file instead of print on exit"
 msgstr ""
 
-#: src/option.c:718
+#: src/option.c:720
 msgid "Confirm save the file if text was changed"
-msgstr ""
-
-#: src/option.c:725
-#, fuzzy
-msgid "Use specified langauge for syntax highlighting"
-msgstr "Utiliser une couleur spécifiée pour le texte"
-
-#: src/option.c:725
-msgid "LANG"
 msgstr ""
 
 #: src/option.c:727
 #, fuzzy
+msgid "Use specified langauge for syntax highlighting"
+msgstr "Utiliser une couleur spécifiée pour le texte"
+
+#: src/option.c:727
+msgid "LANG"
+msgstr ""
+
+#: src/option.c:729
+#, fuzzy
 msgid "Use specified theme"
 msgstr "Utiliser une police spécifiée"
 
-#: src/option.c:729
+#: src/option.c:731
 msgid "Show line numbers"
 msgstr ""
 
-#: src/option.c:731
+#: src/option.c:733
 msgid "Highlight current line"
 msgstr ""
 
-#: src/option.c:733
+#: src/option.c:735
 msgid "Enable line marks"
 msgstr ""
 
-#: src/option.c:735
+#: src/option.c:737
 msgid "Set color for first type marks"
 msgstr ""
 
-#: src/option.c:737
+#: src/option.c:739
 msgid "Set color for second type marks"
 msgstr ""
 
-#: src/option.c:739
+#: src/option.c:741
 msgid "Set position of right margin"
 msgstr ""
 
-#: src/option.c:739
+#: src/option.c:741
 msgid "[POS]"
 msgstr ""
 
-#: src/option.c:741
+#: src/option.c:743
 msgid "Highlight matching brackets"
 msgstr ""
 
-#: src/option.c:743
+#: src/option.c:745
 msgid "Use autoindent"
 msgstr ""
 
-#: src/option.c:745
+#: src/option.c:747
 #, fuzzy
 msgid "Set tabulation width"
 msgstr "Définir la largeur"
 
-#: src/option.c:747
+#: src/option.c:749
 #, fuzzy
 msgid "Set indentation width"
 msgstr "Définir la largeur"
 
-#: src/option.c:749
+#: src/option.c:751
 msgid "Set smart Home/End behavior"
 msgstr ""
 
-#: src/option.c:751
+#: src/option.c:753
 msgid "Enable smart backspace"
 msgstr ""
 
-#: src/option.c:753
+#: src/option.c:755
 msgid "Insert spaces instead of tabs"
 msgstr ""
 
-#: src/option.c:760
+#: src/option.c:762
 msgid "Sets a filename filter"
 msgstr "Définir le filtre de fichier"
 
-#: src/option.c:760
+#: src/option.c:762
 msgid "NAME | PATTERN1 PATTERN2 ..."
 msgstr "NOM | REPERTOIRE1 REPERTOIRE2 ..."
 
-#: src/option.c:762
+#: src/option.c:764
 #, fuzzy
 msgid "Sets a mime-type filter"
 msgstr "Définir le filtre de fichier"
 
-#: src/option.c:762
+#: src/option.c:764
 #, fuzzy
 msgid "NAME | MIME1 MIME2 ..."
 msgstr "NOM | REPERTOIRE1 REPERTOIRE2 ..."
 
-#: src/option.c:764
+#: src/option.c:766
 #, fuzzy
 msgid "Add filter for images"
 msgstr "Ajouter des entêtes à la page"
 
-#: src/option.c:764
+#: src/option.c:766
 #, fuzzy
 msgid "[NAME]"
 msgstr "NOM:ID"
 
-#: src/option.c:770 src/tools.c:64
+#: src/option.c:772 src/tools.c:64
 msgid "Print version"
 msgstr "Afficher la version"
 
-#: src/option.c:772
+#: src/option.c:774
 msgid "Load additional CSS settings from file or string"
 msgstr ""
 
-#: src/option.c:775
+#: src/option.c:777
 msgid "Load additional CSS settings from file"
 msgstr ""
 
-#: src/option.c:778
+#: src/option.c:780
 msgid "Set policy for horizontal scrollbars (auto, always, never)"
 msgstr ""
 
-#: src/option.c:780
+#: src/option.c:782
 msgid "Set policy for vertical scrollbars (auto, always, never)"
 msgstr ""
 
-#: src/option.c:782
+#: src/option.c:784
 msgid "Add path for search icons by name"
 msgstr ""
 
-#: src/option.c:784
+#: src/option.c:786
 msgid "Write settings to file and exit"
 msgstr ""
 
-#: src/option.c:790
+#: src/option.c:792
 msgid "Load extra arguments from file"
 msgstr ""
 
-#: src/option.c:1001
+#: src/option.c:1003
 #, c-format
 msgid "Mark %s doesn't have a value\n"
 msgstr "Le marqueur %s n'a pas de valeur\n"
 
-#: src/option.c:1048 src/picture.c:286
+#: src/option.c:1050 src/picture.c:286
 msgid "Images"
 msgstr ""
 
-#: src/option.c:1113
+#: src/option.c:1115
 #, fuzzy, c-format
 msgid "Unknown color mode: %s\n"
 msgstr "Commande inconnue: '%s'\n"
 
-#: src/option.c:1132
+#: src/option.c:1134
 #, fuzzy, c-format
 msgid "Unknown buttons layout type: %s\n"
 msgstr "Type d'alignement inconnue: %s\n"
 
-#: src/option.c:1147
+#: src/option.c:1149
 #, c-format
 msgid "Unknown align type: %s\n"
 msgstr "Type d'alignement inconnue: %s\n"
 
-#: src/option.c:1171
+#: src/option.c:1173
 #, c-format
 msgid "Unknown justification type: %s\n"
 msgstr "Type de justification inconnue: %s\n"
 
-#: src/option.c:1188
+#: src/option.c:1190
 #, fuzzy, c-format
 msgid "Unknown tab position type: %s\n"
 msgstr "Type d'alignement inconnue: %s\n"
 
-#: src/option.c:1225
+#: src/option.c:1227
 #, c-format
 msgid "Unknown ellipsize type: %s\n"
 msgstr "Type de défilement automatique inconnue: %s\n"
 
-#: src/option.c:1238
+#: src/option.c:1240
 #, fuzzy, c-format
 msgid "Unknown orientation: %s\n"
 msgstr "Type d'alignement inconnue: %s\n"
 
-#: src/option.c:1253
+#: src/option.c:1255
 #, fuzzy, c-format
 msgid "Unknown source type: %s\n"
 msgstr "Type de défilement automatique inconnue: %s\n"
 
-#: src/option.c:1264
+#: src/option.c:1266
 #, fuzzy
 msgid "Progress log"
 msgstr "Options de la barre de progression"
 
-#: src/option.c:1277
+#: src/option.c:1279
 #, fuzzy, c-format
 msgid "Unknown size type: %s\n"
 msgstr "Type de défilement automatique inconnue: %s\n"
 
-#: src/option.c:1321
+#: src/option.c:1323
 #, fuzzy, c-format
 msgid "Unknown completion type: %s\n"
 msgstr "Type d'alignement inconnue: %s\n"
 
-#: src/option.c:1353
+#: src/option.c:1355
 #, fuzzy, c-format
 msgid "Unknown boolean format type: %s\n"
 msgstr "Type d'alignement inconnue: %s\n"
 
-#: src/option.c:1369
+#: src/option.c:1371
 #, fuzzy, c-format
 msgid "Unknown grid lines type: %s\n"
 msgstr "Type d'alignement inconnue: %s\n"
 
-#: src/option.c:1386
+#: src/option.c:1388
 #, fuzzy, c-format
 msgid "Unknown scrollbar policy type: %s\n"
 msgstr "Type de défilement automatique inconnue: %s\n"
 
-#: src/option.c:1437
+#: src/option.c:1439
 #, fuzzy, c-format
 msgid "Unknown window type: %s\n"
 msgstr "Type d'alignement inconnue: %s\n"
 
-#: src/option.c:1466
+#: src/option.c:1468
 #, fuzzy, c-format
 msgid "Unknown smart Home/End mode: %s\n"
 msgstr "Type de défilement automatique inconnue: %s\n"
 
-#: src/option.c:1576
+#: src/option.c:1578
 #, fuzzy, c-format
 msgid "Unknown signal: %s\n"
 msgstr "Type d'alignement inconnue: %s\n"
 
-#: src/option.c:1811
+#: src/option.c:1814
 msgid "File exist. Overwrite?"
 msgstr "Le fichier existe. Écraser?"
 
-#: src/option.c:1953
+#: src/option.c:1956
 msgid "File was changed. Save it?"
 msgstr ""
 
-#: src/option.c:1984
+#: src/option.c:1987
 #, fuzzy
 msgid "- Yet another dialoging program"
 msgstr "Yet another dialoging program"
 
-#: src/option.c:1988
+#: src/option.c:1991
 msgid "General options"
 msgstr "Options générales"
 
-#: src/option.c:1988
+#: src/option.c:1991
 msgid "Show general options"
 msgstr "Afficher les options générales"
 
-#: src/option.c:1994
+#: src/option.c:1997
 #, fuzzy
 msgid "Common options"
 msgstr "Options de types form"
 
-#: src/option.c:1994
+#: src/option.c:1997
 #, fuzzy
 msgid "Show common options"
 msgstr "Afficher les options de types form"
 
-#: src/option.c:2000
+#: src/option.c:2003
 #, fuzzy
 msgid "About dialog options"
 msgstr "Options de la barre de progression"
 
-#: src/option.c:2000
+#: src/option.c:2003
 #, fuzzy
 msgid "Show custom about dialog options"
 msgstr "Afficher les options de la barre de progression"
 
-#: src/option.c:2006
+#: src/option.c:2009
 #, fuzzy
 msgid "Application selection options"
 msgstr "Options de la boîte de sélection de police"
 
-#: src/option.c:2006
+#: src/option.c:2009
 #, fuzzy
 msgid "Show application selection options"
 msgstr "Afficher les options de la boîte de sélection de police"
 
-#: src/option.c:2012
+#: src/option.c:2015
 msgid "Calendar options"
 msgstr "Options du calendrier"
 
-#: src/option.c:2012
+#: src/option.c:2015
 msgid "Show calendar options"
 msgstr "Afficher les options du calendrier"
 
-#: src/option.c:2018
+#: src/option.c:2021
 msgid "Color selection options"
 msgstr "Options de la boîte de sélection de couleurs"
 
-#: src/option.c:2018
+#: src/option.c:2021
 msgid "Show color selection options"
 msgstr "Afficher les options de la boîte de sélection de couleurs"
 
-#: src/option.c:2024
+#: src/option.c:2027
 msgid "DND options"
 msgstr "Options de la boîte de glisser/déposer"
 
-#: src/option.c:2024
+#: src/option.c:2027
 msgid "Show drag-n-drop options"
 msgstr "Afficher les options de la boîte de glisser/déposer"
 
-#: src/option.c:2030
+#: src/option.c:2033
 msgid "Text entry options"
 msgstr "Options de la boîte d'entrée"
 
-#: src/option.c:2030
+#: src/option.c:2033
 msgid "Show text entry options"
 msgstr "Afficher les options de la boîte d'entrée"
 
-#: src/option.c:2036
+#: src/option.c:2039
 msgid "File selection options"
 msgstr "Options de la boîte de sélection de fichier"
 
-#: src/option.c:2036
+#: src/option.c:2039
 msgid "Show file selection options"
 msgstr "Afficher les options de la boîte de sélection de fichier"
 
-#: src/option.c:2042
+#: src/option.c:2045
 msgid "Font selection options"
 msgstr "Options de la boîte de sélection de police"
 
-#: src/option.c:2042
+#: src/option.c:2045
 msgid "Show font selection options"
 msgstr "Afficher les options de la boîte de sélection de police"
 
-#: src/option.c:2048
+#: src/option.c:2051
 msgid "Form options"
 msgstr "Options de types form"
 
-#: src/option.c:2048
+#: src/option.c:2051
 msgid "Show form options"
 msgstr "Afficher les options de types form"
 
-#: src/option.c:2055
+#: src/option.c:2058
 #, fuzzy
 msgid "HTML options"
 msgstr "Options de la boîte de type liste"
 
-#: src/option.c:2055
+#: src/option.c:2058
 #, fuzzy
 msgid "Show HTML options"
 msgstr "Afficher les options de types form"
 
-#: src/option.c:2062
+#: src/option.c:2065
 msgid "Icons box options"
 msgstr "Options de la boîte de sélection d'icône"
 
-#: src/option.c:2062
+#: src/option.c:2065
 msgid "Show icons box options"
 msgstr "Afficher les options de la boîte de sélection d'icône"
 
-#: src/option.c:2068
+#: src/option.c:2071
 msgid "List options"
 msgstr "Options de la boîte de type liste"
 
-#: src/option.c:2068
+#: src/option.c:2071
 msgid "Show list options"
 msgstr "Afficher les options de la boîte de sélection d'icône"
 
-#: src/option.c:2074
+#: src/option.c:2077
 #, fuzzy
 msgid "Notebook options"
 msgstr "Options de la boîte de glisser/déposer"
 
-#: src/option.c:2074
+#: src/option.c:2077
 #, fuzzy
 msgid "Show notebook dialog options"
 msgstr "Afficher les options de la barre de progression"
 
-#: src/option.c:2081
+#: src/option.c:2084
 msgid "Notification icon options"
 msgstr "Options de la boîte de type icône"
 
-#: src/option.c:2082
+#: src/option.c:2085
 msgid "Show notification icon options"
 msgstr "Afficher les options de la boîte de type icône"
 
-#: src/option.c:2090
+#: src/option.c:2093
 #, fuzzy
 msgid "StatusNotifier/AppIndicator options"
 msgstr "Options de la boîte de type icône"
 
-#: src/option.c:2091
+#: src/option.c:2094
 #, fuzzy
 msgid "Show indicator options"
 msgstr "Afficher les options de la barre de progression"
 
-#: src/option.c:2098
+#: src/option.c:2101
 #, fuzzy
 msgid "Paned dialog options"
 msgstr "Options de la barre de progression"
 
-#: src/option.c:2098
+#: src/option.c:2101
 #, fuzzy
 msgid "Show paned dialog options"
 msgstr "Afficher les options de la barre de progression"
 
-#: src/option.c:2104
+#: src/option.c:2107
 #, fuzzy
 msgid "Picture dialog options"
 msgstr "Options de la barre de progression"
 
-#: src/option.c:2104
+#: src/option.c:2107
 #, fuzzy
 msgid "Show picture dialog options"
 msgstr "Afficher les options de la barre de progression"
 
-#: src/option.c:2110
+#: src/option.c:2113
 #, fuzzy
 msgid "Popup dialog options"
 msgstr "Options de la barre de progression"
 
-#: src/option.c:2110
+#: src/option.c:2113
 #, fuzzy
 msgid "Show popup dialog options"
 msgstr "Afficher les options de la barre de progression"
 
-#: src/option.c:2116
+#: src/option.c:2119
 #, fuzzy
 msgid "Print dialog options"
 msgstr "Options de la barre de progression"
 
-#: src/option.c:2116
+#: src/option.c:2119
 #, fuzzy
 msgid "Show print dialog options"
 msgstr "Afficher les options de la barre de progression"
 
-#: src/option.c:2122
+#: src/option.c:2125
 msgid "Progress options"
 msgstr "Options de la barre de progression"
 
-#: src/option.c:2122
+#: src/option.c:2125
 msgid "Show progress options"
 msgstr "Afficher les options de la barre de progression"
 
-#: src/option.c:2128
+#: src/option.c:2131
 msgid "Scale options"
 msgstr "Options de la boîte échelle"
 
-#: src/option.c:2128
+#: src/option.c:2131
 msgid "Show scale options"
 msgstr "Afficher les options de la boîte échelle"
 
-#: src/option.c:2134
+#: src/option.c:2137
 msgid "Text information options"
 msgstr "Options de la boîte de type information"
 
-#: src/option.c:2134
+#: src/option.c:2137
 msgid "Show text information options"
 msgstr "Afficher les options de la boîte de type information"
 
-#: src/option.c:2141
+#: src/option.c:2144
 #, fuzzy
 msgid "SourceView options"
 msgstr "Options de la boîte échelle"
 
-#: src/option.c:2141
+#: src/option.c:2144
 #, fuzzy
 msgid "Show SourceView options"
 msgstr "Afficher les options de types form"
 
-#: src/option.c:2148
+#: src/option.c:2151
 #, fuzzy
 msgid "File filter options"
 msgstr "Options de la boîte de sélection de fichier"
 
-#: src/option.c:2148
+#: src/option.c:2151
 #, fuzzy
 msgid "Show file filter options"
 msgstr "Afficher les options de la boîte de sélection de fichier"
 
-#: src/option.c:2154
+#: src/option.c:2157
 msgid "Miscellaneous options"
 msgstr "Options diverses"
 
-#: src/option.c:2154
+#: src/option.c:2157
 msgid "Show miscellaneous options"
 msgstr "Afficher les options diverses"
 
@@ -2555,7 +2565,7 @@ msgstr ""
 msgid "Insert spaces instead of tabulation:CHK"
 msgstr ""
 
-#: src/yad-settings.sh:113 data/yad-settings.desktop.in:3
+#: src/yad-settings.sh:113 data/yad-settings.desktop.in:4
 msgid "YAD settings"
 msgstr ""
 
@@ -2575,15 +2585,15 @@ msgstr ""
 msgid "Editor"
 msgstr ""
 
-#: data/yad-icon-browser.desktop.in:3
+#: data/yad-icon-browser.desktop.in:4
 msgid "Icon Browser"
 msgstr "Navigateur d'Icônes"
 
-#: data/yad-icon-browser.desktop.in:4
+#: data/yad-icon-browser.desktop.in:5
 msgid "Inspect GTK Icon Theme"
 msgstr "Parcourir les icônes du thème GTK"
 
-#: data/yad-settings.desktop.in:4
+#: data/yad-settings.desktop.in:5
 msgid "Simple GUI for editing YAD settings"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YAD\n"
 "Report-Msgid-Bugs-To: victor@sanana.kiev.ua\n"
-"POT-Creation-Date: 2026-06-30 16:06+0300\n"
+"POT-Creation-Date: 2026-07-06 22:04-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Yannou90 <windaube.non.merci@gmail.com>\n"
 "Language-Team: Français\n"
@@ -97,15 +97,15 @@ msgstr "Seleziona o crea una cartella"
 msgid "Select date"
 msgstr "Seleziona la data"
 
-#: src/form.c:1047
+#: src/form.c:1055
 msgid "Select file"
 msgstr "Seleziona il file"
 
-#: src/form.c:1077
+#: src/form.c:1085
 msgid "Select folder"
 msgstr "Seleziona una cartella"
 
-#: src/form.c:1245 src/form.c:1247
+#: src/form.c:1253 src/form.c:1255
 msgid "Link"
 msgstr ""
 
@@ -146,35 +146,35 @@ msgstr "Impossibile aprire la cartella  %s: %s\n"
 msgid "%d sec"
 msgstr "%d sec"
 
-#: src/main.c:748 src/main.c:755
+#: src/main.c:764 src/main.c:771
 #, fuzzy, c-format
 msgid "Unable to parse YAD_OPTIONS: %s\n"
 msgstr "Impossibile parsificare il file %s: %s\n"
 
-#: src/main.c:766
+#: src/main.c:782
 #, c-format
 msgid "Unable to parse command line: %s\n"
 msgstr "Impossibile parsificare la linea di comando: %s\n"
 
-#: src/main.c:780
+#: src/main.c:796
 msgid ""
 "WARNING: Using splash option is deprecated, please use --window-type instead"
 msgstr ""
 
-#: src/main.c:790
+#: src/main.c:806
 #, fuzzy, c-format
 msgid "Unable to change directory to %s: %s\n"
 msgstr "Impossibile aprire la cartella  %s: %s\n"
 
-#: src/main.c:819
+#: src/main.c:835
 msgid "WARNING: Using gtkrc option is deprecated, please use --css instead\n"
 msgstr ""
 
-#: src/main.c:893
+#: src/main.c:909
 msgid "WARNING: --plug mode not supported outside X11\n"
 msgstr ""
 
-#: src/main.c:913
+#: src/main.c:929
 msgid "WARNING: This mode not supported outside X11\n"
 msgstr ""
 
@@ -275,12 +275,12 @@ msgstr "ALTEZZA"
 msgid "Set the X position of a window"
 msgstr ""
 
-#: src/option.c:106 src/option.c:108 src/option.c:118 src/option.c:140
-#: src/option.c:144 src/option.c:189 src/option.c:203 src/option.c:342
-#: src/option.c:400 src/option.c:406 src/option.c:487 src/option.c:495
-#: src/option.c:497 src/option.c:499 src/option.c:501 src/option.c:503
-#: src/option.c:505 src/option.c:509 src/option.c:543 src/option.c:545
-#: src/option.c:599 src/option.c:633 src/option.c:702
+#: src/option.c:106 src/option.c:108 src/option.c:118 src/option.c:142
+#: src/option.c:146 src/option.c:191 src/option.c:205 src/option.c:344
+#: src/option.c:402 src/option.c:408 src/option.c:489 src/option.c:497
+#: src/option.c:499 src/option.c:501 src/option.c:503 src/option.c:505
+#: src/option.c:507 src/option.c:511 src/option.c:545 src/option.c:547
+#: src/option.c:601 src/option.c:635 src/option.c:704
 msgid "NUMBER"
 msgstr "NUMERO"
 
@@ -310,7 +310,7 @@ msgstr ""
 "Mostra un indicatore del tempo mancante alla scomparsa (su, giù, sinistra, "
 "destra)"
 
-#: src/option.c:114 src/option.c:587
+#: src/option.c:114 src/option.c:589
 msgid "POS"
 msgstr "POS"
 
@@ -318,8 +318,8 @@ msgstr "POS"
 msgid "Set the dialog text"
 msgstr "Seleziona il testo della finestra di dialogo"
 
-#: src/option.c:116 src/option.c:273 src/option.c:275 src/option.c:350
-#: src/option.c:352 src/option.c:386 src/option.c:507 src/option.c:637
+#: src/option.c:116 src/option.c:275 src/option.c:277 src/option.c:352
+#: src/option.c:354 src/option.c:388 src/option.c:509 src/option.c:639
 msgid "TEXT"
 msgstr "TESTO"
 
@@ -335,11 +335,11 @@ msgstr ""
 "Seleziona l'allineamento del testo all'interno della finestra di dialogo (a "
 "sinistra, centrato o a destra)"
 
-#: src/option.c:120 src/option.c:132 src/option.c:185 src/option.c:235
-#: src/option.c:241 src/option.c:243 src/option.c:398 src/option.c:481
-#: src/option.c:491 src/option.c:541 src/option.c:585 src/option.c:597
-#: src/option.c:609 src/option.c:621 src/option.c:635 src/option.c:698
-#: src/option.c:749 src/option.c:778 src/option.c:780 src/tools.c:86
+#: src/option.c:120 src/option.c:132 src/option.c:187 src/option.c:237
+#: src/option.c:243 src/option.c:245 src/option.c:400 src/option.c:483
+#: src/option.c:493 src/option.c:543 src/option.c:587 src/option.c:599
+#: src/option.c:611 src/option.c:623 src/option.c:637 src/option.c:700
+#: src/option.c:751 src/option.c:780 src/option.c:782 src/tools.c:86
 msgid "TYPE"
 msgstr "TIPO"
 
@@ -347,7 +347,7 @@ msgstr "TIPO"
 msgid "Set the dialog image"
 msgstr "Seleziona una immagine per la finestra di dialogo"
 
-#: src/option.c:122 src/option.c:360 src/option.c:364
+#: src/option.c:122 src/option.c:362 src/option.c:366
 msgid "IMAGE"
 msgstr "IMMAGINE"
 
@@ -355,7 +355,7 @@ msgstr "IMMAGINE"
 msgid "Use specified icon theme instead of default"
 msgstr "Usa il tema desiderato al posto di quello predefinito"
 
-#: src/option.c:124 src/option.c:727 src/browser.c:220 src/tools.c:87
+#: src/option.c:124 src/option.c:729 src/browser.c:220 src/tools.c:87
 msgid "THEME"
 msgstr "TEMA"
 
@@ -363,7 +363,7 @@ msgstr "TEMA"
 msgid "Hide main widget with expander"
 msgstr "Nascondi il widget principale con un expander"
 
-#: src/option.c:126 src/option.c:378 src/option.c:654 src/option.c:718
+#: src/option.c:126 src/option.c:380 src/option.c:656 src/option.c:720
 msgid "[TEXT]"
 msgstr "[TESTO]"
 
@@ -386,668 +386,678 @@ msgstr ""
 "alla fine o centrati)"
 
 #: src/option.c:134
+#, fuzzy
+msgid "Set focus to the named button when dialog opens"
+msgstr "Mostra le opzioni della finestra di dialogo con menù a schede"
+
+#: src/option.c:134
+#, fuzzy
+msgid "NAME"
+msgstr "NOME:ID"
+
+#: src/option.c:136
 msgid "Don't use pango markup language in dialog's text"
 msgstr ""
 "Non usare il linguaggio di markup Pango per i testi della finestra di dialogo"
 
-#: src/option.c:136
+#: src/option.c:138
 msgid "Don't close dialog if Escape was pressed"
 msgstr ""
 
-#: src/option.c:138
+#: src/option.c:140
 msgid "Escape acts like OK button"
 msgstr ""
 
-#: src/option.c:140
+#: src/option.c:142
 msgid "Set window borders"
 msgstr "Seleziona i bordi della finestra"
 
-#: src/option.c:142
+#: src/option.c:144
 msgid "Always print result"
 msgstr "Stampa sempre il risultato"
 
-#: src/option.c:144
+#: src/option.c:146
 #, fuzzy
 msgid "Set default return code"
 msgstr "Seleziona il formato della data di ritorno"
 
-#: src/option.c:146
+#: src/option.c:148
 msgid "Dialog text can be selected"
 msgstr "Il testo della finestra può essere selezionato"
 
-#: src/option.c:148
+#: src/option.c:150
 #, fuzzy
 msgid "Don't scale icons"
 msgstr "Mostra le opzioni della scala"
 
-#: src/option.c:150
+#: src/option.c:152
 #, c-format
 msgid "Run commands under specified interpreter (default: bash -c '%s')"
 msgstr ""
 
-#: src/option.c:150 src/option.c:152 src/option.c:154 src/option.c:205
-#: src/option.c:312 src/option.c:362 src/option.c:366 src/option.c:412
-#: src/option.c:511 src/option.c:513 src/option.c:515 src/option.c:601
+#: src/option.c:152 src/option.c:154 src/option.c:156 src/option.c:207
+#: src/option.c:314 src/option.c:364 src/option.c:368 src/option.c:414
+#: src/option.c:513 src/option.c:515 src/option.c:517 src/option.c:603
 msgid "CMD"
 msgstr "CMD"
 
-#: src/option.c:152
+#: src/option.c:154
 msgid "Set URI handler"
 msgstr ""
 
-#: src/option.c:154
+#: src/option.c:156
 msgid "Set command running when F1 was pressed"
 msgstr ""
 
-#: src/option.c:156
+#: src/option.c:158
 #, fuzzy
 msgid "Set working directory"
 msgstr "Seleziona se la finestra è senza decorazioni"
 
-#: src/option.c:156 src/option.c:782
+#: src/option.c:158 src/option.c:784
 #, fuzzy
 msgid "PATH"
 msgstr "ICONPATH"
 
-#: src/option.c:159
+#: src/option.c:161
 msgid "Set window sticky"
 msgstr "Seleziona se la finestra è agganciata"
 
-#: src/option.c:161
+#: src/option.c:163
 msgid "Set window unresizable"
 msgstr "Seleziona se la finestra è non ridimensionabile"
 
-#: src/option.c:163
+#: src/option.c:165
 msgid "Place window on top"
 msgstr "Colloca la finestra sopra"
 
-#: src/option.c:165
+#: src/option.c:167
 msgid "Place window on center of screen"
 msgstr "Centra la finestra rispetto allo schermo"
 
-#: src/option.c:167
+#: src/option.c:169
 msgid "Place window at the mouse position"
 msgstr "Colloca la finestra nella posizione del mouse"
 
-#: src/option.c:169
+#: src/option.c:171
 msgid "Set window undecorated"
 msgstr "Seleziona se la finestra è senza decorazioni"
 
-#: src/option.c:171
+#: src/option.c:173
 msgid "Don't show window in taskbar"
 msgstr "Non mostrare la finestra nella lista dei task"
 
-#: src/option.c:173
+#: src/option.c:175
 #, fuzzy
 msgid "Set window maximized"
 msgstr "Seleziona se la finestra è non ridimensionabile"
 
-#: src/option.c:175
+#: src/option.c:177
 #, fuzzy
 msgid "Set window fullscreen"
 msgstr "Seleziona se la finestra è non ridimensionabile"
 
-#: src/option.c:177
+#: src/option.c:179
 #, fuzzy
 msgid "Don't focus dialog window"
 msgstr "Altezza della finestra dei log"
 
-#: src/option.c:179
+#: src/option.c:181
 msgid "Close window when it sets unfocused"
 msgstr ""
 
-#: src/option.c:182
+#: src/option.c:184
 msgid "Open window as a splashscreen (Deprecated, see man page for details)"
 msgstr ""
 
-#: src/option.c:185
+#: src/option.c:187
 msgid "Specify the window type for the dialog"
 msgstr ""
 
-#: src/option.c:187
+#: src/option.c:189
 msgid "Special type of dialog for XEMBED"
 msgstr "Tipo speciale di finestra di dialogo per XEMBED"
 
-#: src/option.c:187 src/option.c:239
+#: src/option.c:189 src/option.c:241
 msgid "KEY"
 msgstr "CHIAVE"
 
-#: src/option.c:189
+#: src/option.c:191
 #, fuzzy
 msgid "Tab number of this dialog"
 msgstr "Numero delle schede per questa finestra di dialogo"
 
-#: src/option.c:192
+#: src/option.c:194
 msgid "Send SIGNAL to parent"
 msgstr "Invia il SEGNALE al genitore"
 
-#: src/option.c:192
+#: src/option.c:194
 #, fuzzy
 msgid "[SIGNAL]"
 msgstr "SEGNALE"
 
-#: src/option.c:194
+#: src/option.c:196
 #, fuzzy
 msgid "Print X Window Id to the file/stderr"
 msgstr "Stampa l'identificatore della finestra sulla standard error"
 
-#: src/option.c:194 src/option.c:324
+#: src/option.c:196 src/option.c:326
 #, fuzzy
 msgid "[FILENAME]"
 msgstr "NOMEDELFILE"
 
-#: src/option.c:201
+#: src/option.c:203
 msgid "Set the format for the returned date"
 msgstr "Seleziona il formato della data di ritorno"
 
-#: src/option.c:201 src/option.c:453
+#: src/option.c:203 src/option.c:455
 msgid "PATTERN"
 msgstr "PATTERN"
 
-#: src/option.c:203
+#: src/option.c:205
 msgid "Set presicion of floating numbers (default - 3)"
 msgstr ""
 
-#: src/option.c:205
+#: src/option.c:207
 msgid "Set command handler"
 msgstr ""
 
-#: src/option.c:207
+#: src/option.c:209
 #, fuzzy
 msgid "Listen for data on stdin"
 msgstr "Prendi i comando dallo standard input"
 
-#: src/option.c:209
+#: src/option.c:211
 #, fuzzy
 msgid "Set common separator character"
 msgstr "Seleziona il carattere separatore per l'output"
 
-#: src/option.c:209 src/option.c:211
+#: src/option.c:211 src/option.c:213
 msgid "SEPARATOR"
 msgstr "SEPARATORE"
 
-#: src/option.c:211
+#: src/option.c:213
 #, fuzzy
 msgid "Set item separator character"
 msgstr "Seleziona il carattere separatore per l'output"
 
-#: src/option.c:213
+#: src/option.c:215
 #, fuzzy
 msgid "Allow changes to text in some cases"
 msgstr "Permetti il cambiamento del testo nella casella combinata"
 
-#: src/option.c:215
-msgid "Autoscroll to end of text"
-msgstr "Scroll automatico alla fine del testo"
-
 #: src/option.c:217
-#, fuzzy
-msgid "Autoscroll to end of text (alias to tail)"
+msgid "Autoscroll to end of text"
 msgstr "Scroll automatico alla fine del testo"
 
 #: src/option.c:219
 #, fuzzy
+msgid "Autoscroll to end of text (alias to tail)"
+msgstr "Scroll automatico alla fine del testo"
+
+#: src/option.c:221
+#, fuzzy
 msgid "Quote dialogs output"
 msgstr "Seleziona il testo della finestra di dialogo"
 
-#: src/option.c:221
+#: src/option.c:223
 #, fuzzy
 msgid "Output number instead of text for combo-box"
 msgstr "Utilizza il completamento automatico al posto della casella combinata"
 
-#: src/option.c:223
+#: src/option.c:225
 msgid "Specify font name to use"
 msgstr ""
 
-#: src/option.c:223
+#: src/option.c:225
 msgid "FONTNAME"
 msgstr "NOMEDELFONT"
 
-#: src/option.c:225
+#: src/option.c:227
 #, fuzzy
 msgid "Allow multiple selection"
 msgstr "Permetti la seleziona multipla di righe"
 
-#: src/option.c:227
-msgid "Enable preview"
-msgstr "Abilita anteprima"
-
 #: src/option.c:229
-#, fuzzy
-msgid "Use large preview"
+msgid "Enable preview"
 msgstr "Abilita anteprima"
 
 #: src/option.c:231
 #, fuzzy
+msgid "Use large preview"
+msgstr "Abilita anteprima"
+
+#: src/option.c:233
+#, fuzzy
 msgid "Show hidden files in file selection dialogs"
 msgstr "Mostra la finestra di dialogo per la selezione dei file"
 
-#: src/option.c:233
+#: src/option.c:235
 #, fuzzy
 msgid "Set source filename"
 msgstr "Nome del file sorgente"
 
-#: src/option.c:233 src/option.c:308 src/option.c:775 src/option.c:790
+#: src/option.c:235 src/option.c:310 src/option.c:777 src/option.c:792
 msgid "FILENAME"
 msgstr "NOMEDELFILE"
 
-#: src/option.c:235
+#: src/option.c:237
 msgid "Set mime type of input data"
 msgstr ""
 
-#: src/option.c:237
+#: src/option.c:239
 #, fuzzy
 msgid "Set vertical orientation"
 msgstr "Seleziona l'azione al click sinistro"
 
-#: src/option.c:239
+#: src/option.c:241
 msgid "Identifier of embedded dialogs"
 msgstr "Identificatore per finestre di dialogo incorporate"
 
-#: src/option.c:241
+#: src/option.c:243
 msgid "Set extended completion for entries (any, all, or regex)"
 msgstr ""
 
-#: src/option.c:243
+#: src/option.c:245
 msgid "Set type of output for boolean values (T, t, Y, y, O, o, 1)"
 msgstr ""
 
-#: src/option.c:245
+#: src/option.c:247
 #, fuzzy
 msgid "Make main widget scrollable"
 msgstr "Rendi la form scorrevole"
 
-#: src/option.c:247
+#: src/option.c:249
 msgid "Disable search in text and html dialogs"
 msgstr ""
 
-#: src/option.c:249
+#: src/option.c:251
 #, fuzzy
 msgid "Enable file operations"
 msgstr "Opzione della scala"
 
-#: src/option.c:252
+#: src/option.c:254
 msgid "Use IEC (base 1024) units with for size values"
 msgstr ""
 
-#: src/option.c:256
+#: src/option.c:258
 #, fuzzy
 msgid "Enable spell check for text"
 msgstr "Usa il colore specificato per il testo"
 
-#: src/option.c:258
+#: src/option.c:260
 msgid "Set spell checking language"
 msgstr ""
 
-#: src/option.c:258
+#: src/option.c:260
 msgid "LANGUAGE"
 msgstr ""
 
-#: src/option.c:265
+#: src/option.c:267
 #, fuzzy
 msgid "Display about dialog"
 msgstr "Mostra la finestra di dialogo per le liste"
 
-#: src/option.c:267
+#: src/option.c:269
 msgid "Set application name"
 msgstr ""
 
-#: src/option.c:267 src/option.c:269 src/option.c:271 src/option.c:281
-#: src/option.c:429 src/option.c:431 src/option.c:529 src/option.c:531
-#: src/option.c:558 src/option.c:574 src/option.c:772
+#: src/option.c:269 src/option.c:271 src/option.c:273 src/option.c:283
+#: src/option.c:431 src/option.c:433 src/option.c:531 src/option.c:533
+#: src/option.c:560 src/option.c:576 src/option.c:774
 msgid "STRING"
 msgstr ""
 
-#: src/option.c:269
+#: src/option.c:271
 msgid "Set application version"
 msgstr ""
 
-#: src/option.c:271
+#: src/option.c:273
 msgid "Set application copyright string"
 msgstr ""
 
-#: src/option.c:273
+#: src/option.c:275
 msgid "Set application comments string"
 msgstr ""
 
-#: src/option.c:275
+#: src/option.c:277
 msgid "Set application license"
 msgstr ""
 
-#: src/option.c:277
+#: src/option.c:279
 msgid "Set application authors"
 msgstr ""
 
-#: src/option.c:277 src/option.c:485 src/option.c:489 src/option.c:493
+#: src/option.c:279 src/option.c:487 src/option.c:491 src/option.c:495
 msgid "LIST"
 msgstr ""
 
-#: src/option.c:279
+#: src/option.c:281
 #, fuzzy
 msgid "Set application website"
 msgstr "Seleziona la dimensione del paginamento"
 
-#: src/option.c:279
+#: src/option.c:281
 msgid "URI"
 msgstr ""
 
-#: src/option.c:281
+#: src/option.c:283
 msgid "Set application website label"
 msgstr ""
 
-#: src/option.c:287
+#: src/option.c:289
 #, fuzzy
 msgid "Display application selection dialog"
 msgstr "Mostra la finestra di dialogo per la selezione del font"
 
-#: src/option.c:289
+#: src/option.c:291
 #, fuzzy
 msgid "Show fallback applications"
 msgstr "Mostra le opzioni del calendario"
 
-#: src/option.c:291
+#: src/option.c:293
 #, fuzzy
 msgid "Show other applications"
 msgstr "Mostra le opzioni della form"
 
-#: src/option.c:293
+#: src/option.c:295
 #, fuzzy
 msgid "Show all applications"
 msgstr "Mostra le opzioni della scala"
 
-#: src/option.c:295
+#: src/option.c:297
 msgid "Output all application data"
 msgstr ""
 
-#: src/option.c:300
+#: src/option.c:302
 msgid "Display calendar dialog"
 msgstr "Visualizza la finestra di dialogo calendario"
 
-#: src/option.c:302
+#: src/option.c:304
 msgid "Set the calendar day"
 msgstr "Seleziona il giorno nel calendario"
 
-#: src/option.c:302
+#: src/option.c:304
 msgid "DAY"
 msgstr "GIORNO"
 
-#: src/option.c:304
+#: src/option.c:306
 msgid "Set the calendar month"
 msgstr "Seleziona il mese nel calendario"
 
-#: src/option.c:304
+#: src/option.c:306
 msgid "MONTH"
 msgstr "MESE"
 
-#: src/option.c:306
+#: src/option.c:308
 msgid "Set the calendar year"
 msgstr "Seleziona l'anno nel calendario"
 
-#: src/option.c:306
+#: src/option.c:308
 msgid "YEAR"
 msgstr "ANNO"
 
-#: src/option.c:308
+#: src/option.c:310
 msgid "Set the filename with dates details"
 msgstr "Seleziona il nome del file con i dettagli delle date"
 
-#: src/option.c:310
+#: src/option.c:312
 msgid "Show week numbers at the left side of calendar"
 msgstr ""
 
-#: src/option.c:312 src/option.c:513
+#: src/option.c:314 src/option.c:515
 #, fuzzy
 msgid "Set select action"
 msgstr "Seleziona l'azione al click sinistro"
 
-#: src/option.c:318
+#: src/option.c:320
 msgid "Display color selection dialog"
 msgstr ""
 "Visualizza il colore della finestra di dialogo per la selezione del file"
 
-#: src/option.c:320
+#: src/option.c:322
 msgid "Set initial color value"
 msgstr "Seleziona il valore iniziale del colore"
 
-#: src/option.c:320 src/option.c:704 src/option.c:706 src/option.c:712
-#: src/option.c:735 src/option.c:737
+#: src/option.c:322 src/option.c:706 src/option.c:708 src/option.c:714
+#: src/option.c:737 src/option.c:739
 msgid "COLOR"
 msgstr "COLORE"
 
-#: src/option.c:322
+#: src/option.c:324
 msgid "Show system palette in color dialog"
 msgstr ""
 
-#: src/option.c:324
+#: src/option.c:326
 msgid "Set path to palette file. Default - "
 msgstr ""
 "Seleziona il percorso del file per la palette dei colori. Predefinito -"
 
-#: src/option.c:326
+#: src/option.c:328
 msgid "Expand user palette"
 msgstr ""
 
-#: src/option.c:328
+#: src/option.c:330
 msgid "Show color picker"
 msgstr ""
 
-#: src/option.c:330
+#: src/option.c:332
 msgid "Set output mode to MODE. Values are hex (default) or rgb"
 msgstr ""
 
-#: src/option.c:330
+#: src/option.c:332
 msgid "MODE"
 msgstr ""
 
-#: src/option.c:332
+#: src/option.c:334
 msgid "Add opacity to output color value"
 msgstr ""
 
-#: src/option.c:338
+#: src/option.c:340
 msgid "Display drag-n-drop box"
 msgstr "Visualizza il box per il drag-n-drop"
 
-#: src/option.c:340
+#: src/option.c:342
 msgid "Use dialog text as tooltip"
 msgstr "Usa il testo della finestra di dialogo come suggerimento"
 
-#: src/option.c:342
+#: src/option.c:344
 msgid "Exit after NUMBER of drops"
 msgstr ""
 
-#: src/option.c:348
+#: src/option.c:350
 msgid "Display text entry or combo-box dialog"
 msgstr ""
 "Mostra l'elemento di immissione di testo o la finestra di dialogo casella "
 "combinata"
 
-#: src/option.c:350
+#: src/option.c:352
 msgid "Set the entry label"
 msgstr "Seleziona l'etichetta dell'elemento"
 
-#: src/option.c:352
+#: src/option.c:354
 msgid "Set the entry text"
 msgstr "Seleziona il testo dell'elemento di immissione di testo"
 
-#: src/option.c:354
+#: src/option.c:356
 msgid "Hide the entry text"
 msgstr "Nascondi il testo dell'elemento di immissione di testo"
 
-#: src/option.c:356
+#: src/option.c:358
 msgid "Use completion instead of combo-box"
 msgstr "Utilizza il completamento automatico al posto della casella combinata"
 
-#: src/option.c:358
+#: src/option.c:360
 msgid "Use spin button for text entry"
 msgstr "Utilizza lo spin button per l'elemento di immissione di testo"
 
-#: src/option.c:360
+#: src/option.c:362
 msgid "Set the left entry icon"
 msgstr "Seleziona l'icona dell'elemento a sinistra "
 
-#: src/option.c:362
+#: src/option.c:364
 msgid "Set the left entry icon action"
 msgstr "Seleziona l'azione dell'icona dell'elemento a sinistra"
 
-#: src/option.c:364
+#: src/option.c:366
 msgid "Set the right entry icon"
 msgstr "Seleziona l'icona dell'elemento a destra"
 
-#: src/option.c:366
+#: src/option.c:368
 msgid "Set the right entry icon action"
 msgstr "Seleziona l'azione dell'icona dell'elemento a destra"
 
-#: src/option.c:372
+#: src/option.c:374
 msgid "Display file selection dialog"
 msgstr "Mostra la finestra di dialogo per la selezione dei file"
 
-#: src/option.c:374
+#: src/option.c:376
 msgid "Activate directory-only selection"
 msgstr "Attiva la selezione delle sole cartelle"
 
-#: src/option.c:376
+#: src/option.c:378
 msgid "Activate save mode"
 msgstr "Activa la modalità di salvataggio"
 
-#: src/option.c:378
+#: src/option.c:380
 msgid "Confirm file selection if filename already exists"
 msgstr "Conferma la selezione del file se già esiste"
 
-#: src/option.c:384
+#: src/option.c:386
 msgid "Display font selection dialog"
 msgstr "Mostra la finestra di dialogo per la selezione del font"
 
-#: src/option.c:386
+#: src/option.c:388
 msgid "Set text string for preview"
 msgstr ""
 
-#: src/option.c:388
+#: src/option.c:390
 msgid "Separate output of font description"
 msgstr ""
 
-#: src/option.c:394
+#: src/option.c:396
 msgid "Display form dialog"
 msgstr "Mostra la finestra di dialogo per le tabelle"
 
-#: src/option.c:396
+#: src/option.c:398
 msgid "Add field to form (see man page for list of possible types)"
 msgstr ""
 
-#: src/option.c:396 src/option.c:631
+#: src/option.c:398 src/option.c:633
 msgid "LABEL[:TYPE]"
 msgstr "ETICHETTA[:TIPO]"
 
-#: src/option.c:398
+#: src/option.c:400
 msgid "Set alignment of filed labels (left, center or right)"
 msgstr "Seleziona l'allineamento dei campi (a sinistra, centrato, a destra)"
 
-#: src/option.c:400
+#: src/option.c:402
 msgid "Set number of columns in form"
 msgstr "Seleziona il numero delle colonne della tabella"
 
-#: src/option.c:402
+#: src/option.c:404
 msgid "Make form fields height and columns width the same size"
 msgstr ""
 
-#: src/option.c:404
+#: src/option.c:406
 msgid "Order output fields by rows"
 msgstr ""
 
-#: src/option.c:406
+#: src/option.c:408
 #, fuzzy
 msgid "Set focused field"
 msgstr "Seleziona il valore del passo"
 
-#: src/option.c:408
+#: src/option.c:410
 msgid "Cycled reading of stdin data"
 msgstr ""
 
-#: src/option.c:410
+#: src/option.c:412
 msgid "Align labels on button fields"
 msgstr ""
 
-#: src/option.c:412
+#: src/option.c:414
 #, fuzzy
 msgid "Set changed action"
 msgstr "Seleziona l'azione al click sinistro"
 
-#: src/option.c:419
+#: src/option.c:421
 #, fuzzy
 msgid "Display HTML dialog"
 msgstr "Mostra la finestra di dialogo per le tabelle"
 
-#: src/option.c:421
+#: src/option.c:423
 #, fuzzy
 msgid "Open specified location"
 msgstr "Usa il font specificato"
 
-#: src/option.c:423
+#: src/option.c:425
 #, fuzzy
 msgid "Turn on browser mode"
 msgstr "- Navigatore di icone"
 
-#: src/option.c:425
+#: src/option.c:427
 msgid "Print clicked uri to stdout"
 msgstr ""
 
-#: src/option.c:427
+#: src/option.c:429
 msgid "Set encoding of input stream data"
 msgstr ""
 
-#: src/option.c:427
+#: src/option.c:429
 msgid "ENCODING"
 msgstr ""
 
-#: src/option.c:429
+#: src/option.c:431
 msgid "Set user agent string"
 msgstr ""
 
-#: src/option.c:431
+#: src/option.c:433
 msgid "Set custom user style"
 msgstr ""
 
-#: src/option.c:433
+#: src/option.c:435
 msgid "Set WebKit property"
 msgstr ""
 
-#: src/option.c:433
+#: src/option.c:435
 msgid "PROP"
 msgstr ""
 
-#: src/option.c:440
+#: src/option.c:442
 msgid "Display icons box dialog"
 msgstr "Mostra una finestra di dialogo contenente icone"
 
-#: src/option.c:442
+#: src/option.c:444
 msgid "Read data from .desktop files in specified directory"
 msgstr "Leggi i dati dai .desktop file nella cartella selezionata"
 
-#: src/option.c:442
+#: src/option.c:444
 msgid "DIR"
 msgstr ""
 
-#: src/option.c:444
+#: src/option.c:446
 msgid "Use compact (list) view"
 msgstr "Utilizza la vista compatta (a lista)"
 
-#: src/option.c:446
+#: src/option.c:448
 msgid "Use GenericName field instead of Name for icon label"
 msgstr ""
 "Utilizza il nome generico piuttosto che il nome come etichetta dell'icona"
 
-#: src/option.c:448
+#: src/option.c:450
 msgid "Set the width of dialog items"
 msgstr "Configura la larghezza degli elementi della finestra di dialogo"
 
-#: src/option.c:450
+#: src/option.c:452
 msgid "Force using specified icon size"
 msgstr ""
 
-#: src/option.c:450 src/option.c:564 src/option.c:700 src/tools.c:85
+#: src/option.c:452 src/option.c:566 src/option.c:702 src/tools.c:85
 msgid "SIZE"
 msgstr "DIMENSIONE"
 
-#: src/option.c:453
+#: src/option.c:455
 #, no-c-format
 msgid ""
 "Use specified pattern for launch command in terminal (default: xterm -e %s)"
@@ -1055,90 +1065,90 @@ msgstr ""
 "Usa il pattern specificato per lanciare i comandi dal terminale "
 "(predefinito: xterm-e% s)"
 
-#: src/option.c:455
+#: src/option.c:457
 msgid "Sort items by name instead of filename"
 msgstr "Ordina gli elementi per nome piuttosto che per nome del file"
 
-#: src/option.c:457
+#: src/option.c:459
 msgid "Sort items in descending order"
 msgstr "Ordina gli elementi in ordine decrescente"
 
-#: src/option.c:459
+#: src/option.c:461
 msgid "Activate items by single click"
 msgstr "Attiva gli elemento solo con un click"
 
-#: src/option.c:461
+#: src/option.c:463
 msgid "Watch fot changes in directory"
 msgstr ""
 
-#: src/option.c:467
+#: src/option.c:469
 msgid "Display list dialog"
 msgstr "Mostra la finestra di dialogo per le liste"
 
-#: src/option.c:469
+#: src/option.c:471
 msgid "Set the column header (see man page for list of possible types)"
 msgstr ""
 
-#: src/option.c:469
+#: src/option.c:471
 msgid "COLUMN[:TYPE]"
 msgstr "COLONNA[:TIPO]"
 
-#: src/option.c:471
+#: src/option.c:473
 msgid "Enbale tree mode"
 msgstr ""
 
-#: src/option.c:473
+#: src/option.c:475
 msgid "Use checkboxes for first column"
 msgstr "Usa checkbox per la prima colonna"
 
-#: src/option.c:475
+#: src/option.c:477
 msgid "Use radioboxes for first column"
 msgstr "Usa radiobox per la prima colonna"
 
-#: src/option.c:477
+#: src/option.c:479
 msgid "Don't show column headers"
 msgstr "Non mostrare l'intestazione delle colonne"
 
-#: src/option.c:479
+#: src/option.c:481
 msgid "Disable clickable column headers"
 msgstr ""
 
-#: src/option.c:481
+#: src/option.c:483
 msgid "Set grid lines (hor[izontal], vert[ical] or both)"
 msgstr ""
 
-#: src/option.c:483
+#: src/option.c:485
 msgid "Print all data from list"
 msgstr "Stampa tutti i dati della lista"
 
-#: src/option.c:485
+#: src/option.c:487
 #, fuzzy
 msgid "Set the list of editable columns"
 msgstr "Configura la larghezza degli elementi della finestra di dialogo"
 
-#: src/option.c:487
+#: src/option.c:489
 #, fuzzy
 msgid "Set the width of a column for start wrapping text"
 msgstr "Configura la larghezza degli elementi della finestra di dialogo"
 
-#: src/option.c:489
+#: src/option.c:491
 #, fuzzy
 msgid "Set the list of wrapped columns"
 msgstr "Seleziona il limite massimo delle linee nella lista"
 
-#: src/option.c:491
+#: src/option.c:493
 #, fuzzy
 msgid "Set ellipsize mode for text columns (none, start, middle or end)"
 msgstr ""
 "Seleziona la modalità arrotondata per il testo delle colonne(TIPO - NONE, "
 "START, MIDDLE or END)"
 
-#: src/option.c:493
+#: src/option.c:495
 #, fuzzy
 msgid "Set the list of ellipsized columns"
 msgstr "Seleziona il limite massimo delle linee nella lista"
 
-#: src/option.c:495
+#: src/option.c:497
 msgid ""
 "Print a specific column. By default or if 0 is specified will be printed all "
 "columns"
@@ -1146,17 +1156,17 @@ msgstr ""
 "Stampa una specifica colonna. Come comportamento predefinito o scegliendo 0 "
 "sarannostampate tutte le colonne"
 
-#: src/option.c:497
+#: src/option.c:499
 msgid "Hide a specific column"
 msgstr "Nascondi una specifica colonna"
 
-#: src/option.c:499
+#: src/option.c:501
 msgid "Set the column expandable by default. 0 sets all columns expandable"
 msgstr ""
 "Seleziona una colonna predefinita estendibile. 0 seleziona tutte le colonne "
 "come estendibili"
 
-#: src/option.c:501
+#: src/option.c:503
 msgid ""
 "Set the quick search column. Default is first column. Set it to 0 for "
 "disable searching"
@@ -1164,862 +1174,862 @@ msgstr ""
 "Seleziona la colonna per la ricerca veloce. Quella predefinita è la prima "
 "colonna.Configura a 0 per disabilitare la ricerca"
 
-#: src/option.c:503
+#: src/option.c:505
 #, fuzzy
 msgid "Set the tooltip column"
 msgstr "Configura l'icona della finestra"
 
-#: src/option.c:505
+#: src/option.c:507
 #, fuzzy
 msgid "Set the row separator column"
 msgstr "Seleziona l'icona dell'elemento a destra"
 
-#: src/option.c:507
+#: src/option.c:509
 #, fuzzy
 msgid "Set the row separator value"
 msgstr "Seleziona il carattere separatore per l'output"
 
-#: src/option.c:509
+#: src/option.c:511
 msgid "Set the limit of rows in list"
 msgstr "Seleziona il limite massimo delle linee nella lista"
 
-#: src/option.c:511
+#: src/option.c:513
 msgid "Set double-click action"
 msgstr "Seleziona l'azione al doppio click"
 
-#: src/option.c:515
+#: src/option.c:517
 #, fuzzy
 msgid "Set row action"
 msgstr "Seleziona l'azione al doppio click"
 
-#: src/option.c:517
+#: src/option.c:519
 msgid "Expand all tree nodes"
 msgstr ""
 
-#: src/option.c:519
+#: src/option.c:521
 msgid "Use regex in search"
 msgstr "Utilizza regular expression nella ricerca"
 
-#: src/option.c:521
+#: src/option.c:523
 #, fuzzy
 msgid "Disable selection"
 msgstr "Mostra la finestra di dialogo per la selezione dei file"
 
-#: src/option.c:523
+#: src/option.c:525
 msgid "Add new records on the top of a list"
 msgstr ""
 
-#: src/option.c:525
+#: src/option.c:527
 msgid "Don't use markup in tooltips"
 msgstr ""
 
-#: src/option.c:527
+#: src/option.c:529
 msgid "Use column name as a header tooltip"
 msgstr ""
 
-#: src/option.c:529
+#: src/option.c:531
 #, fuzzy
 msgid "Set columns alignment"
 msgstr "Seleziona il numero delle colonne della tabella"
 
-#: src/option.c:531
+#: src/option.c:533
 #, fuzzy
 msgid "Set headers alignment"
 msgstr "Seleziona il mese nel calendario"
 
-#: src/option.c:537
+#: src/option.c:539
 #, fuzzy
 msgid "Display notebook dialog"
 msgstr "Mostra una finestra di dialogo a schede"
 
-#: src/option.c:539
+#: src/option.c:541
 msgid "Add a tab to notebook"
 msgstr "Aggiungi una scheda alla finestra di dialogo a schede"
 
-#: src/option.c:539
+#: src/option.c:541
 msgid "LABEL"
 msgstr "ETICHETTA"
 
-#: src/option.c:541
+#: src/option.c:543
 #, fuzzy
 msgid "Set position of a notebook tabs (top, bottom, left or right)"
 msgstr ""
 "Mostra un indicatore del tempo mancante alla scomparsa (su, giù, sinistra, "
 "destra)"
 
-#: src/option.c:543
+#: src/option.c:545
 msgid "Set tab borders"
 msgstr "Seleziona i bordi delle schede"
 
-#: src/option.c:545
+#: src/option.c:547
 #, fuzzy
 msgid "Set active tab"
 msgstr "Seleziona l'etichetta dell'elemento"
 
-#: src/option.c:547
+#: src/option.c:549
 msgid "Expand tabs"
 msgstr ""
 
-#: src/option.c:549
+#: src/option.c:551
 msgid "Use stack mode"
 msgstr ""
 
-#: src/option.c:556
+#: src/option.c:558
 msgid "Display notification"
 msgstr "Usa la notifica"
 
-#: src/option.c:558 src/option.c:574
+#: src/option.c:560 src/option.c:576
 #, fuzzy
 msgid "Set initial popup menu"
 msgstr "Seleziona il font iniziale"
 
-#: src/option.c:560
+#: src/option.c:562
 msgid "Disable exit on middle click"
 msgstr ""
 
-#: src/option.c:562 src/option.c:576
+#: src/option.c:564 src/option.c:578
 #, fuzzy
 msgid "Doesn't show icon at startup"
 msgstr "Non mostrare la finestra nella lista dei task"
 
-#: src/option.c:564
+#: src/option.c:566
 msgid "Set icon size for fully specified icons (default - 16)"
 msgstr ""
 
-#: src/option.c:572
+#: src/option.c:574
 msgid "Display indicator icon (StatusNotifier/AppIndicator)"
 msgstr ""
 
-#: src/option.c:583
+#: src/option.c:585
 #, fuzzy
 msgid "Display paned dialog"
 msgstr "Mostra la finestra di dialogo a scala"
 
-#: src/option.c:585
+#: src/option.c:587
 msgid "Set orientation (hor[izontal] or vert[ical])"
 msgstr ""
 
-#: src/option.c:587
+#: src/option.c:589
 #, fuzzy
 msgid "Set initial splitter position"
 msgstr "Seleziona la percentuale iniziale"
 
-#: src/option.c:589
+#: src/option.c:591
 msgid "Set focused pane (1 or 2)"
 msgstr ""
 
-#: src/option.c:589
+#: src/option.c:591
 msgid "PANE"
 msgstr ""
 
-#: src/option.c:595
+#: src/option.c:597
 #, fuzzy
 msgid "Display picture dialog"
 msgstr "Mostra la finestra di dialogo per le liste"
 
-#: src/option.c:597
+#: src/option.c:599
 #, fuzzy
 msgid "Set initial size (fit or orig)"
 msgstr "Seleziona il font iniziale"
 
-#: src/option.c:599
+#: src/option.c:601
 msgid "Set increment for picture scaling (default - 5)"
 msgstr ""
 
-#: src/option.c:601
+#: src/option.c:603
 msgid "Set action on image changing"
 msgstr ""
 
-#: src/option.c:607
+#: src/option.c:609
 #, fuzzy
 msgid "Display popup dialog"
 msgstr "Mostra la finestra di dialogo per le liste"
 
-#: src/option.c:609
+#: src/option.c:611
 #, fuzzy
 msgid "Set alignment of title and text (left, center or right)"
 msgstr "Seleziona l'allineamento dei campi (a sinistra, centrato, a destra)"
 
-#: src/option.c:611
+#: src/option.c:613
 msgid "Set transparency"
 msgstr ""
 
-#: src/option.c:611
+#: src/option.c:613
 #, fuzzy
 msgid "PERCENT"
 msgstr "PERCENTUALE"
 
-#: src/option.c:613
+#: src/option.c:615
 msgid "Don't close popup by timeout"
 msgstr ""
 
-#: src/option.c:619
+#: src/option.c:621
 msgid "Display printing dialog"
 msgstr "Mostra una finestra di dialogo di stampa"
 
-#: src/option.c:621
+#: src/option.c:623
 #, fuzzy
 msgid "Set source type (text, image or raw)"
 msgstr "Seleziona il tipo di sorgente (TIPO - TEXT, IMAGE or RAW)"
 
-#: src/option.c:623
+#: src/option.c:625
 msgid "Add headers to page"
 msgstr "Aggiungi intestazione alla pagina"
 
-#: src/option.c:629
+#: src/option.c:631
 msgid "Display progress indication dialog"
 msgstr "Mostra la finestra di dialogo della barra di avanzamento"
 
-#: src/option.c:631
+#: src/option.c:633
 #, fuzzy
 msgid "Add the progress bar (norm, rtl, pulse, cpulse or perm)"
 msgstr "Aggiungi una barra di avanzamento (TIPO - NORM, RTL or PULSE)"
 
-#: src/option.c:633
+#: src/option.c:635
 msgid "Watch for specific bar for auto close"
 msgstr ""
 
-#: src/option.c:635
+#: src/option.c:637
 #, fuzzy
 msgid "Set alignment of bar labels (left, center or right)"
 msgstr ""
 "Seleziona l'allineamentio delle etichette nelle barre (a sinistra, centrate, "
 "a destra)"
 
-#: src/option.c:637
+#: src/option.c:639
 msgid "Set progress text"
 msgstr "Seleziona il testo della barra di avanzamento"
 
-#: src/option.c:639
+#: src/option.c:641
 #, fuzzy
 msgid "Hide text on progress bar"
 msgstr "Barra di avanzamento pulsante"
 
-#: src/option.c:641
+#: src/option.c:643
 msgid "Pulsate progress bar"
 msgstr "Barra di avanzamento pulsante"
 
-#: src/option.c:643
+#: src/option.c:645
 #, fuzzy
 msgid "Conlinuous pulsating progress bar"
 msgstr "Barra di avanzamento pulsante"
 
-#: src/option.c:646
+#: src/option.c:648
 #, no-c-format
 msgid "Dismiss the dialog when 100% has been reached"
 msgstr "Chiudi la finestra di dialogo quando arriva al 100%"
 
-#: src/option.c:649
+#: src/option.c:651
 msgid "Kill parent process if cancel button is pressed"
 msgstr "Uccidi il processo genitore quando viene schiacciato il bottone cancel"
 
-#: src/option.c:652
+#: src/option.c:654
 msgid "Right-To-Left progress bar direction"
 msgstr "Direzione della barra di avanzamento da destra a sinistra"
 
-#: src/option.c:654
+#: src/option.c:656
 msgid "Show log window"
 msgstr "Mostra la finestra dei log"
 
-#: src/option.c:656
+#: src/option.c:658
 msgid "Expand log window"
 msgstr "Espandi la finestra dei log"
 
-#: src/option.c:658
+#: src/option.c:660
 #, fuzzy
 msgid "Place log window above progress bar"
 msgstr "Colloca la finestra dei log sopra alla barra di avanzamento"
 
-#: src/option.c:660
+#: src/option.c:662
 msgid "Height of log window"
 msgstr "Altezza della finestra dei log"
 
-#: src/option.c:666
+#: src/option.c:668
 msgid "Display scale dialog"
 msgstr "Mostra la finestra di dialogo a scala"
 
-#: src/option.c:668
+#: src/option.c:670
 msgid "Set initial value"
 msgstr "Seleziona il valore iniziale"
 
-#: src/option.c:668 src/option.c:670 src/option.c:672 src/option.c:674
-#: src/option.c:678 src/option.c:745 src/option.c:747
+#: src/option.c:670 src/option.c:672 src/option.c:674 src/option.c:676
+#: src/option.c:680 src/option.c:747 src/option.c:749
 msgid "VALUE"
 msgstr "VALORE"
 
-#: src/option.c:670
+#: src/option.c:672
 msgid "Set minimum value"
 msgstr "Seleziona il valore minimo"
 
-#: src/option.c:672
+#: src/option.c:674
 msgid "Set maximum value"
 msgstr "Seleziona il valore massimo"
 
-#: src/option.c:674
+#: src/option.c:676
 msgid "Set step size"
 msgstr "Seleziona il valore del passo"
 
-#: src/option.c:676
+#: src/option.c:678
 msgid "Only allow values in step increments"
 msgstr ""
 
-#: src/option.c:678
+#: src/option.c:680
 msgid "Set paging size"
 msgstr "Seleziona la dimensione del paginamento"
 
-#: src/option.c:680
+#: src/option.c:682
 msgid "Print partial values"
 msgstr "Stampa i valori parziali"
 
-#: src/option.c:682
+#: src/option.c:684
 msgid "Hide value"
 msgstr "Nascondi il valore"
 
-#: src/option.c:684
+#: src/option.c:686
 msgid "Invert direction"
 msgstr "Inverti la direzione"
 
-#: src/option.c:686
+#: src/option.c:688
 msgid "Show +/- buttons in scale"
 msgstr ""
 
-#: src/option.c:688
+#: src/option.c:690
 msgid "Add mark to scale (may be used multiple times)"
 msgstr "Aggiungi un marcatore alla scala (può essere usato più volte)"
 
-#: src/option.c:688
+#: src/option.c:690
 msgid "NAME:VALUE"
 msgstr "NOME:VALORE"
 
-#: src/option.c:694
+#: src/option.c:696
 msgid "Display text information dialog"
 msgstr "Mostra la finestra di dialogo di testo"
 
-#: src/option.c:696
+#: src/option.c:698
 msgid "Enable text wrapping"
 msgstr "Abilita il text wrapping"
 
-#: src/option.c:698
+#: src/option.c:700
 #, fuzzy
 msgid "Set justification (left, right, center or fill)"
 msgstr "Seleziona il tipo (TIPO - a sinistra, a destra, centrato o riempi)"
 
-#: src/option.c:700
+#: src/option.c:702
 msgid "Set text margins"
 msgstr "Seleziona i margini del testo"
 
-#: src/option.c:702
+#: src/option.c:704
 #, fuzzy
 msgid "Jump to specific line"
 msgstr "Nascondi una specifica colonna"
 
-#: src/option.c:704
+#: src/option.c:706
 msgid "Use specified color for text"
 msgstr "Usa il colore specificato per il testo"
 
-#: src/option.c:706
+#: src/option.c:708
 msgid "Use specified color for background"
 msgstr "Usa il colore specificato per lo sfondo"
 
-#: src/option.c:708
+#: src/option.c:710
 msgid "Show cursor in read-only mode"
 msgstr ""
 
-#: src/option.c:710
+#: src/option.c:712
 msgid "Make URI clickable"
 msgstr "Rendi l'URI cliccabile"
 
-#: src/option.c:712
+#: src/option.c:714
 #, fuzzy
 msgid "Use specified color for links"
 msgstr "Usa il colore specificato per il testo"
 
-#: src/option.c:714
+#: src/option.c:716
 msgid "Use pango markup"
 msgstr ""
 
-#: src/option.c:716
+#: src/option.c:718
 msgid "Save file instead of print on exit"
 msgstr ""
 
-#: src/option.c:718
+#: src/option.c:720
 msgid "Confirm save the file if text was changed"
-msgstr ""
-
-#: src/option.c:725
-#, fuzzy
-msgid "Use specified langauge for syntax highlighting"
-msgstr "Usa il colore specificato per il testo"
-
-#: src/option.c:725
-msgid "LANG"
 msgstr ""
 
 #: src/option.c:727
 #, fuzzy
+msgid "Use specified langauge for syntax highlighting"
+msgstr "Usa il colore specificato per il testo"
+
+#: src/option.c:727
+msgid "LANG"
+msgstr ""
+
+#: src/option.c:729
+#, fuzzy
 msgid "Use specified theme"
 msgstr "Usa il font specificato"
 
-#: src/option.c:729
+#: src/option.c:731
 msgid "Show line numbers"
 msgstr ""
 
-#: src/option.c:731
+#: src/option.c:733
 msgid "Highlight current line"
 msgstr ""
 
-#: src/option.c:733
+#: src/option.c:735
 msgid "Enable line marks"
 msgstr ""
 
-#: src/option.c:735
+#: src/option.c:737
 msgid "Set color for first type marks"
 msgstr ""
 
-#: src/option.c:737
+#: src/option.c:739
 msgid "Set color for second type marks"
 msgstr ""
 
-#: src/option.c:739
+#: src/option.c:741
 msgid "Set position of right margin"
 msgstr ""
 
-#: src/option.c:739
+#: src/option.c:741
 msgid "[POS]"
 msgstr ""
 
-#: src/option.c:741
+#: src/option.c:743
 msgid "Highlight matching brackets"
 msgstr ""
 
-#: src/option.c:743
+#: src/option.c:745
 msgid "Use autoindent"
 msgstr ""
 
-#: src/option.c:745
+#: src/option.c:747
 #, fuzzy
 msgid "Set tabulation width"
 msgstr "Configura la larghezza"
 
-#: src/option.c:747
+#: src/option.c:749
 #, fuzzy
 msgid "Set indentation width"
 msgstr "Configura la larghezza"
 
-#: src/option.c:749
+#: src/option.c:751
 msgid "Set smart Home/End behavior"
 msgstr ""
 
-#: src/option.c:751
+#: src/option.c:753
 msgid "Enable smart backspace"
 msgstr ""
 
-#: src/option.c:753
+#: src/option.c:755
 msgid "Insert spaces instead of tabs"
 msgstr ""
 
-#: src/option.c:760
+#: src/option.c:762
 msgid "Sets a filename filter"
 msgstr "Seleziona un filtro per i file"
 
-#: src/option.c:760
+#: src/option.c:762
 msgid "NAME | PATTERN1 PATTERN2 ..."
 msgstr "NOME | PATTERN1 PATTERN2 ..."
 
-#: src/option.c:762
+#: src/option.c:764
 #, fuzzy
 msgid "Sets a mime-type filter"
 msgstr "Seleziona un filtro per i file"
 
-#: src/option.c:762
+#: src/option.c:764
 #, fuzzy
 msgid "NAME | MIME1 MIME2 ..."
 msgstr "NOME | PATTERN1 PATTERN2 ..."
 
-#: src/option.c:764
+#: src/option.c:766
 #, fuzzy
 msgid "Add filter for images"
 msgstr "Aggiungi intestazione alla pagina"
 
-#: src/option.c:764
+#: src/option.c:766
 #, fuzzy
 msgid "[NAME]"
 msgstr "NOME:ID"
 
-#: src/option.c:770 src/tools.c:64
+#: src/option.c:772 src/tools.c:64
 msgid "Print version"
 msgstr "Stampa versione"
 
-#: src/option.c:772
+#: src/option.c:774
 msgid "Load additional CSS settings from file or string"
 msgstr ""
 
-#: src/option.c:775
+#: src/option.c:777
 #, fuzzy
 msgid "Load additional CSS settings from file"
 msgstr "Carica argomenti addizionali da file"
 
-#: src/option.c:778
+#: src/option.c:780
 msgid "Set policy for horizontal scrollbars (auto, always, never)"
 msgstr ""
 
-#: src/option.c:780
+#: src/option.c:782
 msgid "Set policy for vertical scrollbars (auto, always, never)"
 msgstr ""
 
-#: src/option.c:782
+#: src/option.c:784
 msgid "Add path for search icons by name"
 msgstr ""
 
-#: src/option.c:784
+#: src/option.c:786
 msgid "Write settings to file and exit"
 msgstr ""
 
-#: src/option.c:790
+#: src/option.c:792
 msgid "Load extra arguments from file"
 msgstr "Carica argomenti addizionali da file"
 
-#: src/option.c:1001
+#: src/option.c:1003
 #, c-format
 msgid "Mark %s doesn't have a value\n"
 msgstr "Il marcatore %s non ha valori\n"
 
-#: src/option.c:1048 src/picture.c:286
+#: src/option.c:1050 src/picture.c:286
 msgid "Images"
 msgstr ""
 
-#: src/option.c:1113
+#: src/option.c:1115
 #, fuzzy, c-format
 msgid "Unknown color mode: %s\n"
 msgstr "Commando sconosciuto: '%s'\n"
 
-#: src/option.c:1132
+#: src/option.c:1134
 #, c-format
 msgid "Unknown buttons layout type: %s\n"
 msgstr "Tipo di allineamento sconosciuto: %s\n"
 
-#: src/option.c:1147
+#: src/option.c:1149
 #, c-format
 msgid "Unknown align type: %s\n"
 msgstr "Tipo di allineamento sconosciuto: %s\n"
 
-#: src/option.c:1171
+#: src/option.c:1173
 #, c-format
 msgid "Unknown justification type: %s\n"
 msgstr "Tipo di giustificazione sconosciuto: %s\n"
 
-#: src/option.c:1188
+#: src/option.c:1190
 #, fuzzy, c-format
 msgid "Unknown tab position type: %s\n"
 msgstr "Tipo di allineamento sconosciuto: %s\n"
 
-#: src/option.c:1225
+#: src/option.c:1227
 #, c-format
 msgid "Unknown ellipsize type: %s\n"
 msgstr "Tipo di arrotondamento sconosciuto: %s\n"
 
-#: src/option.c:1238
+#: src/option.c:1240
 #, fuzzy, c-format
 msgid "Unknown orientation: %s\n"
 msgstr "Segnale sconosciuto: %s\n"
 
-#: src/option.c:1253
+#: src/option.c:1255
 #, c-format
 msgid "Unknown source type: %s\n"
 msgstr "Tipo di sorgente sconosciuto: %s\n"
 
-#: src/option.c:1264
+#: src/option.c:1266
 #, fuzzy
 msgid "Progress log"
 msgstr "Log della barra di avanzamento"
 
-#: src/option.c:1277
+#: src/option.c:1279
 #, fuzzy, c-format
 msgid "Unknown size type: %s\n"
 msgstr "Tipo di arrotondamento sconosciuto: %s\n"
 
-#: src/option.c:1321
+#: src/option.c:1323
 #, fuzzy, c-format
 msgid "Unknown completion type: %s\n"
 msgstr "Tipo di allineamento sconosciuto: %s\n"
 
-#: src/option.c:1353
+#: src/option.c:1355
 #, fuzzy, c-format
 msgid "Unknown boolean format type: %s\n"
 msgstr "Tipo di allineamento sconosciuto: %s\n"
 
-#: src/option.c:1369
+#: src/option.c:1371
 #, fuzzy, c-format
 msgid "Unknown grid lines type: %s\n"
 msgstr "Tipo di allineamento sconosciuto: %s\n"
 
-#: src/option.c:1386
+#: src/option.c:1388
 #, fuzzy, c-format
 msgid "Unknown scrollbar policy type: %s\n"
 msgstr "Tipo di sorgente sconosciuto: %s\n"
 
-#: src/option.c:1437
+#: src/option.c:1439
 #, fuzzy, c-format
 msgid "Unknown window type: %s\n"
 msgstr "Tipo di allineamento sconosciuto: %s\n"
 
-#: src/option.c:1466
+#: src/option.c:1468
 #, fuzzy, c-format
 msgid "Unknown smart Home/End mode: %s\n"
 msgstr "Tipo di sorgente sconosciuto: %s\n"
 
-#: src/option.c:1576
+#: src/option.c:1578
 #, c-format
 msgid "Unknown signal: %s\n"
 msgstr "Segnale sconosciuto: %s\n"
 
-#: src/option.c:1811
+#: src/option.c:1814
 msgid "File exist. Overwrite?"
 msgstr "Il file esiste. Sovrascrivo?"
 
-#: src/option.c:1953
+#: src/option.c:1956
 msgid "File was changed. Save it?"
 msgstr ""
 
-#: src/option.c:1984
+#: src/option.c:1987
 #, fuzzy
 msgid "- Yet another dialoging program"
 msgstr "Yet another dialoging program"
 
-#: src/option.c:1988
+#: src/option.c:1991
 msgid "General options"
 msgstr "Opzioni generiche"
 
-#: src/option.c:1988
+#: src/option.c:1991
 msgid "Show general options"
 msgstr "Mostra le opzioni generiche"
 
-#: src/option.c:1994
+#: src/option.c:1997
 #, fuzzy
 msgid "Common options"
 msgstr "Opzioni della form"
 
-#: src/option.c:1994
+#: src/option.c:1997
 #, fuzzy
 msgid "Show common options"
 msgstr "Mostra le opzioni della form"
 
-#: src/option.c:2000
+#: src/option.c:2003
 #, fuzzy
 msgid "About dialog options"
 msgstr "Stampa le opzioni della finestra i dialogo"
 
-#: src/option.c:2000
+#: src/option.c:2003
 #, fuzzy
 msgid "Show custom about dialog options"
 msgstr "Mostra le opzioni della finestra di dialogo con menù a schede"
 
-#: src/option.c:2006
+#: src/option.c:2009
 #, fuzzy
 msgid "Application selection options"
 msgstr "Opzioni della selezione di font"
 
-#: src/option.c:2006
+#: src/option.c:2009
 #, fuzzy
 msgid "Show application selection options"
 msgstr "Mostra le opzioni della selezione di font"
 
-#: src/option.c:2012
+#: src/option.c:2015
 msgid "Calendar options"
 msgstr "Options del calendario"
 
-#: src/option.c:2012
+#: src/option.c:2015
 msgid "Show calendar options"
 msgstr "Mostra le opzioni del calendario"
 
-#: src/option.c:2018
+#: src/option.c:2021
 msgid "Color selection options"
 msgstr "Opzioni della selezione del colore"
 
-#: src/option.c:2018
+#: src/option.c:2021
 msgid "Show color selection options"
 msgstr "Mostra le opzioni della selezione del colore"
 
-#: src/option.c:2024
+#: src/option.c:2027
 msgid "DND options"
 msgstr "Opzioni del drag-n-drop"
 
-#: src/option.c:2024
+#: src/option.c:2027
 msgid "Show drag-n-drop options"
 msgstr "Mostra le opzioni del drag-n-drop"
 
-#: src/option.c:2030
+#: src/option.c:2033
 msgid "Text entry options"
 msgstr "Opzioni dell'elemento per l'immissione di testo"
 
-#: src/option.c:2030
+#: src/option.c:2033
 msgid "Show text entry options"
 msgstr "Mostra le opzioni dell'elemento per l'immissione di testo"
 
-#: src/option.c:2036
+#: src/option.c:2039
 msgid "File selection options"
 msgstr "Opzioni della selezione di file"
 
-#: src/option.c:2036
+#: src/option.c:2039
 msgid "Show file selection options"
 msgstr "Mostra le opzioni della selezione di file"
 
-#: src/option.c:2042
+#: src/option.c:2045
 msgid "Font selection options"
 msgstr "Opzioni della selezione di font"
 
-#: src/option.c:2042
+#: src/option.c:2045
 msgid "Show font selection options"
 msgstr "Mostra le opzioni della selezione di font"
 
-#: src/option.c:2048
+#: src/option.c:2051
 msgid "Form options"
 msgstr "Opzioni della form"
 
-#: src/option.c:2048
+#: src/option.c:2051
 msgid "Show form options"
 msgstr "Mostra le opzioni della form"
 
-#: src/option.c:2055
+#: src/option.c:2058
 #, fuzzy
 msgid "HTML options"
 msgstr "Optioni delle liste"
 
-#: src/option.c:2055
+#: src/option.c:2058
 #, fuzzy
 msgid "Show HTML options"
 msgstr "Mostra le opzioni della form"
 
-#: src/option.c:2062
+#: src/option.c:2065
 msgid "Icons box options"
 msgstr "Opzioni del contenitore di icone"
 
-#: src/option.c:2062
+#: src/option.c:2065
 msgid "Show icons box options"
 msgstr "Mostra le opzioni del contenitore di icone"
 
-#: src/option.c:2068
+#: src/option.c:2071
 msgid "List options"
 msgstr "Optioni delle liste"
 
-#: src/option.c:2068
+#: src/option.c:2071
 msgid "Show list options"
 msgstr "Mostra le opzioni delle liste"
 
-#: src/option.c:2074
+#: src/option.c:2077
 msgid "Notebook options"
 msgstr "Opzioni del menù a schede"
 
-#: src/option.c:2074
+#: src/option.c:2077
 msgid "Show notebook dialog options"
 msgstr "Mostra le opzioni della finestra di dialogo con menù a schede"
 
-#: src/option.c:2081
+#: src/option.c:2084
 msgid "Notification icon options"
 msgstr "Opzioni delle icone di notifica"
 
-#: src/option.c:2082
+#: src/option.c:2085
 msgid "Show notification icon options"
 msgstr "Mostra le opzioni delle icone di notifica"
 
-#: src/option.c:2090
+#: src/option.c:2093
 #, fuzzy
 msgid "StatusNotifier/AppIndicator options"
 msgstr "Opzioni delle icone di notifica"
 
-#: src/option.c:2091
+#: src/option.c:2094
 #, fuzzy
 msgid "Show indicator options"
 msgstr "Mostra le opzioni delle finestra di dialogo"
 
-#: src/option.c:2098
+#: src/option.c:2101
 #, fuzzy
 msgid "Paned dialog options"
 msgstr "Stampa le opzioni della finestra i dialogo"
 
-#: src/option.c:2098
+#: src/option.c:2101
 #, fuzzy
 msgid "Show paned dialog options"
 msgstr "Mostra le opzioni delle finestra di dialogo"
 
-#: src/option.c:2104
+#: src/option.c:2107
 #, fuzzy
 msgid "Picture dialog options"
 msgstr "Stampa le opzioni della finestra i dialogo"
 
-#: src/option.c:2104
+#: src/option.c:2107
 #, fuzzy
 msgid "Show picture dialog options"
 msgstr "Mostra le opzioni delle finestra di dialogo"
 
-#: src/option.c:2110
+#: src/option.c:2113
 #, fuzzy
 msgid "Popup dialog options"
 msgstr "Stampa le opzioni della finestra i dialogo"
 
-#: src/option.c:2110
+#: src/option.c:2113
 #, fuzzy
 msgid "Show popup dialog options"
 msgstr "Mostra le opzioni delle finestra di dialogo"
 
-#: src/option.c:2116
+#: src/option.c:2119
 msgid "Print dialog options"
 msgstr "Stampa le opzioni della finestra i dialogo"
 
-#: src/option.c:2116
+#: src/option.c:2119
 #, fuzzy
 msgid "Show print dialog options"
 msgstr "Mostra le opzioni delle finestra di dialogo"
 
-#: src/option.c:2122
+#: src/option.c:2125
 msgid "Progress options"
 msgstr "Opzioni della barra di avanzamento"
 
-#: src/option.c:2122
+#: src/option.c:2125
 msgid "Show progress options"
 msgstr "Mostra le opzioni della barra di avanzamento"
 
-#: src/option.c:2128
+#: src/option.c:2131
 msgid "Scale options"
 msgstr "Opzione della scala"
 
-#: src/option.c:2128
+#: src/option.c:2131
 msgid "Show scale options"
 msgstr "Mostra le opzioni della scala"
 
-#: src/option.c:2134
+#: src/option.c:2137
 msgid "Text information options"
 msgstr "Opzioni della finestra del dialogo delle infomazioni"
 
-#: src/option.c:2134
+#: src/option.c:2137
 msgid "Show text information options"
 msgstr "Mostra le opzioni della finestra del dialogo delle infomazioni"
 
-#: src/option.c:2141
+#: src/option.c:2144
 #, fuzzy
 msgid "SourceView options"
 msgstr "Opzione della scala"
 
-#: src/option.c:2141
+#: src/option.c:2144
 #, fuzzy
 msgid "Show SourceView options"
 msgstr "Mostra le opzioni della form"
 
-#: src/option.c:2148
+#: src/option.c:2151
 #, fuzzy
 msgid "File filter options"
 msgstr "Opzioni della selezione di file"
 
-#: src/option.c:2148
+#: src/option.c:2151
 #, fuzzy
 msgid "Show file filter options"
 msgstr "Mostra le opzioni della selezione di file"
 
-#: src/option.c:2154
+#: src/option.c:2157
 msgid "Miscellaneous options"
 msgstr "Altre opzioni"
 
-#: src/option.c:2154
+#: src/option.c:2157
 msgid "Show miscellaneous options"
 msgstr "Mostra le altre opzioni"
 
@@ -2561,7 +2571,7 @@ msgstr ""
 msgid "Insert spaces instead of tabulation:CHK"
 msgstr ""
 
-#: src/yad-settings.sh:113 data/yad-settings.desktop.in:3
+#: src/yad-settings.sh:113 data/yad-settings.desktop.in:4
 msgid "YAD settings"
 msgstr ""
 
@@ -2581,15 +2591,15 @@ msgstr ""
 msgid "Editor"
 msgstr ""
 
-#: data/yad-icon-browser.desktop.in:3
+#: data/yad-icon-browser.desktop.in:4
 msgid "Icon Browser"
 msgstr "Navigatore di icone"
 
-#: data/yad-icon-browser.desktop.in:4
+#: data/yad-icon-browser.desktop.in:5
 msgid "Inspect GTK Icon Theme"
 msgstr "Sfoglia le icone del tema GTK"
 
-#: data/yad-settings.desktop.in:4
+#: data/yad-settings.desktop.in:5
 msgid "Simple GUI for editing YAD settings"
 msgstr ""
 

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: yad git\n"
 "Report-Msgid-Bugs-To: victor@sanana.kiev.ua\n"
-"POT-Creation-Date: 2026-06-30 16:06+0300\n"
+"POT-Creation-Date: 2026-07-06 22:04-0400\n"
 "PO-Revision-Date: 2026-01-01 15:41+0100\n"
 "Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>\n"
 "Language-Team: Georgian <(nothing)>\n"
@@ -93,15 +93,15 @@ msgstr "აირჩიეთ ან შექმენით საქაღა
 msgid "Select date"
 msgstr "აირჩიეთ თარიღი"
 
-#: src/form.c:1047
+#: src/form.c:1055
 msgid "Select file"
 msgstr "აირჩიეთ ფაილი"
 
-#: src/form.c:1077
+#: src/form.c:1085
 msgid "Select folder"
 msgstr "საქაღალდეს არჩევა"
 
-#: src/form.c:1245 src/form.c:1247
+#: src/form.c:1253 src/form.c:1255
 msgid "Link"
 msgstr "ბმული"
 
@@ -140,37 +140,37 @@ msgstr "%s საქაღალდის გახსნის შეცდო�
 msgid "%d sec"
 msgstr "%d წმ"
 
-#: src/main.c:748 src/main.c:755
+#: src/main.c:764 src/main.c:771
 #, c-format
 msgid "Unable to parse YAD_OPTIONS: %s\n"
 msgstr "YAD_OPTIONS-ის დამუშავების შეცდომა: %s\n"
 
-#: src/main.c:766
+#: src/main.c:782
 #, c-format
 msgid "Unable to parse command line: %s\n"
 msgstr "ბრძანების პარამეტრების დამუშავების შეცდომა: %s\n"
 
-#: src/main.c:780
+#: src/main.c:796
 msgid ""
 "WARNING: Using splash option is deprecated, please use --window-type instead"
 msgstr ""
 "გაფრთხილება: გაშვების სურათის პარამეტრი მოძველებულია. გამოიყენეთ მის მაგიერ "
 "--window-type"
 
-#: src/main.c:790
+#: src/main.c:806
 #, c-format
 msgid "Unable to change directory to %s: %s\n"
 msgstr "საქაღალდის %s-ზე შეცვლა შეუძლებელია: %s\n"
 
-#: src/main.c:819
+#: src/main.c:835
 msgid "WARNING: Using gtkrc option is deprecated, please use --css instead\n"
 msgstr "გაფრთხილება: gtkrc პარამეტრი მოძველებულია. გამოიყენეთ --css\n"
 
-#: src/main.c:893
+#: src/main.c:909
 msgid "WARNING: --plug mode not supported outside X11\n"
 msgstr "გაფრთხილება: --plug რეჟიმი X11-ის გარეთ მხარდაუჭერელია\n"
 
-#: src/main.c:913
+#: src/main.c:929
 msgid "WARNING: This mode not supported outside X11\n"
 msgstr "გაფრთხილება: ეს რეჟიმი X11-ის გარეთ მხარდაუჭერელია\n"
 
@@ -268,12 +268,12 @@ msgstr "სიმაღლე"
 msgid "Set the X position of a window"
 msgstr "ფანჯრის X პოზიციის დაყენება"
 
-#: src/option.c:106 src/option.c:108 src/option.c:118 src/option.c:140
-#: src/option.c:144 src/option.c:189 src/option.c:203 src/option.c:342
-#: src/option.c:400 src/option.c:406 src/option.c:487 src/option.c:495
-#: src/option.c:497 src/option.c:499 src/option.c:501 src/option.c:503
-#: src/option.c:505 src/option.c:509 src/option.c:543 src/option.c:545
-#: src/option.c:599 src/option.c:633 src/option.c:702
+#: src/option.c:106 src/option.c:108 src/option.c:118 src/option.c:142
+#: src/option.c:146 src/option.c:191 src/option.c:205 src/option.c:344
+#: src/option.c:402 src/option.c:408 src/option.c:489 src/option.c:497
+#: src/option.c:499 src/option.c:501 src/option.c:503 src/option.c:505
+#: src/option.c:507 src/option.c:511 src/option.c:545 src/option.c:547
+#: src/option.c:601 src/option.c:635 src/option.c:704
 msgid "NUMBER"
 msgstr "რიცხვი"
 
@@ -303,7 +303,7 @@ msgstr ""
 "დარჩენილი დროის ინდიკატორის ჩვენება (top (ზემოთ), bottom (ქვემოთ), left "
 "(მარცხნივ), right (მარჯვნივ))"
 
-#: src/option.c:114 src/option.c:587
+#: src/option.c:114 src/option.c:589
 msgid "POS"
 msgstr "პოზ"
 
@@ -311,8 +311,8 @@ msgstr "პოზ"
 msgid "Set the dialog text"
 msgstr "ფანჯრის ტექსტის დაყენება"
 
-#: src/option.c:116 src/option.c:273 src/option.c:275 src/option.c:350
-#: src/option.c:352 src/option.c:386 src/option.c:507 src/option.c:637
+#: src/option.c:116 src/option.c:275 src/option.c:277 src/option.c:352
+#: src/option.c:354 src/option.c:388 src/option.c:509 src/option.c:639
 msgid "TEXT"
 msgstr "ტექსტი"
 
@@ -326,11 +326,11 @@ msgstr ""
 "დიალოგის ტექსტის სწორების დაყენება (left (მარცხენა), center (ცენტრი), right "
 "(მარჯვენა), fill (შევსება))"
 
-#: src/option.c:120 src/option.c:132 src/option.c:185 src/option.c:235
-#: src/option.c:241 src/option.c:243 src/option.c:398 src/option.c:481
-#: src/option.c:491 src/option.c:541 src/option.c:585 src/option.c:597
-#: src/option.c:609 src/option.c:621 src/option.c:635 src/option.c:698
-#: src/option.c:749 src/option.c:778 src/option.c:780 src/tools.c:86
+#: src/option.c:120 src/option.c:132 src/option.c:187 src/option.c:237
+#: src/option.c:243 src/option.c:245 src/option.c:400 src/option.c:483
+#: src/option.c:493 src/option.c:543 src/option.c:587 src/option.c:599
+#: src/option.c:611 src/option.c:623 src/option.c:637 src/option.c:700
+#: src/option.c:751 src/option.c:780 src/option.c:782 src/tools.c:86
 msgid "TYPE"
 msgstr "ტიპი"
 
@@ -338,7 +338,7 @@ msgstr "ტიპი"
 msgid "Set the dialog image"
 msgstr "დიალოგის გამოსახულეის დაყენება"
 
-#: src/option.c:122 src/option.c:360 src/option.c:364
+#: src/option.c:122 src/option.c:362 src/option.c:366
 msgid "IMAGE"
 msgstr "გამოსახულება"
 
@@ -346,7 +346,7 @@ msgstr "გამოსახულება"
 msgid "Use specified icon theme instead of default"
 msgstr "ნაგულისხმების მაგიერ მითითებული ხატულების თემის გამოყენება"
 
-#: src/option.c:124 src/option.c:727 src/browser.c:220 src/tools.c:87
+#: src/option.c:124 src/option.c:729 src/browser.c:220 src/tools.c:87
 msgid "THEME"
 msgstr "თემა"
 
@@ -354,7 +354,7 @@ msgstr "თემა"
 msgid "Hide main widget with expander"
 msgstr "მთავარი ვიჯეტის დამალვა გამფართოებლით"
 
-#: src/option.c:126 src/option.c:378 src/option.c:654 src/option.c:718
+#: src/option.c:126 src/option.c:380 src/option.c:656 src/option.c:720
 msgid "[TEXT]"
 msgstr "[ტექსტი]"
 
@@ -377,634 +377,644 @@ msgstr ""
 "(დასაწყისი), end (დასასრული) ან center (ცენტრი))"
 
 #: src/option.c:134
+#, fuzzy
+msgid "Set focus to the named button when dialog opens"
+msgstr "მორგებული შესახებ დიალოგის პარამეტრების ჩვენება"
+
+#: src/option.c:134
+#, fuzzy
+msgid "NAME"
+msgstr "[სახელი]"
+
+#: src/option.c:136
 msgid "Don't use pango markup language in dialog's text"
 msgstr "დიალოგის ტექსტში მარქაფის ენა pango გამოყენებული არ იქნება"
 
-#: src/option.c:136
+#: src/option.c:138
 msgid "Don't close dialog if Escape was pressed"
 msgstr "Escape-ის დაჭერის შემდეგ ფანჯარა არ დაიხურება"
 
-#: src/option.c:138
+#: src/option.c:140
 msgid "Escape acts like OK button"
 msgstr "Escape აკეთებს იგივეს, რასაც ღილაკი დიახ"
 
-#: src/option.c:140
+#: src/option.c:142
 msgid "Set window borders"
 msgstr "ფანჯრის საზღვრების დაყენება"
 
-#: src/option.c:142
+#: src/option.c:144
 msgid "Always print result"
 msgstr "შედეგის ყოველთვის გამოტანა"
 
-#: src/option.c:144
+#: src/option.c:146
 msgid "Set default return code"
 msgstr "ნაგულისხმები დასაბრუნებელი კოდის დაყენება"
 
-#: src/option.c:146
+#: src/option.c:148
 msgid "Dialog text can be selected"
 msgstr "დიალოგის ტექსტის მონიშვნა შესაძლებელია"
 
-#: src/option.c:148
+#: src/option.c:150
 msgid "Don't scale icons"
 msgstr "ხატულების მასშტაბირების გარეშე"
 
-#: src/option.c:150
+#: src/option.c:152
 #, c-format
 msgid "Run commands under specified interpreter (default: bash -c '%s')"
 msgstr ""
 "ბრძანებების მითითებული ინტერპრეტატორით გაშვება (ნაგულისხმები: bash -c '%s')"
 
-#: src/option.c:150 src/option.c:152 src/option.c:154 src/option.c:205
-#: src/option.c:312 src/option.c:362 src/option.c:366 src/option.c:412
-#: src/option.c:511 src/option.c:513 src/option.c:515 src/option.c:601
+#: src/option.c:152 src/option.c:154 src/option.c:156 src/option.c:207
+#: src/option.c:314 src/option.c:364 src/option.c:368 src/option.c:414
+#: src/option.c:513 src/option.c:515 src/option.c:517 src/option.c:603
 msgid "CMD"
 msgstr "CMD"
 
-#: src/option.c:152
+#: src/option.c:154
 msgid "Set URI handler"
 msgstr "URI-ის დამმუშავებლის დაყენება"
 
-#: src/option.c:154
+#: src/option.c:156
 msgid "Set command running when F1 was pressed"
 msgstr "F11-ის დაჭერის დროს გასაშვები ბრძანების დაყენება"
 
-#: src/option.c:156
+#: src/option.c:158
 msgid "Set working directory"
 msgstr "სამუშაო საქაღალდის დაყენება"
 
-#: src/option.c:156 src/option.c:782
+#: src/option.c:158 src/option.c:784
 msgid "PATH"
 msgstr "ბილიკი"
 
-#: src/option.c:159
+#: src/option.c:161
 msgid "Set window sticky"
 msgstr "ფანჯრის წებოვნობის დაყენება"
 
-#: src/option.c:161
+#: src/option.c:163
 msgid "Set window unresizable"
 msgstr "ფანჯრის ზომების შეცვლის გამორთვა"
 
-#: src/option.c:163
+#: src/option.c:165
 msgid "Place window on top"
 msgstr "ფანჯრის ზემოდან დადება"
 
-#: src/option.c:165
+#: src/option.c:167
 msgid "Place window on center of screen"
 msgstr "ფანჯრის ეკრანის ცენტრში დადება"
 
-#: src/option.c:167
+#: src/option.c:169
 msgid "Place window at the mouse position"
 msgstr "ფანჯრის თაგუნას მდებარეობასთან მოთავსება"
 
-#: src/option.c:169
+#: src/option.c:171
 msgid "Set window undecorated"
 msgstr "ფანჯრის დეკორაციების გათიშვა"
 
-#: src/option.c:171
+#: src/option.c:173
 msgid "Don't show window in taskbar"
 msgstr "ფანჯარა ამოცანების პანელზე ნაჩვენები არ იქნება"
 
-#: src/option.c:173
+#: src/option.c:175
 msgid "Set window maximized"
 msgstr "ფანჯრის გადიდებულად დაყენება"
 
-#: src/option.c:175
+#: src/option.c:177
 msgid "Set window fullscreen"
 msgstr "ფანჯრის მთელ ეკრანზე გაშლა"
 
-#: src/option.c:177
+#: src/option.c:179
 msgid "Don't focus dialog window"
 msgstr "დიალოგის ფანჯარას ფოკუსი არ ექნება"
 
-#: src/option.c:179
+#: src/option.c:181
 msgid "Close window when it sets unfocused"
 msgstr "ფანჯრის დახურვა მასზე ფოკუსის მოხსნისას"
 
-#: src/option.c:182
+#: src/option.c:184
 msgid "Open window as a splashscreen (Deprecated, see man page for details)"
 msgstr ""
 "ფანჯრის გახსნა გაშვების ეკრანის სახით (მოძველებულია. დეტალებისთვის იხილეთ "
 "man-ის გვერდი)"
 
-#: src/option.c:185
+#: src/option.c:187
 msgid "Specify the window type for the dialog"
 msgstr "მიუთითეთ ფანჯრის ტიპი დიალოგისთვის"
 
-#: src/option.c:187
+#: src/option.c:189
 msgid "Special type of dialog for XEMBED"
 msgstr "დიალოგის სპეციალური ტიპი XEMBED-ისთვის"
 
-#: src/option.c:187 src/option.c:239
+#: src/option.c:189 src/option.c:241
 msgid "KEY"
 msgstr "ღილაკი"
 
-#: src/option.c:189
+#: src/option.c:191
 msgid "Tab number of this dialog"
 msgstr "ამ დიალოგის ჩანართის ნომერი"
 
-#: src/option.c:192
+#: src/option.c:194
 msgid "Send SIGNAL to parent"
 msgstr "მშობლისთვის სიგნალის გაგზავნა"
 
-#: src/option.c:192
+#: src/option.c:194
 msgid "[SIGNAL]"
 msgstr "[სიგნალი]"
 
-#: src/option.c:194
+#: src/option.c:196
 msgid "Print X Window Id to the file/stderr"
 msgstr "ფაილში/stderr-ში X Window ID-ის გამოტანა"
 
-#: src/option.c:194 src/option.c:324
+#: src/option.c:196 src/option.c:326
 msgid "[FILENAME]"
 msgstr "[ფაილის სახელი]"
 
-#: src/option.c:201
+#: src/option.c:203
 msgid "Set the format for the returned date"
 msgstr "დაბრუნებული თარიღის ფორმატის დაყენება"
 
-#: src/option.c:201 src/option.c:453
+#: src/option.c:203 src/option.c:455
 msgid "PATTERN"
 msgstr "შაბლონი"
 
-#: src/option.c:203
+#: src/option.c:205
 msgid "Set presicion of floating numbers (default - 3)"
 msgstr "მცურავმძიმიანი რიცხვების სიზუსტის დაყენება (ნაგულისხმები 3)"
 
-#: src/option.c:205
+#: src/option.c:207
 msgid "Set command handler"
 msgstr "ბრძანებლის დამმუშავებლის დაყენება"
 
-#: src/option.c:207
+#: src/option.c:209
 msgid "Listen for data on stdin"
 msgstr "მონაცემებისთვის stdin-ის მოსმენა"
 
-#: src/option.c:209
+#: src/option.c:211
 msgid "Set common separator character"
 msgstr "საერთო გამყოფი სიმბოლოს დაყენება"
 
-#: src/option.c:209 src/option.c:211
+#: src/option.c:211 src/option.c:213
 msgid "SEPARATOR"
 msgstr "გამყოფი"
 
-#: src/option.c:211
+#: src/option.c:213
 msgid "Set item separator character"
 msgstr "ელემენტის გამყოფი სიმბოლოს დაყენება"
 
-#: src/option.c:213
+#: src/option.c:215
 msgid "Allow changes to text in some cases"
 msgstr "ზოგიერთ შემთხვევაში ტექსტის შეცვლის დაშვება"
 
-#: src/option.c:215
+#: src/option.c:217
 msgid "Autoscroll to end of text"
 msgstr "ავტომატური გადახვევა ტექსტის ბოლოში"
 
-#: src/option.c:217
+#: src/option.c:219
 msgid "Autoscroll to end of text (alias to tail)"
 msgstr "ავტომატური გადახვევა ტექსტის ბოლოში (იგივე, რაც tail)"
 
-#: src/option.c:219
+#: src/option.c:221
 msgid "Quote dialogs output"
 msgstr "ფანჯრის გამოტანის ბრჭყალებში ჩასმა"
 
-#: src/option.c:221
+#: src/option.c:223
 msgid "Output number instead of text for combo-box"
 msgstr "Combo-box-სთვის ტექსტის მაგიერ რიცხვის გამოტანა"
 
-#: src/option.c:223
+#: src/option.c:225
 msgid "Specify font name to use"
 msgstr "მიუთითეთ ფონტის სახელი"
 
-#: src/option.c:223
+#: src/option.c:225
 msgid "FONTNAME"
 msgstr "ფონტისსახელი"
 
-#: src/option.c:225
+#: src/option.c:227
 msgid "Allow multiple selection"
 msgstr "მრავალი არჩევანის დაშვება"
 
-#: src/option.c:227
+#: src/option.c:229
 msgid "Enable preview"
 msgstr "მინიატურის ჩართვა"
 
-#: src/option.c:229
+#: src/option.c:231
 msgid "Use large preview"
 msgstr "დიდი მინიატურების გამოყენება"
 
-#: src/option.c:231
+#: src/option.c:233
 msgid "Show hidden files in file selection dialogs"
 msgstr "ფაილის არჩევის დიალოგებში დამალული ფაილების ჩვენება"
 
-#: src/option.c:233
+#: src/option.c:235
 msgid "Set source filename"
 msgstr "დააყენეთ წყაროს ფაილის სახელი"
 
-#: src/option.c:233 src/option.c:308 src/option.c:775 src/option.c:790
+#: src/option.c:235 src/option.c:310 src/option.c:777 src/option.c:792
 msgid "FILENAME"
 msgstr "ფაილის სახელი"
 
-#: src/option.c:235
+#: src/option.c:237
 msgid "Set mime type of input data"
 msgstr "შეყვანის მონაცემების MIME ტიპის დაყენება"
 
-#: src/option.c:237
+#: src/option.c:239
 msgid "Set vertical orientation"
 msgstr "ვერტიკალური ორიენტაციის დაყენება"
 
-#: src/option.c:239
+#: src/option.c:241
 msgid "Identifier of embedded dialogs"
 msgstr "ჩაშენებული დიალოგების იდენტიფიკატორი"
 
-#: src/option.c:241
+#: src/option.c:243
 msgid "Set extended completion for entries (any, all, or regex)"
 msgstr ""
 "ჩანაწერების გაფართოებული დასრულების დაყენება (any (ნებისმიერი), all(ყველა) "
 "ან regex (რეგულარული გამოსახულება)"
 
-#: src/option.c:243
+#: src/option.c:245
 msgid "Set type of output for boolean values (T, t, Y, y, O, o, 1)"
 msgstr "ლოგიკური მნიშვნელობების გამოტანის ტიპის დაყენება (T, t, Y, y, O, o, 1)"
 
-#: src/option.c:245
+#: src/option.c:247
 msgid "Make main widget scrollable"
 msgstr "მთავარი ვიჯეტის გადახვევადად გახდომა"
 
-#: src/option.c:247
+#: src/option.c:249
 msgid "Disable search in text and html dialogs"
 msgstr "ტექსტში და HTML დიალოგებში ძებნის გამორთვა"
 
-#: src/option.c:249
+#: src/option.c:251
 msgid "Enable file operations"
 msgstr "ფაილის ოპერაციების ჩართვა"
 
-#: src/option.c:252
+#: src/option.c:254
 msgid "Use IEC (base 1024) units with for size values"
 msgstr "ზომის მნიშვნელობებში IEC (1024-ზე ბაზირებული) ერთეულების გამოყენება"
 
-#: src/option.c:256
+#: src/option.c:258
 msgid "Enable spell check for text"
 msgstr "ტექსტისთვის მართლწერის შემოწმების ჩართვა"
 
-#: src/option.c:258
+#: src/option.c:260
 msgid "Set spell checking language"
 msgstr "მართლწერის შემოწმების ენის დაყენება"
 
-#: src/option.c:258
+#: src/option.c:260
 msgid "LANGUAGE"
 msgstr "ენა"
 
-#: src/option.c:265
+#: src/option.c:267
 msgid "Display about dialog"
 msgstr "შესახებ დიალოგის ჩვენება"
 
-#: src/option.c:267
+#: src/option.c:269
 msgid "Set application name"
 msgstr "აპლიკაციის სახელის დაყენება"
 
-#: src/option.c:267 src/option.c:269 src/option.c:271 src/option.c:281
-#: src/option.c:429 src/option.c:431 src/option.c:529 src/option.c:531
-#: src/option.c:558 src/option.c:574 src/option.c:772
+#: src/option.c:269 src/option.c:271 src/option.c:273 src/option.c:283
+#: src/option.c:431 src/option.c:433 src/option.c:531 src/option.c:533
+#: src/option.c:560 src/option.c:576 src/option.c:774
 msgid "STRING"
 msgstr "სტრიქონი"
 
-#: src/option.c:269
+#: src/option.c:271
 msgid "Set application version"
 msgstr "აპლიკაციის ვერსიის დაყენება"
 
-#: src/option.c:271
+#: src/option.c:273
 msgid "Set application copyright string"
 msgstr "აპლიკაციის ლიცენზიის სტრიქონის დაყენება"
 
-#: src/option.c:273
+#: src/option.c:275
 msgid "Set application comments string"
 msgstr "აპლიკაციის კომენტარის სტრიქონის დაყენება"
 
-#: src/option.c:275
+#: src/option.c:277
 msgid "Set application license"
 msgstr "აპლიკაციის ლიცენზიის დაყენება"
 
-#: src/option.c:277
+#: src/option.c:279
 msgid "Set application authors"
 msgstr "აპლიკაციის ავტორების დაყენება"
 
-#: src/option.c:277 src/option.c:485 src/option.c:489 src/option.c:493
+#: src/option.c:279 src/option.c:487 src/option.c:491 src/option.c:495
 msgid "LIST"
 msgstr "სია"
 
-#: src/option.c:279
+#: src/option.c:281
 msgid "Set application website"
 msgstr "აპლიკაციის ვებსაიტის დაყენება"
 
-#: src/option.c:279
+#: src/option.c:281
 msgid "URI"
 msgstr "URI"
 
-#: src/option.c:281
+#: src/option.c:283
 msgid "Set application website label"
 msgstr "აპლიკაციის ვებსაიტის წდის დაყენება"
 
-#: src/option.c:287
+#: src/option.c:289
 msgid "Display application selection dialog"
 msgstr "აპლიკაციის არჩევის დიალოგის ჩვენება"
 
-#: src/option.c:289
+#: src/option.c:291
 msgid "Show fallback applications"
 msgstr "თუ არჩეული არ მუშაობს, აპლიკაციის მითითება, გადასართავად"
 
-#: src/option.c:291
+#: src/option.c:293
 msgid "Show other applications"
 msgstr "სხვა აპლიკაციების ჩვენება"
 
-#: src/option.c:293
+#: src/option.c:295
 msgid "Show all applications"
 msgstr "ყველა აპლიკაციის ჩვენება"
 
-#: src/option.c:295
+#: src/option.c:297
 msgid "Output all application data"
 msgstr "ყველა აპლიკაციის მონაცემების გამოტანა"
 
-#: src/option.c:300
+#: src/option.c:302
 msgid "Display calendar dialog"
 msgstr "კალენდრის ფანჯრის ჩვენება"
 
-#: src/option.c:302
+#: src/option.c:304
 msgid "Set the calendar day"
 msgstr "კალენდრის დღის დაყენება"
 
-#: src/option.c:302
+#: src/option.c:304
 msgid "DAY"
 msgstr "დღე"
 
-#: src/option.c:304
+#: src/option.c:306
 msgid "Set the calendar month"
 msgstr "კალენდრის თვის დაყენება"
 
-#: src/option.c:304
+#: src/option.c:306
 msgid "MONTH"
 msgstr "თვე"
 
-#: src/option.c:306
+#: src/option.c:308
 msgid "Set the calendar year"
 msgstr "კალენდრის წლის დაყენება"
 
-#: src/option.c:306
+#: src/option.c:308
 msgid "YEAR"
 msgstr "წელი"
 
-#: src/option.c:308
+#: src/option.c:310
 msgid "Set the filename with dates details"
 msgstr "თარიღის დეტალების შემცველი ფაილის სახელის დაყენება"
 
-#: src/option.c:310
+#: src/option.c:312
 msgid "Show week numbers at the left side of calendar"
 msgstr "კალენდარის მარცხენა მხარეს კვირის დღეების ჩვენება"
 
-#: src/option.c:312 src/option.c:513
+#: src/option.c:314 src/option.c:515
 msgid "Set select action"
 msgstr "არჩევის ქმედების დაყენება"
 
-#: src/option.c:318
+#: src/option.c:320
 msgid "Display color selection dialog"
 msgstr "ფერის ასარჩევი ფანჯრის ჩვენება"
 
-#: src/option.c:320
+#: src/option.c:322
 msgid "Set initial color value"
 msgstr "საწყისი ფერის მნიშვნელობის დაყენება"
 
-#: src/option.c:320 src/option.c:704 src/option.c:706 src/option.c:712
-#: src/option.c:735 src/option.c:737
+#: src/option.c:322 src/option.c:706 src/option.c:708 src/option.c:714
+#: src/option.c:737 src/option.c:739
 msgid "COLOR"
 msgstr "ფერი"
 
-#: src/option.c:322
+#: src/option.c:324
 msgid "Show system palette in color dialog"
 msgstr "ფერის დიალოგში სისტემური პალიტრის ჩვენება"
 
-#: src/option.c:324
+#: src/option.c:326
 msgid "Set path to palette file. Default - "
 msgstr "პალიტრის ფაილის ბილიკის დაყენება. ნაგულისხმები - "
 
-#: src/option.c:326
+#: src/option.c:328
 msgid "Expand user palette"
 msgstr "მომხმარებლის პალიტრის გაფართოება"
 
-#: src/option.c:328
+#: src/option.c:330
 msgid "Show color picker"
 msgstr "ფერის ამრჩევის ჩვენება"
 
-#: src/option.c:330
+#: src/option.c:332
 msgid "Set output mode to MODE. Values are hex (default) or rgb"
 msgstr ""
 "გამოტანის რეჟიმის მითითებულ მნიშვნელობებზე დაყენება. მნიშვნელობები "
 "თექვსმეტობითშია (ნაგულისხმები) ან RGB"
 
-#: src/option.c:330
+#: src/option.c:332
 msgid "MODE"
 msgstr "რეჟიმი"
 
-#: src/option.c:332
+#: src/option.c:334
 msgid "Add opacity to output color value"
 msgstr "გამოტანის ფერის მნიშვნელობისთვის გაუმჭვირვალობის დამატება"
 
-#: src/option.c:338
+#: src/option.c:340
 msgid "Display drag-n-drop box"
 msgstr "DnD ფანჯრის ჩვენება"
 
-#: src/option.c:340
+#: src/option.c:342
 msgid "Use dialog text as tooltip"
 msgstr "დიალოგის ტექსტის მინიშნებად გამოყენება"
 
-#: src/option.c:342
+#: src/option.c:344
 msgid "Exit after NUMBER of drops"
 msgstr "გასვლა მითითებული რაოდენობა დაგდების შემდეგ"
 
-#: src/option.c:348
+#: src/option.c:350
 msgid "Display text entry or combo-box dialog"
 msgstr "ტექსტის შეყვანის ან კომბო-ბოქსის ფანჯრის ჩვენება"
 
-#: src/option.c:350
+#: src/option.c:352
 msgid "Set the entry label"
 msgstr "ელემენტის ჭდის დაყენება"
 
-#: src/option.c:352
+#: src/option.c:354
 msgid "Set the entry text"
 msgstr "ჩანაწერის ტექსტის დაყენება"
 
-#: src/option.c:354
+#: src/option.c:356
 msgid "Hide the entry text"
 msgstr "ჩანაწერის ტესტის დამალვა"
 
-#: src/option.c:356
+#: src/option.c:358
 msgid "Use completion instead of combo-box"
 msgstr "Combo-box-ის მაგიერ დასრულების გამოყენება"
 
-#: src/option.c:358
+#: src/option.c:360
 msgid "Use spin button for text entry"
 msgstr "ტექსტური ჩანაწერებისთვის ბრუნვის ღილაკის ჩვენება"
 
-#: src/option.c:360
+#: src/option.c:362
 msgid "Set the left entry icon"
 msgstr "მარცხენა ელემენტის ხატულის დაყენება"
 
-#: src/option.c:362
+#: src/option.c:364
 msgid "Set the left entry icon action"
 msgstr "მარცხენა ელემენტის ხატულის ქმედების დაყენება"
 
-#: src/option.c:364
+#: src/option.c:366
 msgid "Set the right entry icon"
 msgstr "მარჯვენა ელემენტის ხატულის დაყენება"
 
-#: src/option.c:366
+#: src/option.c:368
 msgid "Set the right entry icon action"
 msgstr "მარჯვენა ელემენტის ხატულის ქმედების დაყენება"
 
-#: src/option.c:372
+#: src/option.c:374
 msgid "Display file selection dialog"
 msgstr "ფაილის არჩევის ფანჯრის ჩვენება"
 
-#: src/option.c:374
+#: src/option.c:376
 msgid "Activate directory-only selection"
 msgstr "მხოლოდ საქაღალდის არჩევა"
 
-#: src/option.c:376
+#: src/option.c:378
 msgid "Activate save mode"
 msgstr "ნახვის რეჟიმის გააქტიურება"
 
-#: src/option.c:378
+#: src/option.c:380
 msgid "Confirm file selection if filename already exists"
 msgstr "ფაილის არჩევის დადასტურება, თუ ის უკვე არსებობს"
 
-#: src/option.c:384
+#: src/option.c:386
 msgid "Display font selection dialog"
 msgstr "ფონტის არჩევის დიალოგის ჩვენება"
 
-#: src/option.c:386
+#: src/option.c:388
 msgid "Set text string for preview"
 msgstr "მინიატურისთვის ტექტური სტრიქონის დაყენება"
 
-#: src/option.c:388
+#: src/option.c:390
 msgid "Separate output of font description"
 msgstr "ფონტის აღწერის გამოტანის განცალკევება"
 
-#: src/option.c:394
+#: src/option.c:396
 msgid "Display form dialog"
 msgstr "ფორმის დიალოგის ჩვენება"
 
-#: src/option.c:396
+#: src/option.c:398
 msgid "Add field to form (see man page for list of possible types)"
 msgstr "ფორმისთვის ველის დამატება (შესაძლო ტიპებისთვის იხილეთ man page)"
 
-#: src/option.c:396 src/option.c:631
+#: src/option.c:398 src/option.c:633
 msgid "LABEL[:TYPE]"
 msgstr "ჭდე[:ტიპი]"
 
-#: src/option.c:398
+#: src/option.c:400
 msgid "Set alignment of filed labels (left, center or right)"
 msgstr ""
 "ველის ჭდეების სწორების დაყენება (left (მარცხენა), center (ცენტრი), right "
 "(მარჯვენა), fill (შევსება))"
 
-#: src/option.c:400
+#: src/option.c:402
 msgid "Set number of columns in form"
 msgstr "ფორმაში სვეტების რაოდენობის დაყენება"
 
-#: src/option.c:402
+#: src/option.c:404
 msgid "Make form fields height and columns width the same size"
 msgstr "ფორმის ველების სიმაღლისა და სვეტების სიგანის იგივე ზომის დაყენება"
 
-#: src/option.c:404
+#: src/option.c:406
 msgid "Order output fields by rows"
 msgstr "გამოტანის ველების მწკრივების მიხედვით დალაგება"
 
-#: src/option.c:406
+#: src/option.c:408
 msgid "Set focused field"
 msgstr "ფოკუსის მქონე ველის დაყენება"
 
-#: src/option.c:408
+#: src/option.c:410
 msgid "Cycled reading of stdin data"
 msgstr "Stdin-ის მონაცემების წრიული კითხვა"
 
-#: src/option.c:410
+#: src/option.c:412
 msgid "Align labels on button fields"
 msgstr "ღილაკის ველებზე ჭდეების დალაგება"
 
-#: src/option.c:412
+#: src/option.c:414
 msgid "Set changed action"
 msgstr "შეცვლილი ქმედების დაყენება"
 
-#: src/option.c:419
+#: src/option.c:421
 msgid "Display HTML dialog"
 msgstr "HTML დიალოგის ჩვენება"
 
-#: src/option.c:421
+#: src/option.c:423
 msgid "Open specified location"
 msgstr "მითითებული მდებარეობის გახსნა"
 
-#: src/option.c:423
+#: src/option.c:425
 msgid "Turn on browser mode"
 msgstr "ბრაუზერის რეჟიმის ჩართვა"
 
-#: src/option.c:425
+#: src/option.c:427
 msgid "Print clicked uri to stdout"
 msgstr "დაწკაპუნებული URI-ის stdout-ზე გამოტანა"
 
-#: src/option.c:427
+#: src/option.c:429
 msgid "Set encoding of input stream data"
 msgstr "შეყვანის ნაკადის მონაცემების კოდირების დაყენება"
 
-#: src/option.c:427
+#: src/option.c:429
 msgid "ENCODING"
 msgstr "_კოდირება"
 
-#: src/option.c:429
+#: src/option.c:431
 msgid "Set user agent string"
 msgstr "მომხმარებლის აგენტის სტრიქონის დაყენება"
 
-#: src/option.c:431
+#: src/option.c:433
 msgid "Set custom user style"
 msgstr "მომხმარებლის სტილის ხელით მითითება"
 
-#: src/option.c:433
+#: src/option.c:435
 msgid "Set WebKit property"
 msgstr "WebKit-ის თვისების დაყენება"
 
-#: src/option.c:433
+#: src/option.c:435
 msgid "PROP"
 msgstr "თვისება"
 
-#: src/option.c:440
+#: src/option.c:442
 msgid "Display icons box dialog"
 msgstr "ხატულის ფანჯრის დიალოგის ჩვენება"
 
-#: src/option.c:442
+#: src/option.c:444
 msgid "Read data from .desktop files in specified directory"
 msgstr ""
 "მითითებულ საქაღალდეში არსებული .desktop ფაილებიდან მონაცემების წაკითხვა"
 
-#: src/option.c:442
+#: src/option.c:444
 msgid "DIR"
 msgstr "საქაღალდე"
 
-#: src/option.c:444
+#: src/option.c:446
 msgid "Use compact (list) view"
 msgstr "კომპაქტური (სიის) ხედის გამოყენება"
 
-#: src/option.c:446
+#: src/option.c:448
 msgid "Use GenericName field instead of Name for icon label"
 msgstr "ხატულის წდისთვის Name ველის მაგიერ GenericName-ის გამოყენება"
 
-#: src/option.c:448
+#: src/option.c:450
 msgid "Set the width of dialog items"
 msgstr "დიალოგის ელემენტების სიგანის მითითება"
 
-#: src/option.c:450
+#: src/option.c:452
 msgid "Force using specified icon size"
 msgstr "მითითებული ხატულის ზომის ნაძალადევი გამოყენება"
 
-#: src/option.c:450 src/option.c:564 src/option.c:700 src/tools.c:85
+#: src/option.c:452 src/option.c:566 src/option.c:702 src/tools.c:85
 msgid "SIZE"
 msgstr "SIZE"
 
-#: src/option.c:453
+#: src/option.c:455
 #, no-c-format
 msgid ""
 "Use specified pattern for launch command in terminal (default: xterm -e %s)"
@@ -1012,87 +1022,87 @@ msgstr ""
 "ტერმინალში ბრძანების გასაშვებად მითითებული ნიმუშის გამოყენება (ნაგულისხმები: "
 "xterm -e %s)"
 
-#: src/option.c:455
+#: src/option.c:457
 msgid "Sort items by name instead of filename"
 msgstr "ელემენტების ფაილის სახელის მაგიერ სახელით დალაგება"
 
-#: src/option.c:457
+#: src/option.c:459
 msgid "Sort items in descending order"
 msgstr "საგნების დალაგება დაღმავალი წყობით"
 
-#: src/option.c:459
+#: src/option.c:461
 msgid "Activate items by single click"
 msgstr "ელემენტების აქტივაციისთვის ერთი წკაპის გამოყენება"
 
-#: src/option.c:461
+#: src/option.c:463
 msgid "Watch fot changes in directory"
 msgstr "საქაღალდის ცვლილებების თვალყურის დევნება"
 
-#: src/option.c:467
+#: src/option.c:469
 msgid "Display list dialog"
 msgstr "სიის ფანჯარა"
 
-#: src/option.c:469
+#: src/option.c:471
 msgid "Set the column header (see man page for list of possible types)"
 msgstr "სვეტის თავსართის დაყენება (შესაძლო ტიპების სიისთვის იხილეთ man page)"
 
-#: src/option.c:469
+#: src/option.c:471
 msgid "COLUMN[:TYPE]"
 msgstr "სვეტი[:ტიპი]"
 
-#: src/option.c:471
+#: src/option.c:473
 msgid "Enbale tree mode"
 msgstr "ხის რეჟიმის ჩართვა"
 
-#: src/option.c:473
+#: src/option.c:475
 msgid "Use checkboxes for first column"
 msgstr "პირველ სვეტში თოლიების გამოყენება"
 
-#: src/option.c:475
+#: src/option.c:477
 msgid "Use radioboxes for first column"
 msgstr "პირველ სვეტში რადიოჩამრთველების გამოყენება"
 
-#: src/option.c:477
+#: src/option.c:479
 msgid "Don't show column headers"
 msgstr "სვეტების თავსართების დამალვა"
 
-#: src/option.c:479
+#: src/option.c:481
 msgid "Disable clickable column headers"
 msgstr "დაწკაპუნებადი სვეტების თავსართების გამორთვა"
 
-#: src/option.c:481
+#: src/option.c:483
 msgid "Set grid lines (hor[izontal], vert[ical] or both)"
 msgstr ""
 "ბადის ხაზების დაყენება (hor[izontal] (ჰორიზონტალური), vert[ical] "
 "(ვერტიკალური) ან ორივე)"
 
-#: src/option.c:483
+#: src/option.c:485
 msgid "Print all data from list"
 msgstr "სიიდან ყველა მონაცემის გამოტანა"
 
-#: src/option.c:485
+#: src/option.c:487
 msgid "Set the list of editable columns"
 msgstr "ჩასწორებადი სვეტების სიის დაყენება"
 
-#: src/option.c:487
+#: src/option.c:489
 msgid "Set the width of a column for start wrapping text"
 msgstr "ტექსტის გადატანისთვის სვეტის სიგანის დაყენება"
 
-#: src/option.c:489
+#: src/option.c:491
 msgid "Set the list of wrapped columns"
 msgstr "გადატანილი სვეტების სიის დაყენება"
 
-#: src/option.c:491
+#: src/option.c:493
 msgid "Set ellipsize mode for text columns (none, start, middle or end)"
 msgstr ""
 "ტექსტური სვეტებისტვის ellipsize რეჟიმის დაყენება (none (არაფერი), start "
 "(დასაწყისი), middle (შუა) ან end (ბოლო))"
 
-#: src/option.c:493
+#: src/option.c:495
 msgid "Set the list of ellipsized columns"
 msgstr "Ellipsized ტიპის სვეტების სიის დაყენება"
 
-#: src/option.c:495
+#: src/option.c:497
 msgid ""
 "Print a specific column. By default or if 0 is specified will be printed all "
 "columns"
@@ -1100,17 +1110,17 @@ msgstr ""
 "მითითებული სვეტის გამოტანა. ნაგულისხმებად, ან, თუ 0-ია მითითებული, ყველა "
 "სვეტის დაბეჭდვა"
 
-#: src/option.c:497
+#: src/option.c:499
 msgid "Hide a specific column"
 msgstr "მითითებული სვეტის დამალვა"
 
-#: src/option.c:499
+#: src/option.c:501
 msgid "Set the column expandable by default. 0 sets all columns expandable"
 msgstr ""
 "სვეტის ნაგულისხმებად გაფართოებადად მონიშვნა. 0 ყველა სვეტს გაფართოებადად "
 "დააყენებს"
 
-#: src/option.c:501
+#: src/option.c:503
 msgid ""
 "Set the quick search column. Default is first column. Set it to 0 for "
 "disable searching"
@@ -1118,807 +1128,807 @@ msgstr ""
 "სწრაფი ძებნის სვეტის დაყენება. ნაგულისხმებად გამოიყენება პირველი სვეტი. "
 "გამოსართავად დააყენეთ 0"
 
-#: src/option.c:503
+#: src/option.c:505
 msgid "Set the tooltip column"
 msgstr "მინიშნების სვეტის დაყენება"
 
-#: src/option.c:505
+#: src/option.c:507
 msgid "Set the row separator column"
 msgstr "მწკრივის გამყოფი სვეტის დაყენება"
 
-#: src/option.c:507
+#: src/option.c:509
 msgid "Set the row separator value"
 msgstr "მწკრივის გამყოფის მნიშვნელობის დაყენება"
 
-#: src/option.c:509
+#: src/option.c:511
 msgid "Set the limit of rows in list"
 msgstr "სიაში მწკრივების ლიმიტის დაყენება"
 
-#: src/option.c:511
+#: src/option.c:513
 msgid "Set double-click action"
 msgstr "ორმაგი წკაპი ქმედების დაყენება"
 
-#: src/option.c:515
+#: src/option.c:517
 msgid "Set row action"
 msgstr "მწკრივის ქმედების დაყენება"
 
-#: src/option.c:517
+#: src/option.c:519
 msgid "Expand all tree nodes"
 msgstr "ყველა ხის კვანძის ამოკეცვა"
 
-#: src/option.c:519
+#: src/option.c:521
 msgid "Use regex in search"
 msgstr "ძებნაში რეგულარული გამოსახულების გამოყენება"
 
-#: src/option.c:521
+#: src/option.c:523
 msgid "Disable selection"
 msgstr "მონიშვნის გამორთვა"
 
-#: src/option.c:523
+#: src/option.c:525
 msgid "Add new records on the top of a list"
 msgstr "ახალი ელემენტების სიის თავში დამატება"
 
-#: src/option.c:525
+#: src/option.c:527
 msgid "Don't use markup in tooltips"
 msgstr "მინიშნებებში მარქაფი გამოყენებული არ იქნება"
 
-#: src/option.c:527
+#: src/option.c:529
 msgid "Use column name as a header tooltip"
 msgstr "სვეტის სახელის თავსართის მინიშნებად გამოყენება"
 
-#: src/option.c:529
+#: src/option.c:531
 msgid "Set columns alignment"
 msgstr "სვეტების სწორების დაყენება"
 
-#: src/option.c:531
+#: src/option.c:533
 msgid "Set headers alignment"
 msgstr "თავსართის სწორების დაყენება"
 
-#: src/option.c:537
+#: src/option.c:539
 msgid "Display notebook dialog"
 msgstr "რვეულის დიალოგის ჩვენება"
 
-#: src/option.c:539
+#: src/option.c:541
 msgid "Add a tab to notebook"
 msgstr "რვეულში ახალი ჩანართის დამატება"
 
-#: src/option.c:539
+#: src/option.c:541
 msgid "LABEL"
 msgstr "ჭდე"
 
-#: src/option.c:541
+#: src/option.c:543
 msgid "Set position of a notebook tabs (top, bottom, left or right)"
 msgstr "რვეულის ჩანართების მდებარეობის დაყენება (top, bottom, left ან right)"
 
-#: src/option.c:543
+#: src/option.c:545
 msgid "Set tab borders"
 msgstr "ჩანართის საზღვრების დაყენება"
 
-#: src/option.c:545
+#: src/option.c:547
 msgid "Set active tab"
 msgstr "აქტიური ჩანართის დაყენება"
 
-#: src/option.c:547
+#: src/option.c:549
 msgid "Expand tabs"
 msgstr "ჩანართების გაფართოება"
 
-#: src/option.c:549
+#: src/option.c:551
 msgid "Use stack mode"
 msgstr "სტეკის რეჟიმის გამოყენება"
 
-#: src/option.c:556
+#: src/option.c:558
 msgid "Display notification"
 msgstr "შეტყობინების ჩვენება"
 
-#: src/option.c:558 src/option.c:574
+#: src/option.c:560 src/option.c:576
 msgid "Set initial popup menu"
 msgstr "საწყისი მხტუნარა მენიუს დაყენება"
 
-#: src/option.c:560
+#: src/option.c:562
 msgid "Disable exit on middle click"
 msgstr "შუა წკაპზე გამოსვლის გამორთვა"
 
-#: src/option.c:562 src/option.c:576
+#: src/option.c:564 src/option.c:578
 msgid "Doesn't show icon at startup"
 msgstr "გაშვებისას ხატულა ნაჩვენები არ იქნება"
 
-#: src/option.c:564
+#: src/option.c:566
 msgid "Set icon size for fully specified icons (default - 16)"
 msgstr "სრულად მითითებული ხატულების ზომის დაყენება (ნაგულისხმები - 16)"
 
-#: src/option.c:572
+#: src/option.c:574
 msgid "Display indicator icon (StatusNotifier/AppIndicator)"
 msgstr "მაჩვენებლის ხატულას ჩვენებეა (StatusNotifier/AppIndicator)"
 
-#: src/option.c:583
+#: src/option.c:585
 msgid "Display paned dialog"
 msgstr "პანელების დიალოგის ჩვენება"
 
-#: src/option.c:585
+#: src/option.c:587
 msgid "Set orientation (hor[izontal] or vert[ical])"
 msgstr ""
 "ორიენტაციის დაყენება (hor[izontal] (ჰორიზონტალური) ან vert[ical] "
 "(ვერტიკალური))"
 
-#: src/option.c:587
+#: src/option.c:589
 msgid "Set initial splitter position"
 msgstr "საწყისი გამყოფის მდებარეობის დაყენება"
 
-#: src/option.c:589
+#: src/option.c:591
 msgid "Set focused pane (1 or 2)"
 msgstr "სახელის დაყენება : %1-დან %2-მდე (1 ან 2)"
 
-#: src/option.c:589
+#: src/option.c:591
 msgid "PANE"
 msgstr "პანელი"
 
-#: src/option.c:595
+#: src/option.c:597
 msgid "Display picture dialog"
 msgstr "სურათის დიალოგის"
 
-#: src/option.c:597
+#: src/option.c:599
 msgid "Set initial size (fit or orig)"
 msgstr "საწყისი ზომის დაყენება (ჩატევა ან ორიგ)"
 
-#: src/option.c:599
+#: src/option.c:601
 msgid "Set increment for picture scaling (default - 5)"
 msgstr "სურათის მასშტაბირების ინკრემენტის დაყენება (ნაგულისხმები - 5)"
 
-#: src/option.c:601
+#: src/option.c:603
 msgid "Set action on image changing"
 msgstr "გამოსახულების შეცვლის ქმედების დაყენება"
 
-#: src/option.c:607
+#: src/option.c:609
 #, fuzzy
 msgid "Display popup dialog"
 msgstr "შესახებ დიალოგის ჩვენება"
 
-#: src/option.c:609
+#: src/option.c:611
 #, fuzzy
 msgid "Set alignment of title and text (left, center or right)"
 msgstr ""
 "ველის ჭდეების სწორების დაყენება (left (მარცხენა), center (ცენტრი), right "
 "(მარჯვენა), fill (შევსება))"
 
-#: src/option.c:611
+#: src/option.c:613
 msgid "Set transparency"
 msgstr ""
 
-#: src/option.c:611
+#: src/option.c:613
 msgid "PERCENT"
 msgstr ""
 
-#: src/option.c:613
+#: src/option.c:615
 msgid "Don't close popup by timeout"
 msgstr ""
 
-#: src/option.c:619
+#: src/option.c:621
 msgid "Display printing dialog"
 msgstr "გამოტანის დიალოგის ჩვენება"
 
-#: src/option.c:621
+#: src/option.c:623
 msgid "Set source type (text, image or raw)"
 msgstr "წყაროს ტიპის დაყენება (ტექსტი, გამოსახულება ან დაუმუშავებელი)"
 
-#: src/option.c:623
+#: src/option.c:625
 msgid "Add headers to page"
 msgstr "გვერდზე თავსართების დამატება"
 
-#: src/option.c:629
+#: src/option.c:631
 msgid "Display progress indication dialog"
 msgstr "მიმდინარეობის ჩვენება"
 
-#: src/option.c:631
+#: src/option.c:633
 msgid "Add the progress bar (norm, rtl, pulse, cpulse or perm)"
 msgstr "მიმდინარეობის პანელის დამატება (norm, rtl, pulse, cpulse ან perm)"
 
-#: src/option.c:633
+#: src/option.c:635
 msgid "Watch for specific bar for auto close"
 msgstr "მითითებული პანელისთვის თვალყურის დევნება, რომ ავტომატურად დაიხუროს"
 
-#: src/option.c:635
+#: src/option.c:637
 msgid "Set alignment of bar labels (left, center or right)"
 msgstr "პანელის ჭდეების სწორების დაყენება(მარცხენა, ცენტრი ან მარჯვენა)"
 
-#: src/option.c:637
+#: src/option.c:639
 msgid "Set progress text"
 msgstr "მიმდინარეობის ტექსტის დაყენება"
 
-#: src/option.c:639
+#: src/option.c:641
 msgid "Hide text on progress bar"
 msgstr "პროგრესის პანელის ტექსტის დამალვა"
 
-#: src/option.c:641
+#: src/option.c:643
 msgid "Pulsate progress bar"
 msgstr "პულსირებადი მიმდინარეობის მაჩვენებელი"
 
-#: src/option.c:643
+#: src/option.c:645
 msgid "Conlinuous pulsating progress bar"
 msgstr "უწყვეტი პულსირებადი მიმდინარეობის მაჩვენებლის პანელი"
 
-#: src/option.c:646
+#: src/option.c:648
 #, no-c-format
 msgid "Dismiss the dialog when 100% has been reached"
 msgstr "ფანჯრის დახურვა 100%-ის მიღწევისას"
 
-#: src/option.c:649
+#: src/option.c:651
 msgid "Kill parent process if cancel button is pressed"
 msgstr "გაუქმების ღილაკის დაჭერისას მშობელი პროცესის მოკვლა"
 
-#: src/option.c:652
+#: src/option.c:654
 msgid "Right-To-Left progress bar direction"
 msgstr "პროგრესის პანელის მარჯვნიდან-მარცხნივ  მიმართულება"
 
-#: src/option.c:654
+#: src/option.c:656
 msgid "Show log window"
 msgstr "ჟურნალის ფანჯრის ჩვენება"
 
-#: src/option.c:656
+#: src/option.c:658
 msgid "Expand log window"
 msgstr "ჟურნალის ფანჯრის გაფართოება"
 
-#: src/option.c:658
+#: src/option.c:660
 msgid "Place log window above progress bar"
 msgstr "პროგრესის პანელის ზემოთ ჟურნალის ფანჯრის მოთავსება"
 
-#: src/option.c:660
+#: src/option.c:662
 msgid "Height of log window"
 msgstr "ჟურნალის ფანჯრის სიმაღლე"
 
-#: src/option.c:666
+#: src/option.c:668
 msgid "Display scale dialog"
 msgstr "მასშტაბირების ფანჯრის ჩვენება"
 
-#: src/option.c:668
+#: src/option.c:670
 msgid "Set initial value"
 msgstr "საწყისი მნიშვნელობის დაყენება"
 
-#: src/option.c:668 src/option.c:670 src/option.c:672 src/option.c:674
-#: src/option.c:678 src/option.c:745 src/option.c:747
+#: src/option.c:670 src/option.c:672 src/option.c:674 src/option.c:676
+#: src/option.c:680 src/option.c:747 src/option.c:749
 msgid "VALUE"
 msgstr "მნიშვნელობა"
 
-#: src/option.c:670
+#: src/option.c:672
 msgid "Set minimum value"
 msgstr "მინიმალური მნიშვნელობა"
 
-#: src/option.c:672
+#: src/option.c:674
 msgid "Set maximum value"
 msgstr "მაქსიმალური მნიშვნელობა"
 
-#: src/option.c:674
+#: src/option.c:676
 msgid "Set step size"
 msgstr "ბიჯის ზომა"
 
-#: src/option.c:676
+#: src/option.c:678
 msgid "Only allow values in step increments"
 msgstr "ნაბიჯის ბიჯემში მხოლოდ მნიშვნელობების დაშვება"
 
-#: src/option.c:678
+#: src/option.c:680
 msgid "Set paging size"
 msgstr "პეიჯინგის ზომის დაყენება"
 
-#: src/option.c:680
+#: src/option.c:682
 msgid "Print partial values"
 msgstr "ნაწილობრივი მნიშვნელობების ბეჭდვა"
 
-#: src/option.c:682
+#: src/option.c:684
 msgid "Hide value"
 msgstr "მნიშვნელობის დამალვა"
 
-#: src/option.c:684
+#: src/option.c:686
 msgid "Invert direction"
 msgstr "მიმართულების ინვერსია"
 
-#: src/option.c:686
+#: src/option.c:688
 msgid "Show +/- buttons in scale"
 msgstr "მასშტაბში +/- ღილაკების ჩვენება"
 
-#: src/option.c:688
+#: src/option.c:690
 msgid "Add mark to scale (may be used multiple times)"
 msgstr "მასშტაბირების ნიშნის დამატება (შეგიძლიათ ბევრჯერაც გამოიყენოთ)"
 
-#: src/option.c:688
+#: src/option.c:690
 msgid "NAME:VALUE"
 msgstr "სახელი:მნიშვნელობა"
 
-#: src/option.c:694
+#: src/option.c:696
 msgid "Display text information dialog"
 msgstr "ტექსტური ინფორმაციის ფანჯრის ჩვენება"
 
-#: src/option.c:696
+#: src/option.c:698
 msgid "Enable text wrapping"
 msgstr "ტექსტის გადატანის ჩართვა"
 
-#: src/option.c:698
+#: src/option.c:700
 msgid "Set justification (left, right, center or fill)"
 msgstr "სტრიქონის გასწორების დაყენება (მარჯვნივ, მარცხნივ, ცენტრი ან შევსება)"
 
-#: src/option.c:700
+#: src/option.c:702
 msgid "Set text margins"
 msgstr "ტექსტის საზღვრების დაყენება"
 
-#: src/option.c:702
+#: src/option.c:704
 msgid "Jump to specific line"
 msgstr "მითითებულ ხაზზე გადასვლა"
 
-#: src/option.c:704
+#: src/option.c:706
 msgid "Use specified color for text"
 msgstr "ტექსტისთვის მითითებული ფერის გამოყენება"
 
-#: src/option.c:706
+#: src/option.c:708
 msgid "Use specified color for background"
 msgstr "ფონისთვის მითითებული ფერის გამოყენება"
 
-#: src/option.c:708
+#: src/option.c:710
 msgid "Show cursor in read-only mode"
 msgstr "მხოლოდ-კითხვის რეჟიმში კურსორის ჩვენება"
 
-#: src/option.c:710
+#: src/option.c:712
 msgid "Make URI clickable"
 msgstr "URI-ის დაწკაპუნებადად გახდომა"
 
-#: src/option.c:712
+#: src/option.c:714
 msgid "Use specified color for links"
 msgstr "ბმულებისთვის მითითებული ფერის გამოყენება"
 
-#: src/option.c:714
+#: src/option.c:716
 msgid "Use pango markup"
 msgstr "Pango-ის მარქაფის გამოყენება"
 
-#: src/option.c:716
+#: src/option.c:718
 msgid "Save file instead of print on exit"
 msgstr "გამოსვლისას დაბეჭდვის მაგიერ ფაილში შენახვა"
 
-#: src/option.c:718
+#: src/option.c:720
 msgid "Confirm save the file if text was changed"
 msgstr "შენახვის დადასტურება ტექსტის ცვლილების შემთხვევაში"
 
-#: src/option.c:725
+#: src/option.c:727
 msgid "Use specified langauge for syntax highlighting"
 msgstr "სინტაქსის გამოკვეთისთვის მითითებული ენის დაყენება"
 
-#: src/option.c:725
+#: src/option.c:727
 msgid "LANG"
 msgstr "LANG"
 
-#: src/option.c:727
+#: src/option.c:729
 msgid "Use specified theme"
 msgstr "მითითებული თემის გამოყენება"
 
-#: src/option.c:729
+#: src/option.c:731
 msgid "Show line numbers"
 msgstr "ხაზის ნომრების ჩვენება"
 
-#: src/option.c:731
+#: src/option.c:733
 msgid "Highlight current line"
 msgstr "მიმდინარე ხაზის გამოკვეთა"
 
-#: src/option.c:733
+#: src/option.c:735
 msgid "Enable line marks"
 msgstr "ხაზის ნიშნების გამოყენება"
 
-#: src/option.c:735
+#: src/option.c:737
 msgid "Set color for first type marks"
 msgstr "პირველი ტიპის ნიშნებისთვის ფერის დაყენება"
 
-#: src/option.c:737
+#: src/option.c:739
 msgid "Set color for second type marks"
 msgstr "მეორე ტიპის ნიშნებისთვის ფერის დაყენება"
 
-#: src/option.c:739
+#: src/option.c:741
 msgid "Set position of right margin"
 msgstr "მარჯვენა ზღვრის პოზიცია"
 
-#: src/option.c:739
+#: src/option.c:741
 msgid "[POS]"
 msgstr "[პოზ]"
 
-#: src/option.c:741
+#: src/option.c:743
 msgid "Highlight matching brackets"
 msgstr "შესაბამისი ბრჭყალების გამოკვეთა"
 
-#: src/option.c:743
+#: src/option.c:745
 msgid "Use autoindent"
 msgstr "ავტომატური სწორების გამოტოვება"
 
-#: src/option.c:745
+#: src/option.c:747
 msgid "Set tabulation width"
 msgstr "ტაბულაციის სიგანის დაყენება"
 
-#: src/option.c:747
+#: src/option.c:749
 msgid "Set indentation width"
 msgstr "შეწევის სიგანის დაყენება"
 
-#: src/option.c:749
+#: src/option.c:751
 msgid "Set smart Home/End behavior"
 msgstr "ჭკვიანი Home/End-ის ქცევის დაყენება"
 
-#: src/option.c:751
+#: src/option.c:753
 msgid "Enable smart backspace"
 msgstr "ჭკვიანი backspace-ის ჩართვა"
 
-#: src/option.c:753
+#: src/option.c:755
 msgid "Insert spaces instead of tabs"
 msgstr "ტაბულაციის მაგიერ გამოტოვებების ჩასმა"
 
-#: src/option.c:760
+#: src/option.c:762
 msgid "Sets a filename filter"
 msgstr "ფაილის სახელის ფილტრის დაყენება"
 
-#: src/option.c:760
+#: src/option.c:762
 msgid "NAME | PATTERN1 PATTERN2 ..."
 msgstr "სახელი | ნიმუში1 ნიმუში2 .."
 
-#: src/option.c:762
+#: src/option.c:764
 msgid "Sets a mime-type filter"
 msgstr "MIME ტიპის ფილტრის დაყენება"
 
-#: src/option.c:762
+#: src/option.c:764
 msgid "NAME | MIME1 MIME2 ..."
 msgstr "სახელი | MIME1 MIME2 ..."
 
-#: src/option.c:764
+#: src/option.c:766
 msgid "Add filter for images"
 msgstr "გამოსახულებებისთვის ფილტრის დამატება"
 
-#: src/option.c:764
+#: src/option.c:766
 msgid "[NAME]"
 msgstr "[სახელი]"
 
-#: src/option.c:770 src/tools.c:64
+#: src/option.c:772 src/tools.c:64
 msgid "Print version"
 msgstr "მიმდინარე ვერსიის დაბეჭდვა"
 
-#: src/option.c:772
+#: src/option.c:774
 msgid "Load additional CSS settings from file or string"
 msgstr "ფაილიდან ან სტრიქონიდან დამატებითი CSS პარამეტრების ჩატვირთვა"
 
-#: src/option.c:775
+#: src/option.c:777
 msgid "Load additional CSS settings from file"
 msgstr "ფაილიდან დამატებითი CSS პარამეტრების ჩატვირთვა"
 
-#: src/option.c:778
+#: src/option.c:780
 msgid "Set policy for horizontal scrollbars (auto, always, never)"
 msgstr ""
 "ჰორიზონტალური ჩოჩიების წესის დაყენება (ავტომატური, ყოველთვის, არასოდეს)"
 
-#: src/option.c:780
+#: src/option.c:782
 msgid "Set policy for vertical scrollbars (auto, always, never)"
 msgstr "ვერტიკალური ჩოჩიების წესის დაყენება (ავტომატური, ყოველთვის, არასოდეს)"
 
-#: src/option.c:782
+#: src/option.c:784
 msgid "Add path for search icons by name"
 msgstr "სახელით ხატულების მოსაძებნი ბილიკის დამატება"
 
-#: src/option.c:784
+#: src/option.c:786
 msgid "Write settings to file and exit"
 msgstr ""
 
-#: src/option.c:790
+#: src/option.c:792
 msgid "Load extra arguments from file"
 msgstr "ფაილიდან დამატებითი არგუმენტების ჩატვირთვა"
 
-#: src/option.c:1001
+#: src/option.c:1003
 #, c-format
 msgid "Mark %s doesn't have a value\n"
 msgstr "ნიშანს %s მნიშვნელობა არ გააჩნია\n"
 
-#: src/option.c:1048 src/picture.c:286
+#: src/option.c:1050 src/picture.c:286
 msgid "Images"
 msgstr "სურათები"
 
-#: src/option.c:1113
+#: src/option.c:1115
 #, c-format
 msgid "Unknown color mode: %s\n"
 msgstr "უცნობი ფერის რეჟიმი: %s\n"
 
-#: src/option.c:1132
+#: src/option.c:1134
 #, c-format
 msgid "Unknown buttons layout type: %s\n"
 msgstr "უცნობი ღილაკის განლაგების ტიპი: %s\n"
 
-#: src/option.c:1147
+#: src/option.c:1149
 #, c-format
 msgid "Unknown align type: %s\n"
 msgstr "უცნობი სწორების ტიპი: %s\n"
 
-#: src/option.c:1171
+#: src/option.c:1173
 #, c-format
 msgid "Unknown justification type: %s\n"
 msgstr "უცნობი გასწორების ტიპი: %s\n"
 
-#: src/option.c:1188
+#: src/option.c:1190
 #, c-format
 msgid "Unknown tab position type: %s\n"
 msgstr "უცნობი ჩანართის მდებარეობის ტიპი: %s\n"
 
-#: src/option.c:1225
+#: src/option.c:1227
 #, c-format
 msgid "Unknown ellipsize type: %s\n"
 msgstr "უცნობი ellipsize-ის ტიპი: %s\n"
 
-#: src/option.c:1238
+#: src/option.c:1240
 #, c-format
 msgid "Unknown orientation: %s\n"
 msgstr "უცნობი ორიენტაცია: %s\n"
 
-#: src/option.c:1253
+#: src/option.c:1255
 #, c-format
 msgid "Unknown source type: %s\n"
 msgstr "უცნობი წყაროს ტიპი: %s\n"
 
-#: src/option.c:1264
+#: src/option.c:1266
 msgid "Progress log"
 msgstr "მიმდინარეობის ჟურნალი"
 
-#: src/option.c:1277
+#: src/option.c:1279
 #, c-format
 msgid "Unknown size type: %s\n"
 msgstr "უცნობი ზომის ტიპი: %s\n"
 
-#: src/option.c:1321
+#: src/option.c:1323
 #, c-format
 msgid "Unknown completion type: %s\n"
 msgstr "უცნობი დასრულების ტიპი: %s\n"
 
-#: src/option.c:1353
+#: src/option.c:1355
 #, c-format
 msgid "Unknown boolean format type: %s\n"
 msgstr "უცნობი ლოგიკური ფორმატის ტიპი: %s\n"
 
-#: src/option.c:1369
+#: src/option.c:1371
 #, c-format
 msgid "Unknown grid lines type: %s\n"
 msgstr "უცნობი ბადის ხაზების ტიპი: %s\n"
 
-#: src/option.c:1386
+#: src/option.c:1388
 #, c-format
 msgid "Unknown scrollbar policy type: %s\n"
 msgstr "უცნობი ჩოჩიის წესის ტიპი: %s\n"
 
-#: src/option.c:1437
+#: src/option.c:1439
 #, c-format
 msgid "Unknown window type: %s\n"
 msgstr "უცნობი ფანჯრის ტიპი: %s\n"
 
-#: src/option.c:1466
+#: src/option.c:1468
 #, c-format
 msgid "Unknown smart Home/End mode: %s\n"
 msgstr "უცნობი ჭკვიანი Home/End-ის რეჟიმი: %s\n"
 
-#: src/option.c:1576
+#: src/option.c:1578
 #, c-format
 msgid "Unknown signal: %s\n"
 msgstr "უცნობი სიგნალი: %s\n"
 
-#: src/option.c:1811
+#: src/option.c:1814
 msgid "File exist. Overwrite?"
 msgstr "ფაილი არსებობს. გადავაწერო?"
 
-#: src/option.c:1953
+#: src/option.c:1956
 msgid "File was changed. Save it?"
 msgstr "ფაილი შეიცვალა. შევინახო?"
 
-#: src/option.c:1984
+#: src/option.c:1987
 msgid "- Yet another dialoging program"
 msgstr "- მორიგი დიალოგის პროგრამა"
 
-#: src/option.c:1988
+#: src/option.c:1991
 msgid "General options"
 msgstr "საერთო პარამეტრები"
 
-#: src/option.c:1988
+#: src/option.c:1991
 msgid "Show general options"
 msgstr "საერთო პარამეტრების ჩვენება"
 
-#: src/option.c:1994
+#: src/option.c:1997
 msgid "Common options"
 msgstr "საერთო პარამეტრები"
 
-#: src/option.c:1994
+#: src/option.c:1997
 msgid "Show common options"
 msgstr "ზოგადი პარამეტრების ჩვენება"
 
-#: src/option.c:2000
+#: src/option.c:2003
 msgid "About dialog options"
 msgstr "დიალოგის პარამეტრების ჩვენება"
 
-#: src/option.c:2000
+#: src/option.c:2003
 msgid "Show custom about dialog options"
 msgstr "მორგებული შესახებ დიალოგის პარამეტრების ჩვენება"
 
-#: src/option.c:2006
+#: src/option.c:2009
 msgid "Application selection options"
 msgstr "აპლიკაციის არჩევის პარამეტრები"
 
-#: src/option.c:2006
+#: src/option.c:2009
 msgid "Show application selection options"
 msgstr "აპლიკაციის არჩევის პარამეტრების ჩვენება"
 
-#: src/option.c:2012
+#: src/option.c:2015
 msgid "Calendar options"
 msgstr "კალენდრის მორგება"
 
-#: src/option.c:2012
+#: src/option.c:2015
 msgid "Show calendar options"
 msgstr "კალენდრის პარამეტრების ჩვენება"
 
-#: src/option.c:2018
+#: src/option.c:2021
 msgid "Color selection options"
 msgstr "ფერის არჩევის პარამეტრები"
 
-#: src/option.c:2018
+#: src/option.c:2021
 msgid "Show color selection options"
 msgstr "ფერის არჩევის პარამეტრების ჩვენება"
 
-#: src/option.c:2024
+#: src/option.c:2027
 msgid "DND options"
 msgstr "DND-ის მორგება"
 
-#: src/option.c:2024
+#: src/option.c:2027
 msgid "Show drag-n-drop options"
 msgstr "DND-ის პარამეტრების ჩვენება"
 
-#: src/option.c:2030
+#: src/option.c:2033
 msgid "Text entry options"
 msgstr "ტექსტური ელემენტის პარამეტრები"
 
-#: src/option.c:2030
+#: src/option.c:2033
 msgid "Show text entry options"
 msgstr "ტექსტური ელემენტის პარამეტრების ჩვენება"
 
-#: src/option.c:2036
+#: src/option.c:2039
 msgid "File selection options"
 msgstr "ფაილის არჩევის პარამეტრები"
 
-#: src/option.c:2036
+#: src/option.c:2039
 msgid "Show file selection options"
 msgstr "ფაილის არჩევის პარამეტრების ჩვენება"
 
-#: src/option.c:2042
+#: src/option.c:2045
 msgid "Font selection options"
 msgstr "ფონტის არჩევანის მორგება"
 
-#: src/option.c:2042
+#: src/option.c:2045
 msgid "Show font selection options"
 msgstr "ფონტის არჩევანის მორგების ჩვენება"
 
-#: src/option.c:2048
+#: src/option.c:2051
 msgid "Form options"
 msgstr "ფორმის პარამეტრები"
 
-#: src/option.c:2048
+#: src/option.c:2051
 msgid "Show form options"
 msgstr "ფორმის პარამეტრების ცვენება"
 
-#: src/option.c:2055
+#: src/option.c:2058
 msgid "HTML options"
 msgstr "HTML-ის პარამეტრები"
 
-#: src/option.c:2055
+#: src/option.c:2058
 msgid "Show HTML options"
 msgstr "HTML-ის პარამეტრების ჩვენება"
 
-#: src/option.c:2062
+#: src/option.c:2065
 msgid "Icons box options"
 msgstr "ხატულების ფანჯრის პარამეტრები"
 
-#: src/option.c:2062
+#: src/option.c:2065
 msgid "Show icons box options"
 msgstr "ხატულების ფანჯრის პარამეტრების ჩვენება"
 
-#: src/option.c:2068
+#: src/option.c:2071
 msgid "List options"
 msgstr "სიის პარამეტრები"
 
-#: src/option.c:2068
+#: src/option.c:2071
 msgid "Show list options"
 msgstr "სიის პარამეტრების ჩვენება"
 
-#: src/option.c:2074
+#: src/option.c:2077
 msgid "Notebook options"
 msgstr "რვეულის მორგება"
 
-#: src/option.c:2074
+#: src/option.c:2077
 msgid "Show notebook dialog options"
 msgstr "რვეულის დიალოგის პარამეტრების ჩვენება"
 
-#: src/option.c:2081
+#: src/option.c:2084
 msgid "Notification icon options"
 msgstr "გაფრთხილების ხატულების პარამეტრები"
 
-#: src/option.c:2082
+#: src/option.c:2085
 msgid "Show notification icon options"
 msgstr "გაფრთხილების ხატულების პარამეტრების ჩვენება"
 
-#: src/option.c:2090
+#: src/option.c:2093
 msgid "StatusNotifier/AppIndicator options"
 msgstr "StatusNotifier/AppIndicator-ის პარამეტრები"
 
-#: src/option.c:2091
+#: src/option.c:2094
 msgid "Show indicator options"
 msgstr "მაჩვენებლის პარამეტრების ჩვენება"
 
-#: src/option.c:2098
+#: src/option.c:2101
 msgid "Paned dialog options"
 msgstr "პანელის დიალოგის პარამეტრები"
 
-#: src/option.c:2098
+#: src/option.c:2101
 msgid "Show paned dialog options"
 msgstr "პანელის დიალოგის პარამეტრების ჩვენება"
 
-#: src/option.c:2104
+#: src/option.c:2107
 msgid "Picture dialog options"
 msgstr "სურათის დიალოგის პარამეტრები"
 
-#: src/option.c:2104
+#: src/option.c:2107
 msgid "Show picture dialog options"
 msgstr "სურათის დიალოგის პარამეტრების ჩვენება"
 
-#: src/option.c:2110
+#: src/option.c:2113
 #, fuzzy
 msgid "Popup dialog options"
 msgstr "დიალოგის პარამეტრების ჩვენება"
 
-#: src/option.c:2110
+#: src/option.c:2113
 #, fuzzy
 msgid "Show popup dialog options"
 msgstr "სურათის დიალოგის პარამეტრების ჩვენება"
 
-#: src/option.c:2116
+#: src/option.c:2119
 msgid "Print dialog options"
 msgstr "დაბეჭდვის დიალოგის პარამეტრები"
 
-#: src/option.c:2116
+#: src/option.c:2119
 msgid "Show print dialog options"
 msgstr "დაბეჭდვის დიალოგის პარამეტრების ჩვენება"
 
-#: src/option.c:2122
+#: src/option.c:2125
 msgid "Progress options"
 msgstr "მიმდინარეობის პარამეტრები"
 
-#: src/option.c:2122
+#: src/option.c:2125
 msgid "Show progress options"
 msgstr "მიმდინარეობის პარამეტრების ჩვენება"
 
-#: src/option.c:2128
+#: src/option.c:2131
 msgid "Scale options"
 msgstr "მასშტაბირების პარამეტრები"
 
-#: src/option.c:2128
+#: src/option.c:2131
 msgid "Show scale options"
 msgstr "მასშტაბირების პარამეტრების ჩვენება"
 
-#: src/option.c:2134
+#: src/option.c:2137
 msgid "Text information options"
 msgstr "ტექსტური ინფორმაციის პარამეტრები"
 
-#: src/option.c:2134
+#: src/option.c:2137
 msgid "Show text information options"
 msgstr "ტექსტური ინფორმაციის პარამეტრების ჩვენება"
 
-#: src/option.c:2141
+#: src/option.c:2144
 msgid "SourceView options"
 msgstr "SourceView-ის პარამეტრები"
 
-#: src/option.c:2141
+#: src/option.c:2144
 msgid "Show SourceView options"
 msgstr "SourceView-ის პარამეტრების ჩვენება"
 
-#: src/option.c:2148
+#: src/option.c:2151
 msgid "File filter options"
 msgstr "ფაილის ფილტრის პარამეტრები"
 
-#: src/option.c:2148
+#: src/option.c:2151
 msgid "Show file filter options"
 msgstr "ფაილის ფილტრის პარამეტრების ჩვენება"
 
-#: src/option.c:2154
+#: src/option.c:2157
 msgid "Miscellaneous options"
 msgstr "სხვადასხვა პარამეტრები"
 
-#: src/option.c:2154
+#: src/option.c:2157
 msgid "Show miscellaneous options"
 msgstr "სხვადასხვა პარამეტრების ჩვენება"
 
@@ -2438,7 +2448,7 @@ msgstr "შეწევის სიგანე::NUM"
 msgid "Insert spaces instead of tabulation:CHK"
 msgstr "ტაბულაციის მაგიერ _გამოტოვებების ჩასმა:CHK"
 
-#: src/yad-settings.sh:113 data/yad-settings.desktop.in:3
+#: src/yad-settings.sh:113 data/yad-settings.desktop.in:4
 msgid "YAD settings"
 msgstr "YAD-ის მორგება"
 
@@ -2459,14 +2469,14 @@ msgstr "მთავარი"
 msgid "Editor"
 msgstr "რედაქტორი"
 
-#: data/yad-icon-browser.desktop.in:3
+#: data/yad-icon-browser.desktop.in:4
 msgid "Icon Browser"
 msgstr "ხატულების ბრაუზერი"
 
-#: data/yad-icon-browser.desktop.in:4
+#: data/yad-icon-browser.desktop.in:5
 msgid "Inspect GTK Icon Theme"
 msgstr "GTK-ის ხატულების თემის შემოწმება"
 
-#: data/yad-settings.desktop.in:4
+#: data/yad-settings.desktop.in:5
 msgid "Simple GUI for editing YAD settings"
 msgstr "მარტივი GUI-ი YAD-ის პარამეტრების ჩასასწორებლად"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Brazilian\n"
 "Report-Msgid-Bugs-To: victor@sanana.kiev.ua\n"
-"POT-Creation-Date: 2026-06-30 16:06+0300\n"
+"POT-Creation-Date: 2026-07-06 22:04-0400\n"
 "PO-Revision-Date: 2025-12-04 09:22-0300\n"
 "Last-Translator: Cristiano Fraga G. Nunes <cfgnunes@gmail.com>\n"
 "Language-Team: Brazilian\n"
@@ -95,15 +95,15 @@ msgstr "Selecionar ou criar pasta"
 msgid "Select date"
 msgstr "Selecione a data"
 
-#: src/form.c:1047
+#: src/form.c:1055
 msgid "Select file"
 msgstr "Selecione o arquivo"
 
-#: src/form.c:1077
+#: src/form.c:1085
 msgid "Select folder"
 msgstr "Selecione a pasta"
 
-#: src/form.c:1245 src/form.c:1247
+#: src/form.c:1253 src/form.c:1255
 msgid "Link"
 msgstr "Link"
 
@@ -142,36 +142,36 @@ msgstr "Não foi possível abrir o diretório %s: %s\n"
 msgid "%d sec"
 msgstr "%d seg"
 
-#: src/main.c:748 src/main.c:755
+#: src/main.c:764 src/main.c:771
 #, c-format
 msgid "Unable to parse YAD_OPTIONS: %s\n"
 msgstr "Não foi possível interpretar YAD_OPTIONS: %s\n"
 
-#: src/main.c:766
+#: src/main.c:782
 #, c-format
 msgid "Unable to parse command line: %s\n"
 msgstr "Não foi possível analisar a linha de comando: %s\n"
 
-#: src/main.c:780
+#: src/main.c:796
 msgid ""
 "WARNING: Using splash option is deprecated, please use --window-type instead"
 msgstr ""
 "AVISO: A opção splash está obsoleta, por favor use --window-type no lugar"
 
-#: src/main.c:790
+#: src/main.c:806
 #, c-format
 msgid "Unable to change directory to %s: %s\n"
 msgstr "Não foi possível mudar o diretório para %s: %s\n"
 
-#: src/main.c:819
+#: src/main.c:835
 msgid "WARNING: Using gtkrc option is deprecated, please use --css instead\n"
 msgstr "AVISO: A opção gtkrc está obsoleta, use --css em seu lugar\n"
 
-#: src/main.c:893
+#: src/main.c:909
 msgid "WARNING: --plug mode not supported outside X11\n"
 msgstr "AVISO: o modo --plug não é suportado fora do X11\n"
 
-#: src/main.c:913
+#: src/main.c:929
 msgid "WARNING: This mode not supported outside X11\n"
 msgstr "AVISO: Este modo não é suportado fora do X11\n"
 
@@ -269,12 +269,12 @@ msgstr "ALTURA"
 msgid "Set the X position of a window"
 msgstr "Defina a posição X da janela"
 
-#: src/option.c:106 src/option.c:108 src/option.c:118 src/option.c:140
-#: src/option.c:144 src/option.c:189 src/option.c:203 src/option.c:342
-#: src/option.c:400 src/option.c:406 src/option.c:487 src/option.c:495
-#: src/option.c:497 src/option.c:499 src/option.c:501 src/option.c:503
-#: src/option.c:505 src/option.c:509 src/option.c:543 src/option.c:545
-#: src/option.c:599 src/option.c:633 src/option.c:702
+#: src/option.c:106 src/option.c:108 src/option.c:118 src/option.c:142
+#: src/option.c:146 src/option.c:191 src/option.c:205 src/option.c:344
+#: src/option.c:402 src/option.c:408 src/option.c:489 src/option.c:497
+#: src/option.c:499 src/option.c:501 src/option.c:503 src/option.c:505
+#: src/option.c:507 src/option.c:511 src/option.c:545 src/option.c:547
+#: src/option.c:601 src/option.c:635 src/option.c:704
 msgid "NUMBER"
 msgstr "NUMERO"
 
@@ -302,7 +302,7 @@ msgstr "TIMEOUT"
 msgid "Show remaining time indicator (top, bottom, left, right)"
 msgstr "Exibir indicador de tempo restante (top, bottom, left, right)"
 
-#: src/option.c:114 src/option.c:587
+#: src/option.c:114 src/option.c:589
 msgid "POS"
 msgstr "POS"
 
@@ -310,8 +310,8 @@ msgstr "POS"
 msgid "Set the dialog text"
 msgstr "Defina o texto do diálogo"
 
-#: src/option.c:116 src/option.c:273 src/option.c:275 src/option.c:350
-#: src/option.c:352 src/option.c:386 src/option.c:507 src/option.c:637
+#: src/option.c:116 src/option.c:275 src/option.c:277 src/option.c:352
+#: src/option.c:354 src/option.c:388 src/option.c:509 src/option.c:639
 msgid "TEXT"
 msgstr "TEXTO"
 
@@ -323,11 +323,11 @@ msgstr "Definir a largura do texto do diálogo em caracteres"
 msgid "Set the dialog text alignment (left, center, right, fill)"
 msgstr "Definir o alinhamento do texto de diálogo (left,center,right,fill)"
 
-#: src/option.c:120 src/option.c:132 src/option.c:185 src/option.c:235
-#: src/option.c:241 src/option.c:243 src/option.c:398 src/option.c:481
-#: src/option.c:491 src/option.c:541 src/option.c:585 src/option.c:597
-#: src/option.c:609 src/option.c:621 src/option.c:635 src/option.c:698
-#: src/option.c:749 src/option.c:778 src/option.c:780 src/tools.c:86
+#: src/option.c:120 src/option.c:132 src/option.c:187 src/option.c:237
+#: src/option.c:243 src/option.c:245 src/option.c:400 src/option.c:483
+#: src/option.c:493 src/option.c:543 src/option.c:587 src/option.c:599
+#: src/option.c:611 src/option.c:623 src/option.c:637 src/option.c:700
+#: src/option.c:751 src/option.c:780 src/option.c:782 src/tools.c:86
 msgid "TYPE"
 msgstr "TIPO"
 
@@ -335,7 +335,7 @@ msgstr "TIPO"
 msgid "Set the dialog image"
 msgstr "Definir a imagem do diálogo"
 
-#: src/option.c:122 src/option.c:360 src/option.c:364
+#: src/option.c:122 src/option.c:362 src/option.c:366
 msgid "IMAGE"
 msgstr "IMAGEM"
 
@@ -343,7 +343,7 @@ msgstr "IMAGEM"
 msgid "Use specified icon theme instead of default"
 msgstr "Defina o ícone do tema ao invés de usar o default"
 
-#: src/option.c:124 src/option.c:727 src/browser.c:220 src/tools.c:87
+#: src/option.c:124 src/option.c:729 src/browser.c:220 src/tools.c:87
 msgid "THEME"
 msgstr "TEMA"
 
@@ -351,7 +351,7 @@ msgstr "TEMA"
 msgid "Hide main widget with expander"
 msgstr "Esconder a janela principal com expansor"
 
-#: src/option.c:126 src/option.c:378 src/option.c:654 src/option.c:718
+#: src/option.c:126 src/option.c:380 src/option.c:656 src/option.c:720
 msgid "[TEXT]"
 msgstr "[TEXTO]"
 
@@ -372,626 +372,636 @@ msgid "Set buttons layout type (spread, edge, start, end or center)"
 msgstr "Definir o tipo de layout do botão (spread, edge, start, end ou center)"
 
 #: src/option.c:134
+#, fuzzy
+msgid "Set focus to the named button when dialog opens"
+msgstr "Exibir opções personalizadas do diálogo Sobre"
+
+#: src/option.c:134
+#, fuzzy
+msgid "NAME"
+msgstr "[NOME]"
+
+#: src/option.c:136
 msgid "Don't use pango markup language in dialog's text"
 msgstr "Não use linguagem de marcação Pango no texto do diálogo"
 
-#: src/option.c:136
+#: src/option.c:138
 msgid "Don't close dialog if Escape was pressed"
 msgstr "Não feche o diálogo se a tecla de escape for pressionada"
 
-#: src/option.c:138
+#: src/option.c:140
 msgid "Escape acts like OK button"
 msgstr "Esc funciona como o botão OK"
 
-#: src/option.c:140
+#: src/option.c:142
 msgid "Set window borders"
 msgstr "Definir bordas da janela"
 
-#: src/option.c:142
+#: src/option.c:144
 msgid "Always print result"
 msgstr "Sempre imprima o resultado"
 
-#: src/option.c:144
+#: src/option.c:146
 msgid "Set default return code"
 msgstr "Definir código de retorno padrão"
 
-#: src/option.c:146
+#: src/option.c:148
 msgid "Dialog text can be selected"
 msgstr "O texto de diálogo pode ser selecionado"
 
-#: src/option.c:148
+#: src/option.c:150
 msgid "Don't scale icons"
 msgstr "Não redimensionar ícones"
 
-#: src/option.c:150
+#: src/option.c:152
 #, c-format
 msgid "Run commands under specified interpreter (default: bash -c '%s')"
 msgstr "Executar comandos no interpretador indicado (padrão: bash -c '%s')"
 
-#: src/option.c:150 src/option.c:152 src/option.c:154 src/option.c:205
-#: src/option.c:312 src/option.c:362 src/option.c:366 src/option.c:412
-#: src/option.c:511 src/option.c:513 src/option.c:515 src/option.c:601
+#: src/option.c:152 src/option.c:154 src/option.c:156 src/option.c:207
+#: src/option.c:314 src/option.c:364 src/option.c:368 src/option.c:414
+#: src/option.c:513 src/option.c:515 src/option.c:517 src/option.c:603
 msgid "CMD"
 msgstr "CMD"
 
-#: src/option.c:152
+#: src/option.c:154
 msgid "Set URI handler"
 msgstr "Definir manipulador de URI"
 
-#: src/option.c:154
+#: src/option.c:156
 msgid "Set command running when F1 was pressed"
 msgstr "Definir comando executado quando F1 for pressionado"
 
-#: src/option.c:156
+#: src/option.c:158
 msgid "Set working directory"
 msgstr "Definir diretório de trabalho"
 
-#: src/option.c:156 src/option.c:782
+#: src/option.c:158 src/option.c:784
 msgid "PATH"
 msgstr "CAMINHO"
 
-#: src/option.c:159
+#: src/option.c:161
 msgid "Set window sticky"
 msgstr "Definir janela sticky"
 
-#: src/option.c:161
+#: src/option.c:163
 msgid "Set window unresizable"
 msgstr "Definir janela não redimensionável"
 
-#: src/option.c:163
+#: src/option.c:165
 msgid "Place window on top"
 msgstr "Colocar janela no topo"
 
-#: src/option.c:165
+#: src/option.c:167
 msgid "Place window on center of screen"
 msgstr "Colocar janela no centro da tela"
 
-#: src/option.c:167
+#: src/option.c:169
 msgid "Place window at the mouse position"
 msgstr "Colocar janela na posição do mouse"
 
-#: src/option.c:169
+#: src/option.c:171
 msgid "Set window undecorated"
 msgstr "Conjunto de janela sem decoração"
 
-#: src/option.c:171
+#: src/option.c:173
 msgid "Don't show window in taskbar"
 msgstr "Não exibir a janela na barra de tarefas"
 
-#: src/option.c:173
+#: src/option.c:175
 msgid "Set window maximized"
 msgstr "Definir janela maximizada"
 
-#: src/option.c:175
+#: src/option.c:177
 msgid "Set window fullscreen"
 msgstr "Definir janela em tela cheia"
 
-#: src/option.c:177
+#: src/option.c:179
 msgid "Don't focus dialog window"
 msgstr "Janela de diálogo sem foco"
 
-#: src/option.c:179
+#: src/option.c:181
 msgid "Close window when it sets unfocused"
 msgstr "Fechar janela quando for definida sem foco"
 
-#: src/option.c:182
+#: src/option.c:184
 msgid "Open window as a splashscreen (Deprecated, see man page for details)"
 msgstr "Abrir janela como splashscreen (Obsoleto, veja o manual para detalhes)"
 
-#: src/option.c:185
+#: src/option.c:187
 msgid "Specify the window type for the dialog"
 msgstr "Especificar o tipo de janela para o diálogo"
 
-#: src/option.c:187
+#: src/option.c:189
 msgid "Special type of dialog for XEMBED"
 msgstr "Tipo especial de diálogo para XEMBED"
 
-#: src/option.c:187 src/option.c:239
+#: src/option.c:189 src/option.c:241
 msgid "KEY"
 msgstr "CHAVE"
 
-#: src/option.c:189
+#: src/option.c:191
 msgid "Tab number of this dialog"
 msgstr "Número guia desta caixa de diálogo"
 
-#: src/option.c:192
+#: src/option.c:194
 msgid "Send SIGNAL to parent"
 msgstr "Enviar SIGNAL para o pai"
 
-#: src/option.c:192
+#: src/option.c:194
 msgid "[SIGNAL]"
 msgstr "[SINAL]"
 
-#: src/option.c:194
+#: src/option.c:196
 msgid "Print X Window Id to the file/stderr"
 msgstr "Imprimir o ID da janela X para arquivo/stderr"
 
-#: src/option.c:194 src/option.c:324
+#: src/option.c:196 src/option.c:326
 msgid "[FILENAME]"
 msgstr "[NOMEDOARQUIVO]"
 
-#: src/option.c:201
+#: src/option.c:203
 msgid "Set the format for the returned date"
 msgstr "Definir formato de retorno da data"
 
-#: src/option.c:201 src/option.c:453
+#: src/option.c:203 src/option.c:455
 msgid "PATTERN"
 msgstr "PADRAO"
 
-#: src/option.c:203
+#: src/option.c:205
 msgid "Set presicion of floating numbers (default - 3)"
 msgstr "Definir precisão de números flutuantes (default - 3)"
 
-#: src/option.c:205
+#: src/option.c:207
 msgid "Set command handler"
 msgstr "Definir manipulador de comandos"
 
-#: src/option.c:207
+#: src/option.c:209
 msgid "Listen for data on stdin"
 msgstr "Ouça os comandos em stdin"
 
-#: src/option.c:209
+#: src/option.c:211
 msgid "Set common separator character"
 msgstr "Definir caractere separador de saída"
 
-#: src/option.c:209 src/option.c:211
+#: src/option.c:211 src/option.c:213
 msgid "SEPARATOR"
 msgstr "SEPARADOR"
 
-#: src/option.c:211
+#: src/option.c:213
 msgid "Set item separator character"
 msgstr "Definir caractere separador de ítem"
 
-#: src/option.c:213
+#: src/option.c:215
 msgid "Allow changes to text in some cases"
 msgstr "Permitir alterações do texto em alguns casos"
 
-#: src/option.c:215
+#: src/option.c:217
 msgid "Autoscroll to end of text"
 msgstr "Auto rolagem para o fim do texto"
 
-#: src/option.c:217
+#: src/option.c:219
 msgid "Autoscroll to end of text (alias to tail)"
 msgstr "Rolar automaticamente até o fim do texto (equivalente a tail)"
 
-#: src/option.c:219
+#: src/option.c:221
 msgid "Quote dialogs output"
 msgstr "Cota de saída de diálogos"
 
-#: src/option.c:221
+#: src/option.c:223
 msgid "Output number instead of text for combo-box"
 msgstr "Número de saída ao invés de texto na combo-box"
 
-#: src/option.c:223
+#: src/option.c:225
 msgid "Specify font name to use"
 msgstr "Especifique nome da fonte a ser usada"
 
-#: src/option.c:223
+#: src/option.c:225
 msgid "FONTNAME"
 msgstr "NOMEFONTE"
 
-#: src/option.c:225
+#: src/option.c:227
 msgid "Allow multiple selection"
 msgstr "Permitir seleção múltipla"
 
-#: src/option.c:227
+#: src/option.c:229
 msgid "Enable preview"
 msgstr "Ativar pré-visualização"
 
-#: src/option.c:229
+#: src/option.c:231
 msgid "Use large preview"
 msgstr "Usar visualização ampliada"
 
-#: src/option.c:231
+#: src/option.c:233
 msgid "Show hidden files in file selection dialogs"
 msgstr "Exibir arquivos ocultos em caixas de seleção de arquivos"
 
-#: src/option.c:233
+#: src/option.c:235
 msgid "Set source filename"
 msgstr "Defina nome do arquivo fonte"
 
-#: src/option.c:233 src/option.c:308 src/option.c:775 src/option.c:790
+#: src/option.c:235 src/option.c:310 src/option.c:777 src/option.c:792
 msgid "FILENAME"
 msgstr "NOMEDOARQUIVO"
 
-#: src/option.c:235
+#: src/option.c:237
 msgid "Set mime type of input data"
 msgstr "Definir tipo MIME dos dados de entrada"
 
-#: src/option.c:237
+#: src/option.c:239
 msgid "Set vertical orientation"
 msgstr "Defina orientação vertical"
 
-#: src/option.c:239
+#: src/option.c:241
 msgid "Identifier of embedded dialogs"
 msgstr "Identificador de diálogos embutidos"
 
-#: src/option.c:241
+#: src/option.c:243
 msgid "Set extended completion for entries (any, all, or regex)"
 msgstr ""
 "Definir conclusão estendida para entradas (any, all ou expressão regular)"
 
-#: src/option.c:243
+#: src/option.c:245
 msgid "Set type of output for boolean values (T, t, Y, y, O, o, 1)"
 msgstr "Definir tipo de saída para valores booleanos (T, t, Y, y, O, o, 1)"
 
-#: src/option.c:245
+#: src/option.c:247
 msgid "Make main widget scrollable"
 msgstr "Tornar o widget principal rolável"
 
-#: src/option.c:247
+#: src/option.c:249
 msgid "Disable search in text and html dialogs"
 msgstr "Desabilitar busca em diálogos de texto e html"
 
-#: src/option.c:249
+#: src/option.c:251
 msgid "Enable file operations"
 msgstr "Habilitar operações de arquivo"
 
-#: src/option.c:252
+#: src/option.c:254
 msgid "Use IEC (base 1024) units with for size values"
 msgstr "Usar unidades IEC (base 1024) para valores de tamanho"
 
-#: src/option.c:256
+#: src/option.c:258
 msgid "Enable spell check for text"
 msgstr "Ativar a verificação ortográfica do texto"
 
-#: src/option.c:258
+#: src/option.c:260
 msgid "Set spell checking language"
 msgstr "Definir o idioma de verificação ortográfica"
 
-#: src/option.c:258
+#: src/option.c:260
 msgid "LANGUAGE"
 msgstr "IDIOMA"
 
-#: src/option.c:265
+#: src/option.c:267
 msgid "Display about dialog"
 msgstr "Exibir diálogo Sobre"
 
-#: src/option.c:267
+#: src/option.c:269
 msgid "Set application name"
 msgstr "Definir nome da aplicação"
 
-#: src/option.c:267 src/option.c:269 src/option.c:271 src/option.c:281
-#: src/option.c:429 src/option.c:431 src/option.c:529 src/option.c:531
-#: src/option.c:558 src/option.c:574 src/option.c:772
+#: src/option.c:269 src/option.c:271 src/option.c:273 src/option.c:283
+#: src/option.c:431 src/option.c:433 src/option.c:531 src/option.c:533
+#: src/option.c:560 src/option.c:576 src/option.c:774
 msgid "STRING"
 msgstr "STRING"
 
-#: src/option.c:269
+#: src/option.c:271
 msgid "Set application version"
 msgstr "Definir a versão da aplicação"
 
-#: src/option.c:271
+#: src/option.c:273
 msgid "Set application copyright string"
 msgstr "Definir o texto de direitos autorais da aplicação"
 
-#: src/option.c:273
+#: src/option.c:275
 msgid "Set application comments string"
 msgstr "Definir o texto de comentários da aplicação"
 
-#: src/option.c:275
+#: src/option.c:277
 msgid "Set application license"
 msgstr "Definir a licença da aplicação"
 
-#: src/option.c:277
+#: src/option.c:279
 msgid "Set application authors"
 msgstr "Definir os autores da aplicação"
 
-#: src/option.c:277 src/option.c:485 src/option.c:489 src/option.c:493
+#: src/option.c:279 src/option.c:487 src/option.c:491 src/option.c:495
 msgid "LIST"
 msgstr "LISTA"
 
-#: src/option.c:279
+#: src/option.c:281
 msgid "Set application website"
 msgstr "Definir site da aplicação"
 
-#: src/option.c:279
+#: src/option.c:281
 msgid "URI"
 msgstr "URI"
 
-#: src/option.c:281
+#: src/option.c:283
 msgid "Set application website label"
 msgstr "Definir rótulo do site da aplicação"
 
-#: src/option.c:287
+#: src/option.c:289
 msgid "Display application selection dialog"
 msgstr "Exibir diálogo de seleção de aplicativos"
 
-#: src/option.c:289
+#: src/option.c:291
 msgid "Show fallback applications"
 msgstr "Exibir aplicativos alternativos"
 
-#: src/option.c:291
+#: src/option.c:293
 msgid "Show other applications"
 msgstr "Exibir outros aplicativos"
 
-#: src/option.c:293
+#: src/option.c:295
 msgid "Show all applications"
 msgstr "Exibir todos os aplicativos"
 
-#: src/option.c:295
+#: src/option.c:297
 msgid "Output all application data"
 msgstr "Exibir todos os dados da aplicação"
 
-#: src/option.c:300
+#: src/option.c:302
 msgid "Display calendar dialog"
 msgstr "Exibir caixa de diálogo de calendário"
 
-#: src/option.c:302
+#: src/option.c:304
 msgid "Set the calendar day"
 msgstr "Defina o dia no calendário"
 
-#: src/option.c:302
+#: src/option.c:304
 msgid "DAY"
 msgstr "DIA"
 
-#: src/option.c:304
+#: src/option.c:306
 msgid "Set the calendar month"
 msgstr "Defina o mês"
 
-#: src/option.c:304
+#: src/option.c:306
 msgid "MONTH"
 msgstr "MES"
 
-#: src/option.c:306
+#: src/option.c:308
 msgid "Set the calendar year"
 msgstr "Defina o ano"
 
-#: src/option.c:306
+#: src/option.c:308
 msgid "YEAR"
 msgstr "ANO"
 
-#: src/option.c:308
+#: src/option.c:310
 msgid "Set the filename with dates details"
 msgstr "Defina o nome do arquivo com detalhes da data"
 
-#: src/option.c:310
+#: src/option.c:312
 msgid "Show week numbers at the left side of calendar"
 msgstr "Exibir números de semana no lado esquerdo do calendário"
 
-#: src/option.c:312 src/option.c:513
+#: src/option.c:314 src/option.c:515
 msgid "Set select action"
 msgstr "Defina ação de seleção"
 
-#: src/option.c:318
+#: src/option.c:320
 msgid "Display color selection dialog"
 msgstr "Exibir diálogo de seleção de cores"
 
-#: src/option.c:320
+#: src/option.c:322
 msgid "Set initial color value"
 msgstr "Definir o valor de cor inicial"
 
-#: src/option.c:320 src/option.c:704 src/option.c:706 src/option.c:712
-#: src/option.c:735 src/option.c:737
+#: src/option.c:322 src/option.c:706 src/option.c:708 src/option.c:714
+#: src/option.c:737 src/option.c:739
 msgid "COLOR"
 msgstr "COR"
 
-#: src/option.c:322
+#: src/option.c:324
 msgid "Show system palette in color dialog"
 msgstr "Exibir paleta de cor"
 
-#: src/option.c:324
+#: src/option.c:326
 msgid "Set path to palette file. Default - "
 msgstr "Definir caminho para o arquivo de paleta. Padrão - "
 
-#: src/option.c:326
+#: src/option.c:328
 msgid "Expand user palette"
 msgstr "Paleta expandida"
 
-#: src/option.c:328
+#: src/option.c:330
 msgid "Show color picker"
 msgstr "Exibir seletor de cores"
 
-#: src/option.c:330
+#: src/option.c:332
 msgid "Set output mode to MODE. Values are hex (default) or rgb"
 msgstr "Definir modo de saída para MODE. Valores: hex (padrão) ou rgb"
 
-#: src/option.c:330
+#: src/option.c:332
 msgid "MODE"
 msgstr "MODE"
 
-#: src/option.c:332
+#: src/option.c:334
 msgid "Add opacity to output color value"
 msgstr "Adicionar opacidade ao valor de saída da cor"
 
-#: src/option.c:338
+#: src/option.c:340
 msgid "Display drag-n-drop box"
 msgstr "Exibir a caixa drag-n-drop"
 
-#: src/option.c:340
+#: src/option.c:342
 msgid "Use dialog text as tooltip"
 msgstr "Use o texto de diálogo como dica"
 
-#: src/option.c:342
+#: src/option.c:344
 msgid "Exit after NUMBER of drops"
 msgstr "Sair após NÚMERO de inserções"
 
-#: src/option.c:348
+#: src/option.c:350
 msgid "Display text entry or combo-box dialog"
 msgstr "Exibir a entrada de texto ou diálogo combo-box"
 
-#: src/option.c:350
+#: src/option.c:352
 msgid "Set the entry label"
 msgstr "Defina o rótula da entrada"
 
-#: src/option.c:352
+#: src/option.c:354
 msgid "Set the entry text"
 msgstr "Defina o texto de entrada"
 
-#: src/option.c:354
+#: src/option.c:356
 msgid "Hide the entry text"
 msgstr "Ocultar o texto de entrada"
 
-#: src/option.c:356
+#: src/option.c:358
 msgid "Use completion instead of combo-box"
 msgstr "Use complemento ao invés de combo-box"
 
-#: src/option.c:358
+#: src/option.c:360
 msgid "Use spin button for text entry"
 msgstr "Use o botão de rotação para entrada do texto"
 
-#: src/option.c:360
+#: src/option.c:362
 msgid "Set the left entry icon"
 msgstr "Defina o ícone de entrada a esquerda"
 
-#: src/option.c:362
+#: src/option.c:364
 msgid "Set the left entry icon action"
 msgstr "Defina a ação do ícone de entrada a esquerda"
 
-#: src/option.c:364
+#: src/option.c:366
 msgid "Set the right entry icon"
 msgstr "Defina o ícone de entrada a direita"
 
-#: src/option.c:366
+#: src/option.c:368
 msgid "Set the right entry icon action"
 msgstr "Defina a ação do ícone de entrada a direita"
 
-#: src/option.c:372
+#: src/option.c:374
 msgid "Display file selection dialog"
 msgstr "Exibir caixa diálogo de seleção de arquivo"
 
-#: src/option.c:374
+#: src/option.c:376
 msgid "Activate directory-only selection"
 msgstr "Ativar seleção apenas de diretório"
 
-#: src/option.c:376
+#: src/option.c:378
 msgid "Activate save mode"
 msgstr "Ative o modo de salvar"
 
-#: src/option.c:378
+#: src/option.c:380
 msgid "Confirm file selection if filename already exists"
 msgstr "Confirme se o nome do arquivo selecionado já existe"
 
-#: src/option.c:384
+#: src/option.c:386
 msgid "Display font selection dialog"
 msgstr "Exibir caixa de diálogo de seleção de fonte"
 
-#: src/option.c:386
+#: src/option.c:388
 msgid "Set text string for preview"
 msgstr "Definir sequência de texto para visualização"
 
-#: src/option.c:388
+#: src/option.c:390
 msgid "Separate output of font description"
 msgstr "Saída separada da descrição da fonte"
 
-#: src/option.c:394
+#: src/option.c:396
 msgid "Display form dialog"
 msgstr "Exibir caixa de diálogo tipo formulário"
 
-#: src/option.c:396
+#: src/option.c:398
 msgid "Add field to form (see man page for list of possible types)"
 msgstr "Adicionar campo ao formulário (veja o manual para tipos possíveis)"
 
-#: src/option.c:396 src/option.c:631
+#: src/option.c:398 src/option.c:633
 msgid "LABEL[:TYPE]"
 msgstr "ROTULO[:TIPO]"
 
-#: src/option.c:398
+#: src/option.c:400
 msgid "Set alignment of filed labels (left, center or right)"
 msgstr "Defina o alinhamento dos rótulos de campo (left, center ou right)"
 
-#: src/option.c:400
+#: src/option.c:402
 msgid "Set number of columns in form"
 msgstr "Defina o número de colunas no formulário"
 
-#: src/option.c:402
+#: src/option.c:404
 msgid "Make form fields height and columns width the same size"
 msgstr ""
 "Tornar a altura dos campos e a largura das colunas do formulário iguais"
 
-#: src/option.c:404
+#: src/option.c:406
 msgid "Order output fields by rows"
 msgstr "Ordenar campos de saída das linhas"
 
-#: src/option.c:406
+#: src/option.c:408
 msgid "Set focused field"
 msgstr "Definir campo ofuscado"
 
-#: src/option.c:408
+#: src/option.c:410
 msgid "Cycled reading of stdin data"
 msgstr "Leitura cíclica de dados da stdin"
 
-#: src/option.c:410
+#: src/option.c:412
 msgid "Align labels on button fields"
 msgstr "Alinhar rótulos nos campos de botão"
 
-#: src/option.c:412
+#: src/option.c:414
 msgid "Set changed action"
 msgstr "Definir ação ao mudar valor"
 
-#: src/option.c:419
+#: src/option.c:421
 msgid "Display HTML dialog"
 msgstr "Exibir diálogo HTML"
 
-#: src/option.c:421
+#: src/option.c:423
 msgid "Open specified location"
 msgstr "Abrir local especificado"
 
-#: src/option.c:423
+#: src/option.c:425
 msgid "Turn on browser mode"
 msgstr "Ativar o modo de navegador"
 
-#: src/option.c:425
+#: src/option.c:427
 msgid "Print clicked uri to stdout"
 msgstr "Imprimir clique de URI em stdout"
 
-#: src/option.c:427
+#: src/option.c:429
 msgid "Set encoding of input stream data"
 msgstr "Definir a codificação de dados de fluxo de entrada"
 
-#: src/option.c:427
+#: src/option.c:429
 msgid "ENCODING"
 msgstr "CODIFICACAO"
 
-#: src/option.c:429
+#: src/option.c:431
 msgid "Set user agent string"
 msgstr "Definir string de user agent"
 
-#: src/option.c:431
+#: src/option.c:433
 msgid "Set custom user style"
 msgstr "Definir estilo personalizado do usuário"
 
-#: src/option.c:433
+#: src/option.c:435
 msgid "Set WebKit property"
 msgstr "Definir propriedade do WebKit"
 
-#: src/option.c:433
+#: src/option.c:435
 msgid "PROP"
 msgstr "PROP"
 
-#: src/option.c:440
+#: src/option.c:442
 msgid "Display icons box dialog"
 msgstr "Exibir caixa de diálogo de ícones"
 
-#: src/option.c:442
+#: src/option.c:444
 msgid "Read data from .desktop files in specified directory"
 msgstr "Ler dados dos arquivos tipo .desktop especificando diretório"
 
-#: src/option.c:442
+#: src/option.c:444
 msgid "DIR"
 msgstr "DIRETORIO"
 
-#: src/option.c:444
+#: src/option.c:446
 msgid "Use compact (list) view"
 msgstr "Usar leitura compacta (lista)"
 
-#: src/option.c:446
+#: src/option.c:448
 msgid "Use GenericName field instead of Name for icon label"
 msgstr "Use o campo GenericName ao invés de Nome para o rótulo do ícone"
 
-#: src/option.c:448
+#: src/option.c:450
 msgid "Set the width of dialog items"
 msgstr "Defina a largura dos itens de diálogo"
 
-#: src/option.c:450
+#: src/option.c:452
 msgid "Force using specified icon size"
 msgstr "Forçar uso do tamanho de ícone especificado"
 
-#: src/option.c:450 src/option.c:564 src/option.c:700 src/tools.c:85
+#: src/option.c:452 src/option.c:566 src/option.c:702 src/tools.c:85
 msgid "SIZE"
 msgstr "TAMANHO"
 
-#: src/option.c:453
+#: src/option.c:455
 #, no-c-format
 msgid ""
 "Use specified pattern for launch command in terminal (default: xterm -e %s)"
@@ -999,84 +1009,84 @@ msgstr ""
 "Use o padrão especificado para o comando de inicialização no terminal "
 "(default: xterm -e %s)"
 
-#: src/option.c:455
+#: src/option.c:457
 msgid "Sort items by name instead of filename"
 msgstr "Classificar itens por nome em vez de nome de arquivo"
 
-#: src/option.c:457
+#: src/option.c:459
 msgid "Sort items in descending order"
 msgstr "Classificar itens em ordem decrescente"
 
-#: src/option.c:459
+#: src/option.c:461
 msgid "Activate items by single click"
 msgstr "Ativar itens com um único clique"
 
-#: src/option.c:461
+#: src/option.c:463
 msgid "Watch fot changes in directory"
 msgstr "Procure mudanças no diretório"
 
-#: src/option.c:467
+#: src/option.c:469
 msgid "Display list dialog"
 msgstr "Exibir caixa de diálogo tipo lista"
 
-#: src/option.c:469
+#: src/option.c:471
 msgid "Set the column header (see man page for list of possible types)"
 msgstr "Definir cabeçalho da coluna (veja o manual para tipos possíveis)"
 
-#: src/option.c:469
+#: src/option.c:471
 msgid "COLUMN[:TYPE]"
 msgstr "COLUNA[:TIPO]"
 
-#: src/option.c:471
+#: src/option.c:473
 msgid "Enbale tree mode"
 msgstr "Habilitar modo árvore"
 
-#: src/option.c:473
+#: src/option.c:475
 msgid "Use checkboxes for first column"
 msgstr "Use caixas de seleção para a primeira coluna"
 
-#: src/option.c:475
+#: src/option.c:477
 msgid "Use radioboxes for first column"
 msgstr "Use radiobox para a primeira coluna"
 
-#: src/option.c:477
+#: src/option.c:479
 msgid "Don't show column headers"
 msgstr "Não exibir os cabeçalhos das colunas"
 
-#: src/option.c:479
+#: src/option.c:481
 msgid "Disable clickable column headers"
 msgstr "Desativar clicabilidade dos cabeçalhos de coluna"
 
-#: src/option.c:481
+#: src/option.c:483
 msgid "Set grid lines (hor[izontal], vert[ical] or both)"
 msgstr "Defina linhas de grade (hor[izontal], vert[ical] ou both)"
 
-#: src/option.c:483
+#: src/option.c:485
 msgid "Print all data from list"
 msgstr "Imprimir todos os dados da lista"
 
-#: src/option.c:485
+#: src/option.c:487
 msgid "Set the list of editable columns"
 msgstr "Defina a lista das colinas editáveis"
 
-#: src/option.c:487
+#: src/option.c:489
 msgid "Set the width of a column for start wrapping text"
 msgstr "Definir a largura da coluna para início da quebra de texto"
 
-#: src/option.c:489
+#: src/option.c:491
 msgid "Set the list of wrapped columns"
 msgstr "Definir a lista de colunas cobertas"
 
-#: src/option.c:491
+#: src/option.c:493
 msgid "Set ellipsize mode for text columns (none, start, middle or end)"
 msgstr ""
 "Definir modo de elipse para colunas de texto (none, start, middle ou end)"
 
-#: src/option.c:493
+#: src/option.c:495
 msgid "Set the list of ellipsized columns"
 msgstr "Defina a lista de colunas elipsadas"
 
-#: src/option.c:495
+#: src/option.c:497
 msgid ""
 "Print a specific column. By default or if 0 is specified will be printed all "
 "columns"
@@ -1084,15 +1094,15 @@ msgstr ""
 "Imprimir uma coluna específica. Por padrão, ou se 0 for especificado, serão "
 "impressas todas as colunas"
 
-#: src/option.c:497
+#: src/option.c:499
 msgid "Hide a specific column"
 msgstr "Ocultar uma coluna específica"
 
-#: src/option.c:499
+#: src/option.c:501
 msgid "Set the column expandable by default. 0 sets all columns expandable"
 msgstr "Definir coluna expansível por padrão. 0 torna todas expansíveis"
 
-#: src/option.c:501
+#: src/option.c:503
 msgid ""
 "Set the quick search column. Default is first column. Set it to 0 for "
 "disable searching"
@@ -1100,804 +1110,804 @@ msgstr ""
 "Defina a coluna de pesquisa rápida. Por padrão é primeira coluna. Você pode "
 "configurar 0 para desabilitar a pesquisa"
 
-#: src/option.c:503
+#: src/option.c:505
 msgid "Set the tooltip column"
 msgstr "Defina a dica de coluna"
 
-#: src/option.c:505
+#: src/option.c:507
 msgid "Set the row separator column"
 msgstr "Definir a coluna do separador de linha"
 
-#: src/option.c:507
+#: src/option.c:509
 msgid "Set the row separator value"
 msgstr "Definir valor do separador de linha"
 
-#: src/option.c:509
+#: src/option.c:511
 msgid "Set the limit of rows in list"
 msgstr "Defina o limite de linhas na lista"
 
-#: src/option.c:511
+#: src/option.c:513
 msgid "Set double-click action"
 msgstr "Definir ação com duplo-clique"
 
-#: src/option.c:515
+#: src/option.c:517
 msgid "Set row action"
 msgstr "Definir ação da linha"
 
-#: src/option.c:517
+#: src/option.c:519
 msgid "Expand all tree nodes"
 msgstr "Expandir todos os nós da árvore"
 
-#: src/option.c:519
+#: src/option.c:521
 msgid "Use regex in search"
 msgstr "Usar expressão regular na pesquisa"
 
-#: src/option.c:521
+#: src/option.c:523
 msgid "Disable selection"
 msgstr "Desative seleção"
 
-#: src/option.c:523
+#: src/option.c:525
 msgid "Add new records on the top of a list"
 msgstr "Adicionar novos registros no topo da lista"
 
-#: src/option.c:525
+#: src/option.c:527
 msgid "Don't use markup in tooltips"
 msgstr "Não usar markup em tooltips"
 
-#: src/option.c:527
+#: src/option.c:529
 msgid "Use column name as a header tooltip"
 msgstr "Usar nome da coluna como tooltip do cabeçalho"
 
-#: src/option.c:529
+#: src/option.c:531
 msgid "Set columns alignment"
 msgstr "Definir alinhamento das colunas"
 
-#: src/option.c:531
+#: src/option.c:533
 msgid "Set headers alignment"
 msgstr "Definir alinhamento dos cabeçalhos"
 
-#: src/option.c:537
+#: src/option.c:539
 msgid "Display notebook dialog"
 msgstr "Exibir caixa de diálogo notebook"
 
-#: src/option.c:539
+#: src/option.c:541
 msgid "Add a tab to notebook"
 msgstr "Adicionar uma guia para notebook"
 
-#: src/option.c:539
+#: src/option.c:541
 msgid "LABEL"
 msgstr "ROTULO"
 
-#: src/option.c:541
+#: src/option.c:543
 msgid "Set position of a notebook tabs (top, bottom, left or right)"
 msgstr "Defina a posição das guias no notebook (top, bottom, left ou right)"
 
-#: src/option.c:543
+#: src/option.c:545
 msgid "Set tab borders"
 msgstr "Defina borda para a guia"
 
-#: src/option.c:545
+#: src/option.c:547
 msgid "Set active tab"
 msgstr "Definir aba ativa"
 
-#: src/option.c:547
+#: src/option.c:549
 msgid "Expand tabs"
 msgstr "Expandir abas"
 
-#: src/option.c:549
+#: src/option.c:551
 msgid "Use stack mode"
 msgstr "Usar modo pilha (stack)"
 
-#: src/option.c:556
+#: src/option.c:558
 msgid "Display notification"
 msgstr "Exibir notificação"
 
-#: src/option.c:558 src/option.c:574
+#: src/option.c:560 src/option.c:576
 msgid "Set initial popup menu"
 msgstr "Definir o menu pop-up inicial"
 
-#: src/option.c:560
+#: src/option.c:562
 msgid "Disable exit on middle click"
 msgstr "Desativar saída pelo botão do meio"
 
-#: src/option.c:562 src/option.c:576
+#: src/option.c:564 src/option.c:578
 msgid "Doesn't show icon at startup"
 msgstr "Não exibir ícone na inicialização"
 
-#: src/option.c:564
+#: src/option.c:566
 msgid "Set icon size for fully specified icons (default - 16)"
 msgstr ""
 "Definir tamanho do ícone para ícones totalmente especificados (padrão: 16)"
 
-#: src/option.c:572
+#: src/option.c:574
 msgid "Display indicator icon (StatusNotifier/AppIndicator)"
 msgstr "Exibir ícone indicador (StatusNotifier/AppIndicator)"
 
-#: src/option.c:583
+#: src/option.c:585
 msgid "Display paned dialog"
 msgstr "Exibir diálogo panorâmico"
 
-#: src/option.c:585
+#: src/option.c:587
 msgid "Set orientation (hor[izontal] or vert[ical])"
 msgstr "Defina a orientação (hor[izontal] ou vert[ical])"
 
-#: src/option.c:587
+#: src/option.c:589
 msgid "Set initial splitter position"
 msgstr "Definir a posição inicial do divisor"
 
-#: src/option.c:589
+#: src/option.c:591
 msgid "Set focused pane (1 or 2)"
 msgstr "Definir painel focado (1 ou 2)"
 
-#: src/option.c:589
+#: src/option.c:591
 msgid "PANE"
 msgstr "PAINEL"
 
-#: src/option.c:595
+#: src/option.c:597
 msgid "Display picture dialog"
 msgstr "Exibir caixa de diálogo de imagem"
 
-#: src/option.c:597
+#: src/option.c:599
 msgid "Set initial size (fit or orig)"
 msgstr "Definir tamanho inicial (fit ou orig)"
 
-#: src/option.c:599
+#: src/option.c:601
 msgid "Set increment for picture scaling (default - 5)"
 msgstr "Definir incremento para escala de imagem (default - 5)"
 
-#: src/option.c:601
+#: src/option.c:603
 msgid "Set action on image changing"
 msgstr "Definir ação ao mudar a imagem"
 
-#: src/option.c:607
+#: src/option.c:609
 #, fuzzy
 msgid "Display popup dialog"
 msgstr "Exibir diálogo Sobre"
 
-#: src/option.c:609
+#: src/option.c:611
 #, fuzzy
 msgid "Set alignment of title and text (left, center or right)"
 msgstr "Defina o alinhamento dos rótulos de campo (left, center ou right)"
 
-#: src/option.c:611
+#: src/option.c:613
 msgid "Set transparency"
 msgstr ""
 
-#: src/option.c:611
+#: src/option.c:613
 #, fuzzy
 msgid "PERCENT"
 msgstr "PERCENTUAL"
 
-#: src/option.c:613
+#: src/option.c:615
 msgid "Don't close popup by timeout"
 msgstr ""
 
-#: src/option.c:619
+#: src/option.c:621
 msgid "Display printing dialog"
 msgstr "Exibir caixa de diálogo de impressão"
 
-#: src/option.c:621
+#: src/option.c:623
 msgid "Set source type (text, image or raw)"
 msgstr "Definir o tipo de fonte (text, image ou raw)"
 
-#: src/option.c:623
+#: src/option.c:625
 msgid "Add headers to page"
 msgstr "Adicionar cabeçalhos de página"
 
-#: src/option.c:629
+#: src/option.c:631
 msgid "Display progress indication dialog"
 msgstr "Exibir diálogo indicador de progresso"
 
-#: src/option.c:631
+#: src/option.c:633
 msgid "Add the progress bar (norm, rtl, pulse, cpulse or perm)"
 msgstr "Adicionar barra de progresso (norm, rtl, pulse, cpulse ou perm)"
 
-#: src/option.c:633
+#: src/option.c:635
 msgid "Watch for specific bar for auto close"
 msgstr "Definir barra específica para auto fechar"
 
-#: src/option.c:635
+#: src/option.c:637
 msgid "Set alignment of bar labels (left, center or right)"
 msgstr "Defina o alinhamento dos rótulos de barras (left, center ou right)"
 
-#: src/option.c:637
+#: src/option.c:639
 msgid "Set progress text"
 msgstr "Definir texto do progresso"
 
-#: src/option.c:639
+#: src/option.c:641
 msgid "Hide text on progress bar"
 msgstr "Ocultar texto na barra de progresso"
 
-#: src/option.c:641
+#: src/option.c:643
 msgid "Pulsate progress bar"
 msgstr "Pulsar barra de progresso"
 
-#: src/option.c:643
+#: src/option.c:645
 msgid "Conlinuous pulsating progress bar"
 msgstr "Barra de progresso com pulsação contínua"
 
-#: src/option.c:646
+#: src/option.c:648
 #, no-c-format
 msgid "Dismiss the dialog when 100% has been reached"
 msgstr "Descartar diálogo quando for alcançado 100%"
 
-#: src/option.c:649
+#: src/option.c:651
 msgid "Kill parent process if cancel button is pressed"
 msgstr "Matar processo parente se o botão cancelar for pressionado"
 
-#: src/option.c:652
+#: src/option.c:654
 msgid "Right-To-Left progress bar direction"
 msgstr "Direção da barra de progresso da direita para a esquerda"
 
-#: src/option.c:654
+#: src/option.c:656
 msgid "Show log window"
 msgstr "Exibir janela de log"
 
-#: src/option.c:656
+#: src/option.c:658
 msgid "Expand log window"
 msgstr "Expandir janela de log"
 
-#: src/option.c:658
+#: src/option.c:660
 msgid "Place log window above progress bar"
 msgstr "Colocar janela de log acima da barra de progresso"
 
-#: src/option.c:660
+#: src/option.c:662
 msgid "Height of log window"
 msgstr "Altura da janela de log"
 
-#: src/option.c:666
+#: src/option.c:668
 msgid "Display scale dialog"
 msgstr "Exibir caixa de diálogo tipo escala"
 
-#: src/option.c:668
+#: src/option.c:670
 msgid "Set initial value"
 msgstr "Ajustar o valor inicial"
 
-#: src/option.c:668 src/option.c:670 src/option.c:672 src/option.c:674
-#: src/option.c:678 src/option.c:745 src/option.c:747
+#: src/option.c:670 src/option.c:672 src/option.c:674 src/option.c:676
+#: src/option.c:680 src/option.c:747 src/option.c:749
 msgid "VALUE"
 msgstr "VALOR"
 
-#: src/option.c:670
+#: src/option.c:672
 msgid "Set minimum value"
 msgstr "Defina o valor mínimo"
 
-#: src/option.c:672
+#: src/option.c:674
 msgid "Set maximum value"
 msgstr "Defina o valor máximo"
 
-#: src/option.c:674
+#: src/option.c:676
 msgid "Set step size"
 msgstr "Defina o tamanho do passo"
 
-#: src/option.c:676
+#: src/option.c:678
 msgid "Only allow values in step increments"
 msgstr "Permitir apenas valores em incrementos fixos"
 
-#: src/option.c:678
+#: src/option.c:680
 msgid "Set paging size"
 msgstr "Defina o tamanho de paginação"
 
-#: src/option.c:680
+#: src/option.c:682
 msgid "Print partial values"
 msgstr "Imprimir valores parciais"
 
-#: src/option.c:682
+#: src/option.c:684
 msgid "Hide value"
 msgstr "Esconder valor"
 
-#: src/option.c:684
+#: src/option.c:686
 msgid "Invert direction"
 msgstr "Inverter direção"
 
-#: src/option.c:686
+#: src/option.c:688
 msgid "Show +/- buttons in scale"
 msgstr "Exibir botões +/- na escala"
 
-#: src/option.c:688
+#: src/option.c:690
 msgid "Add mark to scale (may be used multiple times)"
 msgstr "Adicionar marca de escala (pode ser usado várias vezes)"
 
-#: src/option.c:688
+#: src/option.c:690
 msgid "NAME:VALUE"
 msgstr "NOME:VALOR"
 
-#: src/option.c:694
+#: src/option.c:696
 msgid "Display text information dialog"
 msgstr "Exibir diálogo de texto informativo"
 
-#: src/option.c:696
+#: src/option.c:698
 msgid "Enable text wrapping"
 msgstr "Ativar quebra de texto"
 
-#: src/option.c:698
+#: src/option.c:700
 msgid "Set justification (left, right, center or fill)"
 msgstr "Definir justificação (left, right, center ou fill)"
 
-#: src/option.c:700
+#: src/option.c:702
 msgid "Set text margins"
 msgstr "Definir margens do texto"
 
-#: src/option.c:702
+#: src/option.c:704
 msgid "Jump to specific line"
 msgstr "Ir para linha específica"
 
-#: src/option.c:704
+#: src/option.c:706
 msgid "Use specified color for text"
 msgstr "Usar cor específica para o texto"
 
-#: src/option.c:706
+#: src/option.c:708
 msgid "Use specified color for background"
 msgstr "Use cor específica no fundo"
 
-#: src/option.c:708
+#: src/option.c:710
 msgid "Show cursor in read-only mode"
 msgstr "Exibir o cursor no modo só de leitura"
 
-#: src/option.c:710
+#: src/option.c:712
 msgid "Make URI clickable"
 msgstr "Faça URI clicável"
 
-#: src/option.c:712
+#: src/option.c:714
 msgid "Use specified color for links"
 msgstr "Use cor específica para links"
 
-#: src/option.c:714
+#: src/option.c:716
 msgid "Use pango markup"
 msgstr "Usar markup Pango"
 
-#: src/option.c:716
+#: src/option.c:718
 msgid "Save file instead of print on exit"
 msgstr "Salvar arquivo em vez de imprimir ao sair"
 
-#: src/option.c:718
+#: src/option.c:720
 msgid "Confirm save the file if text was changed"
 msgstr "Confirmar salvamento se o texto foi alterado"
 
-#: src/option.c:725
+#: src/option.c:727
 msgid "Use specified langauge for syntax highlighting"
 msgstr "Defina a linguagem para realce de sintaxe"
 
-#: src/option.c:725
+#: src/option.c:727
 msgid "LANG"
 msgstr "LINGUAGEM"
 
-#: src/option.c:727
+#: src/option.c:729
 msgid "Use specified theme"
 msgstr "Usar tema especificado"
 
-#: src/option.c:729
+#: src/option.c:731
 msgid "Show line numbers"
 msgstr "Exibir números de linha"
 
-#: src/option.c:731
+#: src/option.c:733
 msgid "Highlight current line"
 msgstr "Destacar linha atual"
 
-#: src/option.c:733
+#: src/option.c:735
 msgid "Enable line marks"
 msgstr "Habilitar marcas de linha"
 
-#: src/option.c:735
+#: src/option.c:737
 msgid "Set color for first type marks"
 msgstr "Definir cor das marcas do primeiro tipo"
 
-#: src/option.c:737
+#: src/option.c:739
 msgid "Set color for second type marks"
 msgstr "Definir cor das marcas do segundo tipo"
 
-#: src/option.c:739
+#: src/option.c:741
 msgid "Set position of right margin"
 msgstr "Definir posição da margem direita"
 
-#: src/option.c:739
+#: src/option.c:741
 msgid "[POS]"
 msgstr "[POS]"
 
-#: src/option.c:741
+#: src/option.c:743
 msgid "Highlight matching brackets"
 msgstr "Destacar colchetes correspondentes"
 
-#: src/option.c:743
+#: src/option.c:745
 msgid "Use autoindent"
 msgstr "Usar autoidentação"
 
-#: src/option.c:745
+#: src/option.c:747
 msgid "Set tabulation width"
 msgstr "Definir largura da tabulação"
 
-#: src/option.c:747
+#: src/option.c:749
 msgid "Set indentation width"
 msgstr "Definir largura da indentação"
 
-#: src/option.c:749
+#: src/option.c:751
 msgid "Set smart Home/End behavior"
 msgstr "Definir comportamento inteligente do Home/End"
 
-#: src/option.c:751
+#: src/option.c:753
 msgid "Enable smart backspace"
 msgstr "Habilitar backspace inteligente"
 
-#: src/option.c:753
+#: src/option.c:755
 msgid "Insert spaces instead of tabs"
 msgstr "Inserir espaços em vez de tabulações"
 
-#: src/option.c:760
+#: src/option.c:762
 msgid "Sets a filename filter"
 msgstr "Defina filtro para o nome do arquivo"
 
-#: src/option.c:760
+#: src/option.c:762
 msgid "NAME | PATTERN1 PATTERN2 ..."
 msgstr "NOME | PADRAO1 PADRAO2 ..."
 
-#: src/option.c:762
+#: src/option.c:764
 msgid "Sets a mime-type filter"
 msgstr "Defina filtro mime-type"
 
-#: src/option.c:762
+#: src/option.c:764
 msgid "NAME | MIME1 MIME2 ..."
 msgstr "NOME | MIME1 MIME2 ..."
 
-#: src/option.c:764
+#: src/option.c:766
 msgid "Add filter for images"
 msgstr "Adicione filtro para imagens"
 
-#: src/option.c:764
+#: src/option.c:766
 msgid "[NAME]"
 msgstr "[NOME]"
 
-#: src/option.c:770 src/tools.c:64
+#: src/option.c:772 src/tools.c:64
 msgid "Print version"
 msgstr "Imprimir versão"
 
-#: src/option.c:772
+#: src/option.c:774
 msgid "Load additional CSS settings from file or string"
 msgstr "Carregar configurações CSS adicionais de arquivo ou texto"
 
-#: src/option.c:775
+#: src/option.c:777
 msgid "Load additional CSS settings from file"
 msgstr "Carregar configurações CSS adicionais de arquivo"
 
-#: src/option.c:778
+#: src/option.c:780
 msgid "Set policy for horizontal scrollbars (auto, always, never)"
 msgstr "Definir política da barra de rolagem horizontal (auto, always, never)"
 
-#: src/option.c:780
+#: src/option.c:782
 msgid "Set policy for vertical scrollbars (auto, always, never)"
 msgstr "Definir política da barra de rolagem vertical (auto, always, never)"
 
-#: src/option.c:782
+#: src/option.c:784
 msgid "Add path for search icons by name"
 msgstr "Adicionar caminho para ícones de pesquisa por nome"
 
-#: src/option.c:784
+#: src/option.c:786
 msgid "Write settings to file and exit"
 msgstr ""
 
-#: src/option.c:790
+#: src/option.c:792
 msgid "Load extra arguments from file"
 msgstr "Carregar argumentos extras de arquivo"
 
-#: src/option.c:1001
+#: src/option.c:1003
 #, c-format
 msgid "Mark %s doesn't have a value\n"
 msgstr "Marca %s não possui um valor\n"
 
-#: src/option.c:1048 src/picture.c:286
+#: src/option.c:1050 src/picture.c:286
 msgid "Images"
 msgstr "Imagens"
 
-#: src/option.c:1113
+#: src/option.c:1115
 #, c-format
 msgid "Unknown color mode: %s\n"
 msgstr "Modo de cor desconhecido: %s\n"
 
-#: src/option.c:1132
+#: src/option.c:1134
 #, c-format
 msgid "Unknown buttons layout type: %s\n"
 msgstr "Tipo de layout de botão desconhecido: %s\n"
 
-#: src/option.c:1147
+#: src/option.c:1149
 #, c-format
 msgid "Unknown align type: %s\n"
 msgstr "Tipo de alinhamento desconhecido: %s\n"
 
-#: src/option.c:1171
+#: src/option.c:1173
 #, c-format
 msgid "Unknown justification type: %s\n"
 msgstr "Tipo de justificação desconhecida: %s\n"
 
-#: src/option.c:1188
+#: src/option.c:1190
 #, c-format
 msgid "Unknown tab position type: %s\n"
 msgstr "Tipo de posição da aba desconhecido: %s\n"
 
-#: src/option.c:1225
+#: src/option.c:1227
 #, c-format
 msgid "Unknown ellipsize type: %s\n"
 msgstr "Tipo de elipse desconhecida: %s\n"
 
-#: src/option.c:1238
+#: src/option.c:1240
 #, c-format
 msgid "Unknown orientation: %s\n"
 msgstr "Orientação desconhecida: %s\n"
 
-#: src/option.c:1253
+#: src/option.c:1255
 #, c-format
 msgid "Unknown source type: %s\n"
 msgstr "Tipo de fonte desconhecida: %s\n"
 
-#: src/option.c:1264
+#: src/option.c:1266
 msgid "Progress log"
 msgstr "Log do progresso"
 
-#: src/option.c:1277
+#: src/option.c:1279
 #, c-format
 msgid "Unknown size type: %s\n"
 msgstr "Tipo de tamanho desconhecido: %s\n"
 
-#: src/option.c:1321
+#: src/option.c:1323
 #, c-format
 msgid "Unknown completion type: %s\n"
 msgstr "Tipo de complemento desconhecido: %s\n"
 
-#: src/option.c:1353
+#: src/option.c:1355
 #, c-format
 msgid "Unknown boolean format type: %s\n"
 msgstr "Tipo de formato booleano desconhecido: %s\n"
 
-#: src/option.c:1369
+#: src/option.c:1371
 #, c-format
 msgid "Unknown grid lines type: %s\n"
 msgstr "Tipo de linha de grade desconhecido: %s\n"
 
-#: src/option.c:1386
+#: src/option.c:1388
 #, c-format
 msgid "Unknown scrollbar policy type: %s\n"
 msgstr "Tipo de política de barra de rolagem desconhecido: %s\n"
 
-#: src/option.c:1437
+#: src/option.c:1439
 #, c-format
 msgid "Unknown window type: %s\n"
 msgstr "Tipo de janela desconhecido: %s\n"
 
-#: src/option.c:1466
+#: src/option.c:1468
 #, c-format
 msgid "Unknown smart Home/End mode: %s\n"
 msgstr "Modo inteligente de Home/End desconhecido: %s\n"
 
-#: src/option.c:1576
+#: src/option.c:1578
 #, c-format
 msgid "Unknown signal: %s\n"
 msgstr "Sinal desconhecido: %s\n"
 
-#: src/option.c:1811
+#: src/option.c:1814
 msgid "File exist. Overwrite?"
 msgstr "Arquivo já existe. Deseja substituí-lo?"
 
-#: src/option.c:1953
+#: src/option.c:1956
 msgid "File was changed. Save it?"
 msgstr "O arquivo foi modificado. Deseja salvá-lo?"
 
-#: src/option.c:1984
+#: src/option.c:1987
 msgid "- Yet another dialoging program"
 msgstr "- Yet another dialoging program"
 
-#: src/option.c:1988
+#: src/option.c:1991
 msgid "General options"
 msgstr "Opções gerais"
 
-#: src/option.c:1988
+#: src/option.c:1991
 msgid "Show general options"
 msgstr "Exibir opções gerais"
 
-#: src/option.c:1994
+#: src/option.c:1997
 msgid "Common options"
 msgstr "Opções comuns"
 
-#: src/option.c:1994
+#: src/option.c:1997
 msgid "Show common options"
 msgstr "Exibir opções comuns"
 
-#: src/option.c:2000
+#: src/option.c:2003
 msgid "About dialog options"
 msgstr "Opções do diálogo Sobre"
 
-#: src/option.c:2000
+#: src/option.c:2003
 msgid "Show custom about dialog options"
 msgstr "Exibir opções personalizadas do diálogo Sobre"
 
-#: src/option.c:2006
+#: src/option.c:2009
 msgid "Application selection options"
 msgstr "Opções de seleção de aplicativos"
 
-#: src/option.c:2006
+#: src/option.c:2009
 msgid "Show application selection options"
 msgstr "Exibir opções de seleção de aplicativos"
 
-#: src/option.c:2012
+#: src/option.c:2015
 msgid "Calendar options"
 msgstr "Opções de calendário"
 
-#: src/option.c:2012
+#: src/option.c:2015
 msgid "Show calendar options"
 msgstr "Exibir opções de calendário"
 
-#: src/option.c:2018
+#: src/option.c:2021
 msgid "Color selection options"
 msgstr "Opções de seleção de cor"
 
-#: src/option.c:2018
+#: src/option.c:2021
 msgid "Show color selection options"
 msgstr "Exibir opções de seleção de cor"
 
-#: src/option.c:2024
+#: src/option.c:2027
 msgid "DND options"
 msgstr "Opções de arrastar e soltar"
 
-#: src/option.c:2024
+#: src/option.c:2027
 msgid "Show drag-n-drop options"
 msgstr "Exibir opções de arrastar e soltar"
 
-#: src/option.c:2030
+#: src/option.c:2033
 msgid "Text entry options"
 msgstr "Opções de entrada de texto"
 
-#: src/option.c:2030
+#: src/option.c:2033
 msgid "Show text entry options"
 msgstr "Exibir opções de entrada de texto"
 
-#: src/option.c:2036
+#: src/option.c:2039
 msgid "File selection options"
 msgstr "Opções de seleção de arquivos"
 
-#: src/option.c:2036
+#: src/option.c:2039
 msgid "Show file selection options"
 msgstr "Exibir opções de seleção de arquivos"
 
-#: src/option.c:2042
+#: src/option.c:2045
 msgid "Font selection options"
 msgstr "Opções de seleção de fonte"
 
-#: src/option.c:2042
+#: src/option.c:2045
 msgid "Show font selection options"
 msgstr "Exibir opções de seleção de fonte"
 
-#: src/option.c:2048
+#: src/option.c:2051
 msgid "Form options"
 msgstr "Opções de formulário"
 
-#: src/option.c:2048
+#: src/option.c:2051
 msgid "Show form options"
 msgstr "Exibir opções de formulário"
 
-#: src/option.c:2055
+#: src/option.c:2058
 msgid "HTML options"
 msgstr "Opções de HTML"
 
-#: src/option.c:2055
+#: src/option.c:2058
 msgid "Show HTML options"
 msgstr "Exibir opções de HTML"
 
-#: src/option.c:2062
+#: src/option.c:2065
 msgid "Icons box options"
 msgstr "Opções de caixa de ícones"
 
-#: src/option.c:2062
+#: src/option.c:2065
 msgid "Show icons box options"
 msgstr "Exibir opções de caixa de ícones"
 
-#: src/option.c:2068
+#: src/option.c:2071
 msgid "List options"
 msgstr "Opções de lista"
 
-#: src/option.c:2068
+#: src/option.c:2071
 msgid "Show list options"
 msgstr "Exibir opções de lista"
 
-#: src/option.c:2074
+#: src/option.c:2077
 msgid "Notebook options"
 msgstr "Opções de notebook"
 
-#: src/option.c:2074
+#: src/option.c:2077
 msgid "Show notebook dialog options"
 msgstr "Exibir opções de diálogo de notebook"
 
-#: src/option.c:2081
+#: src/option.c:2084
 msgid "Notification icon options"
 msgstr "Opções de ícone de notificação"
 
-#: src/option.c:2082
+#: src/option.c:2085
 msgid "Show notification icon options"
 msgstr "Exibir opções de ícone de notificação"
 
-#: src/option.c:2090
+#: src/option.c:2093
 msgid "StatusNotifier/AppIndicator options"
 msgstr "Opções de StatusNotifier/AppIndicator"
 
-#: src/option.c:2091
+#: src/option.c:2094
 msgid "Show indicator options"
 msgstr "Exibir opções do indicador"
 
-#: src/option.c:2098
+#: src/option.c:2101
 msgid "Paned dialog options"
 msgstr "Opções de diálogos panorâmicos"
 
-#: src/option.c:2098
+#: src/option.c:2101
 msgid "Show paned dialog options"
 msgstr "Exibir opções de diálogos panorâmicos"
 
-#: src/option.c:2104
+#: src/option.c:2107
 msgid "Picture dialog options"
 msgstr "Opções de diálogo de imagens"
 
-#: src/option.c:2104
+#: src/option.c:2107
 msgid "Show picture dialog options"
 msgstr "Exibir opções de diálogo de imagem"
 
-#: src/option.c:2110
+#: src/option.c:2113
 #, fuzzy
 msgid "Popup dialog options"
 msgstr "Opções do diálogo Sobre"
 
-#: src/option.c:2110
+#: src/option.c:2113
 #, fuzzy
 msgid "Show popup dialog options"
 msgstr "Exibir opções de diálogo de imagem"
 
-#: src/option.c:2116
+#: src/option.c:2119
 msgid "Print dialog options"
 msgstr "Opções de diálogo de imressão"
 
-#: src/option.c:2116
+#: src/option.c:2119
 msgid "Show print dialog options"
 msgstr "Exibir opções de diálogo de imressão"
 
-#: src/option.c:2122
+#: src/option.c:2125
 msgid "Progress options"
 msgstr "Opções de progresso"
 
-#: src/option.c:2122
+#: src/option.c:2125
 msgid "Show progress options"
 msgstr "Exibir opções de progresso"
 
-#: src/option.c:2128
+#: src/option.c:2131
 msgid "Scale options"
 msgstr "Opções de escala"
 
-#: src/option.c:2128
+#: src/option.c:2131
 msgid "Show scale options"
 msgstr "Exibir opções de escala"
 
-#: src/option.c:2134
+#: src/option.c:2137
 msgid "Text information options"
 msgstr "Opções de texto de informação"
 
-#: src/option.c:2134
+#: src/option.c:2137
 msgid "Show text information options"
 msgstr "Exibir opções de texto de informação"
 
-#: src/option.c:2141
+#: src/option.c:2144
 msgid "SourceView options"
 msgstr "Opções de leitura de fonte"
 
-#: src/option.c:2141
+#: src/option.c:2144
 msgid "Show SourceView options"
 msgstr "Exibir opções de leitura de fonte"
 
-#: src/option.c:2148
+#: src/option.c:2151
 msgid "File filter options"
 msgstr "Opções de seleção de arquivos"
 
-#: src/option.c:2148
+#: src/option.c:2151
 msgid "Show file filter options"
 msgstr "Exibir opções de seleção de arquivos"
 
-#: src/option.c:2154
+#: src/option.c:2157
 msgid "Miscellaneous options"
 msgstr "Opções de Micelânea"
 
-#: src/option.c:2154
+#: src/option.c:2157
 msgid "Show miscellaneous options"
 msgstr "Exibir opções de micelânea"
 
@@ -2418,7 +2428,7 @@ msgstr "Largura da indentação::NUM"
 msgid "Insert spaces instead of tabulation:CHK"
 msgstr "Inserir espaços em vez de tabulação:CHK"
 
-#: src/yad-settings.sh:113 data/yad-settings.desktop.in:3
+#: src/yad-settings.sh:113 data/yad-settings.desktop.in:4
 msgid "YAD settings"
 msgstr "Configurações do YAD"
 
@@ -2439,15 +2449,15 @@ msgstr "Principal"
 msgid "Editor"
 msgstr "Editor"
 
-#: data/yad-icon-browser.desktop.in:3
+#: data/yad-icon-browser.desktop.in:4
 msgid "Icon Browser"
 msgstr "Navegador de ícones"
 
-#: data/yad-icon-browser.desktop.in:4
+#: data/yad-icon-browser.desktop.in:5
 msgid "Inspect GTK Icon Theme"
 msgstr "Inspecionar ícone tema do GTK"
 
-#: data/yad-settings.desktop.in:4
+#: data/yad-settings.desktop.in:5
 msgid "Simple GUI for editing YAD settings"
 msgstr "Interface simples para editar as configurações do YAD"
 

--- a/po/sk.po
+++ b/po/sk.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YAD\n"
 "Report-Msgid-Bugs-To: victor@sanana.kiev.ua\n"
-"POT-Creation-Date: 2026-06-30 16:06+0300\n"
+"POT-Creation-Date: 2026-07-06 22:04-0400\n"
 "PO-Revision-Date: 2013-03-30 08:10+0100\n"
 "Last-Translator: Slavko <linux@slavino.sk>\n"
 "Language-Team: slovenčina <debian-l10n-slovak@lists.debian.org>\n"
@@ -98,15 +98,15 @@ msgstr "Vyberte alebo vytvorte  adresár"
 msgid "Select date"
 msgstr "Vyberte dátum"
 
-#: src/form.c:1047
+#: src/form.c:1055
 msgid "Select file"
 msgstr "Vyberte súbor"
 
-#: src/form.c:1077
+#: src/form.c:1085
 msgid "Select folder"
 msgstr "Vyberte adresár"
 
-#: src/form.c:1245 src/form.c:1247
+#: src/form.c:1253 src/form.c:1255
 msgid "Link"
 msgstr ""
 
@@ -147,35 +147,35 @@ msgstr "Nemožno otvoriť adresár %s: %s\n"
 msgid "%d sec"
 msgstr "%d s"
 
-#: src/main.c:748 src/main.c:755
+#: src/main.c:764 src/main.c:771
 #, fuzzy, c-format
 msgid "Unable to parse YAD_OPTIONS: %s\n"
 msgstr "Nemožno spracovať súbor %s: %s\n"
 
-#: src/main.c:766
+#: src/main.c:782
 #, c-format
 msgid "Unable to parse command line: %s\n"
 msgstr "Nemožno spracovať príkazový riadok: %s\n"
 
-#: src/main.c:780
+#: src/main.c:796
 msgid ""
 "WARNING: Using splash option is deprecated, please use --window-type instead"
 msgstr ""
 
-#: src/main.c:790
+#: src/main.c:806
 #, fuzzy, c-format
 msgid "Unable to change directory to %s: %s\n"
 msgstr "Nemožno otvoriť adresár %s: %s\n"
 
-#: src/main.c:819
+#: src/main.c:835
 msgid "WARNING: Using gtkrc option is deprecated, please use --css instead\n"
 msgstr ""
 
-#: src/main.c:893
+#: src/main.c:909
 msgid "WARNING: --plug mode not supported outside X11\n"
 msgstr ""
 
-#: src/main.c:913
+#: src/main.c:929
 msgid "WARNING: This mode not supported outside X11\n"
 msgstr ""
 
@@ -276,12 +276,12 @@ msgstr "VÝŠKA"
 msgid "Set the X position of a window"
 msgstr ""
 
-#: src/option.c:106 src/option.c:108 src/option.c:118 src/option.c:140
-#: src/option.c:144 src/option.c:189 src/option.c:203 src/option.c:342
-#: src/option.c:400 src/option.c:406 src/option.c:487 src/option.c:495
-#: src/option.c:497 src/option.c:499 src/option.c:501 src/option.c:503
-#: src/option.c:505 src/option.c:509 src/option.c:543 src/option.c:545
-#: src/option.c:599 src/option.c:633 src/option.c:702
+#: src/option.c:106 src/option.c:108 src/option.c:118 src/option.c:142
+#: src/option.c:146 src/option.c:191 src/option.c:205 src/option.c:344
+#: src/option.c:402 src/option.c:408 src/option.c:489 src/option.c:497
+#: src/option.c:499 src/option.c:501 src/option.c:503 src/option.c:505
+#: src/option.c:507 src/option.c:511 src/option.c:545 src/option.c:547
+#: src/option.c:601 src/option.c:635 src/option.c:704
 msgid "NUMBER"
 msgstr "ČÍSLO"
 
@@ -309,7 +309,7 @@ msgstr "ČASLIMIT"
 msgid "Show remaining time indicator (top, bottom, left, right)"
 msgstr "Zobrazí indikátor zostávajúceho času (top, bottom, left, right)"
 
-#: src/option.c:114 src/option.c:587
+#: src/option.c:114 src/option.c:589
 msgid "POS"
 msgstr "POZÍCIA"
 
@@ -317,8 +317,8 @@ msgstr "POZÍCIA"
 msgid "Set the dialog text"
 msgstr "Nastaví text dialógu"
 
-#: src/option.c:116 src/option.c:273 src/option.c:275 src/option.c:350
-#: src/option.c:352 src/option.c:386 src/option.c:507 src/option.c:637
+#: src/option.c:116 src/option.c:275 src/option.c:277 src/option.c:352
+#: src/option.c:354 src/option.c:388 src/option.c:509 src/option.c:639
 msgid "TEXT"
 msgstr "TEXT"
 
@@ -332,11 +332,11 @@ msgstr "Nastaví text dialógu"
 msgid "Set the dialog text alignment (left, center, right, fill)"
 msgstr "Nastaví zarovnanie textu dialógu (left, center, right)"
 
-#: src/option.c:120 src/option.c:132 src/option.c:185 src/option.c:235
-#: src/option.c:241 src/option.c:243 src/option.c:398 src/option.c:481
-#: src/option.c:491 src/option.c:541 src/option.c:585 src/option.c:597
-#: src/option.c:609 src/option.c:621 src/option.c:635 src/option.c:698
-#: src/option.c:749 src/option.c:778 src/option.c:780 src/tools.c:86
+#: src/option.c:120 src/option.c:132 src/option.c:187 src/option.c:237
+#: src/option.c:243 src/option.c:245 src/option.c:400 src/option.c:483
+#: src/option.c:493 src/option.c:543 src/option.c:587 src/option.c:599
+#: src/option.c:611 src/option.c:623 src/option.c:637 src/option.c:700
+#: src/option.c:751 src/option.c:780 src/option.c:782 src/tools.c:86
 msgid "TYPE"
 msgstr "TYP"
 
@@ -344,7 +344,7 @@ msgstr "TYP"
 msgid "Set the dialog image"
 msgstr "Nastaví obrázok dialógu"
 
-#: src/option.c:122 src/option.c:360 src/option.c:364
+#: src/option.c:122 src/option.c:362 src/option.c:366
 msgid "IMAGE"
 msgstr "OBRÁZOK"
 
@@ -352,7 +352,7 @@ msgstr "OBRÁZOK"
 msgid "Use specified icon theme instead of default"
 msgstr "Použije zadanú tému ikon, namiesto predvolenej"
 
-#: src/option.c:124 src/option.c:727 src/browser.c:220 src/tools.c:87
+#: src/option.c:124 src/option.c:729 src/browser.c:220 src/tools.c:87
 msgid "THEME"
 msgstr "TÉMA"
 
@@ -360,7 +360,7 @@ msgstr "TÉMA"
 msgid "Hide main widget with expander"
 msgstr "Skryť hlavný prvok s expanderom"
 
-#: src/option.c:126 src/option.c:378 src/option.c:654 src/option.c:718
+#: src/option.c:126 src/option.c:380 src/option.c:656 src/option.c:720
 msgid "[TEXT]"
 msgstr "[TEXT]"
 
@@ -381,751 +381,761 @@ msgid "Set buttons layout type (spread, edge, start, end or center)"
 msgstr "Nastaví typ vzhľadu tlačidiel (spread, edge, start, end alebo center)"
 
 #: src/option.c:134
+#, fuzzy
+msgid "Set focus to the named button when dialog opens"
+msgstr "Zobrazí voľby zápisníka"
+
+#: src/option.c:134
+#, fuzzy
+msgid "NAME"
+msgstr "MENO:ID"
+
+#: src/option.c:136
 msgid "Don't use pango markup language in dialog's text"
 msgstr "Nepoužíva značkovací jazyk pango v texte dialógu"
 
-#: src/option.c:136
+#: src/option.c:138
 msgid "Don't close dialog if Escape was pressed"
 msgstr ""
 
-#: src/option.c:138
+#: src/option.c:140
 msgid "Escape acts like OK button"
 msgstr ""
 
-#: src/option.c:140
+#: src/option.c:142
 msgid "Set window borders"
 msgstr "Nastaví okraje okna"
 
-#: src/option.c:142
+#: src/option.c:144
 msgid "Always print result"
 msgstr "Vždy vypíše výsledok"
 
-#: src/option.c:144
+#: src/option.c:146
 #, fuzzy
 msgid "Set default return code"
 msgstr "Nastaví formát vráteného dátumu"
 
-#: src/option.c:146
+#: src/option.c:148
 msgid "Dialog text can be selected"
 msgstr "Text dialógu môže byť vybratý"
 
-#: src/option.c:148
+#: src/option.c:150
 #, fuzzy
 msgid "Don't scale icons"
 msgstr "Zobrazí voľby posuvníka"
 
-#: src/option.c:150
+#: src/option.c:152
 #, c-format
 msgid "Run commands under specified interpreter (default: bash -c '%s')"
 msgstr ""
 
-#: src/option.c:150 src/option.c:152 src/option.c:154 src/option.c:205
-#: src/option.c:312 src/option.c:362 src/option.c:366 src/option.c:412
-#: src/option.c:511 src/option.c:513 src/option.c:515 src/option.c:601
+#: src/option.c:152 src/option.c:154 src/option.c:156 src/option.c:207
+#: src/option.c:314 src/option.c:364 src/option.c:368 src/option.c:414
+#: src/option.c:513 src/option.c:515 src/option.c:517 src/option.c:603
 msgid "CMD"
 msgstr "PRÍKAZ"
 
-#: src/option.c:152
+#: src/option.c:154
 msgid "Set URI handler"
 msgstr ""
 
-#: src/option.c:154
+#: src/option.c:156
 msgid "Set command running when F1 was pressed"
 msgstr ""
 
-#: src/option.c:156
+#: src/option.c:158
 #, fuzzy
 msgid "Set working directory"
 msgstr "Odoberie dekorácie okna"
 
-#: src/option.c:156 src/option.c:782
+#: src/option.c:158 src/option.c:784
 #, fuzzy
 msgid "PATH"
 msgstr "CESTA_IKON"
 
-#: src/option.c:159
+#: src/option.c:161
 msgid "Set window sticky"
 msgstr "Prilepí okno na všetky plochy"
 
-#: src/option.c:161
+#: src/option.c:163
 msgid "Set window unresizable"
 msgstr "Nastaví pevnú veľkosť okna"
 
-#: src/option.c:163
+#: src/option.c:165
 msgid "Place window on top"
 msgstr "Umiestni okno nad ostatnými"
 
-#: src/option.c:165
+#: src/option.c:167
 msgid "Place window on center of screen"
 msgstr "Umiestni okno doprostred plochy"
 
-#: src/option.c:167
+#: src/option.c:169
 msgid "Place window at the mouse position"
 msgstr "Umiestni okno na pozícii myši"
 
-#: src/option.c:169
+#: src/option.c:171
 msgid "Set window undecorated"
 msgstr "Odoberie dekorácie okna"
 
-#: src/option.c:171
+#: src/option.c:173
 msgid "Don't show window in taskbar"
 msgstr "Skryje okno v paneli úloh"
 
-#: src/option.c:173
+#: src/option.c:175
 #, fuzzy
 msgid "Set window maximized"
 msgstr "Nastaví pevnú veľkosť okna"
 
-#: src/option.c:175
+#: src/option.c:177
 #, fuzzy
 msgid "Set window fullscreen"
 msgstr "Nastaví pevnú veľkosť okna"
 
-#: src/option.c:177
+#: src/option.c:179
 #, fuzzy
 msgid "Don't focus dialog window"
 msgstr "Výška okna záznamu"
 
-#: src/option.c:179
+#: src/option.c:181
 msgid "Close window when it sets unfocused"
 msgstr ""
 
-#: src/option.c:182
+#: src/option.c:184
 msgid "Open window as a splashscreen (Deprecated, see man page for details)"
 msgstr ""
 
-#: src/option.c:185
+#: src/option.c:187
 msgid "Specify the window type for the dialog"
 msgstr ""
 
-#: src/option.c:187
+#: src/option.c:189
 msgid "Special type of dialog for XEMBED"
 msgstr "Špeciálny typ dialógu pre XEMBED"
 
-#: src/option.c:187 src/option.c:239
+#: src/option.c:189 src/option.c:241
 msgid "KEY"
 msgstr "KĽÚČ"
 
-#: src/option.c:189
+#: src/option.c:191
 #, fuzzy
 msgid "Tab number of this dialog"
 msgstr "Číslo záložky tohoto dialógu"
 
-#: src/option.c:192
+#: src/option.c:194
 msgid "Send SIGNAL to parent"
 msgstr "Pošle rodičovi SIGNÁL"
 
-#: src/option.c:192
+#: src/option.c:194
 #, fuzzy
 msgid "[SIGNAL]"
 msgstr "SIGNÁL"
 
-#: src/option.c:194
+#: src/option.c:196
 #, fuzzy
 msgid "Print X Window Id to the file/stderr"
 msgstr "Vypíše identifikátor X Window do stderr"
 
-#: src/option.c:194 src/option.c:324
+#: src/option.c:196 src/option.c:326
 #, fuzzy
 msgid "[FILENAME]"
 msgstr "MENO_SÚBORU"
 
-#: src/option.c:201
+#: src/option.c:203
 msgid "Set the format for the returned date"
 msgstr "Nastaví formát vráteného dátumu"
 
-#: src/option.c:201 src/option.c:453
+#: src/option.c:203 src/option.c:455
 msgid "PATTERN"
 msgstr "VZOR"
 
-#: src/option.c:203
+#: src/option.c:205
 msgid "Set presicion of floating numbers (default - 3)"
 msgstr ""
 
-#: src/option.c:205
+#: src/option.c:207
 msgid "Set command handler"
 msgstr ""
 
-#: src/option.c:207
+#: src/option.c:209
 #, fuzzy
 msgid "Listen for data on stdin"
 msgstr "Prijíma príkazy zo štandardného vstupu"
 
-#: src/option.c:209
+#: src/option.c:211
 #, fuzzy
 msgid "Set common separator character"
 msgstr "Nastaví znak výstupného oddeľovača"
 
-#: src/option.c:209 src/option.c:211
+#: src/option.c:211 src/option.c:213
 msgid "SEPARATOR"
 msgstr "ODDEĽOVAČ"
 
-#: src/option.c:211
+#: src/option.c:213
 #, fuzzy
 msgid "Set item separator character"
 msgstr "Nastaví znak výstupného oddeľovača"
 
-#: src/option.c:213
+#: src/option.c:215
 #, fuzzy
 msgid "Allow changes to text in some cases"
 msgstr "Povolí zmeny textu rozbaľovacieho zoznamu"
 
-#: src/option.c:215
-msgid "Autoscroll to end of text"
-msgstr "Automaticky posunúť na koniec textu"
-
 #: src/option.c:217
-#, fuzzy
-msgid "Autoscroll to end of text (alias to tail)"
+msgid "Autoscroll to end of text"
 msgstr "Automaticky posunúť na koniec textu"
 
 #: src/option.c:219
 #, fuzzy
+msgid "Autoscroll to end of text (alias to tail)"
+msgstr "Automaticky posunúť na koniec textu"
+
+#: src/option.c:221
+#, fuzzy
 msgid "Quote dialogs output"
 msgstr "Nastaví text dialógu"
 
-#: src/option.c:221
+#: src/option.c:223
 #, fuzzy
 msgid "Output number instead of text for combo-box"
 msgstr "Použije dopĺňanie namiesto rozbaľovacieho zoznamu"
 
-#: src/option.c:223
+#: src/option.c:225
 msgid "Specify font name to use"
 msgstr ""
 
-#: src/option.c:223
+#: src/option.c:225
 msgid "FONTNAME"
 msgstr "MENO_FONTU"
 
-#: src/option.c:225
+#: src/option.c:227
 #, fuzzy
 msgid "Allow multiple selection"
 msgstr "Dovolí viacnásobný výber riadkov"
 
-#: src/option.c:227
-msgid "Enable preview"
-msgstr "Zapne ukážku"
-
 #: src/option.c:229
-#, fuzzy
-msgid "Use large preview"
+msgid "Enable preview"
 msgstr "Zapne ukážku"
 
 #: src/option.c:231
 #, fuzzy
+msgid "Use large preview"
+msgstr "Zapne ukážku"
+
+#: src/option.c:233
+#, fuzzy
 msgid "Show hidden files in file selection dialogs"
 msgstr "Zobrazí dialóg Výber súboru"
 
-#: src/option.c:233
+#: src/option.c:235
 #, fuzzy
 msgid "Set source filename"
 msgstr "Meno zdrojového súboru"
 
-#: src/option.c:233 src/option.c:308 src/option.c:775 src/option.c:790
+#: src/option.c:235 src/option.c:310 src/option.c:777 src/option.c:792
 msgid "FILENAME"
 msgstr "MENO_SÚBORU"
 
-#: src/option.c:235
+#: src/option.c:237
 msgid "Set mime type of input data"
 msgstr ""
 
-#: src/option.c:237
+#: src/option.c:239
 #, fuzzy
 msgid "Set vertical orientation"
 msgstr "Nastaví akciu ľavého tlačidla myši"
 
-#: src/option.c:239
+#: src/option.c:241
 msgid "Identifier of embedded dialogs"
 msgstr "Identifikátor vnorených dialógov"
 
-#: src/option.c:241
+#: src/option.c:243
 msgid "Set extended completion for entries (any, all, or regex)"
 msgstr ""
 
-#: src/option.c:243
+#: src/option.c:245
 msgid "Set type of output for boolean values (T, t, Y, y, O, o, 1)"
 msgstr ""
 
-#: src/option.c:245
+#: src/option.c:247
 #, fuzzy
 msgid "Make main widget scrollable"
 msgstr "Urobí URI kliknuteľné"
 
-#: src/option.c:247
+#: src/option.c:249
 msgid "Disable search in text and html dialogs"
 msgstr ""
 
-#: src/option.c:249
+#: src/option.c:251
 #, fuzzy
 msgid "Enable file operations"
 msgstr "Voľby posuvníka"
 
-#: src/option.c:252
+#: src/option.c:254
 msgid "Use IEC (base 1024) units with for size values"
 msgstr ""
 
-#: src/option.c:256
+#: src/option.c:258
 #, fuzzy
 msgid "Enable spell check for text"
 msgstr "Použije zadanú farbu textu"
 
-#: src/option.c:258
+#: src/option.c:260
 msgid "Set spell checking language"
 msgstr ""
 
-#: src/option.c:258
+#: src/option.c:260
 msgid "LANGUAGE"
 msgstr ""
 
-#: src/option.c:265
+#: src/option.c:267
 #, fuzzy
 msgid "Display about dialog"
 msgstr "Zobrazí dialóg Zoznam"
 
-#: src/option.c:267
+#: src/option.c:269
 msgid "Set application name"
 msgstr ""
 
-#: src/option.c:267 src/option.c:269 src/option.c:271 src/option.c:281
-#: src/option.c:429 src/option.c:431 src/option.c:529 src/option.c:531
-#: src/option.c:558 src/option.c:574 src/option.c:772
+#: src/option.c:269 src/option.c:271 src/option.c:273 src/option.c:283
+#: src/option.c:431 src/option.c:433 src/option.c:531 src/option.c:533
+#: src/option.c:560 src/option.c:576 src/option.c:774
 msgid "STRING"
 msgstr ""
 
-#: src/option.c:269
+#: src/option.c:271
 msgid "Set application version"
 msgstr ""
 
-#: src/option.c:271
+#: src/option.c:273
 msgid "Set application copyright string"
 msgstr ""
 
-#: src/option.c:273
+#: src/option.c:275
 msgid "Set application comments string"
 msgstr ""
 
-#: src/option.c:275
+#: src/option.c:277
 msgid "Set application license"
 msgstr ""
 
-#: src/option.c:277
+#: src/option.c:279
 msgid "Set application authors"
 msgstr ""
 
-#: src/option.c:277 src/option.c:485 src/option.c:489 src/option.c:493
+#: src/option.c:279 src/option.c:487 src/option.c:491 src/option.c:495
 msgid "LIST"
 msgstr ""
 
-#: src/option.c:279
+#: src/option.c:281
 #, fuzzy
 msgid "Set application website"
 msgstr "Nastaví veľkosť skoku"
 
-#: src/option.c:279
+#: src/option.c:281
 msgid "URI"
 msgstr ""
 
-#: src/option.c:281
+#: src/option.c:283
 msgid "Set application website label"
 msgstr ""
 
-#: src/option.c:287
+#: src/option.c:289
 #, fuzzy
 msgid "Display application selection dialog"
 msgstr "Zobrazí dialóg Výber písma"
 
-#: src/option.c:289
+#: src/option.c:291
 #, fuzzy
 msgid "Show fallback applications"
 msgstr "Zobrazí voľby kalendára"
 
-#: src/option.c:291
+#: src/option.c:293
 #, fuzzy
 msgid "Show other applications"
 msgstr "Zobrazí voľby formulára"
 
-#: src/option.c:293
+#: src/option.c:295
 #, fuzzy
 msgid "Show all applications"
 msgstr "Zobrazí voľby posuvníka"
 
-#: src/option.c:295
+#: src/option.c:297
 msgid "Output all application data"
 msgstr ""
 
-#: src/option.c:300
+#: src/option.c:302
 msgid "Display calendar dialog"
 msgstr "Zobrazí dialóg Kalendár"
 
-#: src/option.c:302
+#: src/option.c:304
 msgid "Set the calendar day"
 msgstr "Nastaví deň kalendára"
 
-#: src/option.c:302
+#: src/option.c:304
 msgid "DAY"
 msgstr "DEŇ"
 
-#: src/option.c:304
+#: src/option.c:306
 msgid "Set the calendar month"
 msgstr "Nastaví mesiac kalendára"
 
-#: src/option.c:304
+#: src/option.c:306
 msgid "MONTH"
 msgstr "MESIAC"
 
-#: src/option.c:306
+#: src/option.c:308
 msgid "Set the calendar year"
 msgstr "Nastaví rok kalendára"
 
-#: src/option.c:306
+#: src/option.c:308
 msgid "YEAR"
 msgstr "ROK"
 
-#: src/option.c:308
+#: src/option.c:310
 msgid "Set the filename with dates details"
 msgstr "Nastaví meno súboru s podrobnosťami dátumu"
 
-#: src/option.c:310
+#: src/option.c:312
 msgid "Show week numbers at the left side of calendar"
 msgstr ""
 
-#: src/option.c:312 src/option.c:513
+#: src/option.c:314 src/option.c:515
 #, fuzzy
 msgid "Set select action"
 msgstr "Nastaví akciu ľavého tlačidla myši"
 
-#: src/option.c:318
+#: src/option.c:320
 msgid "Display color selection dialog"
 msgstr "Zobrazí dialóg Výber farby"
 
-#: src/option.c:320
+#: src/option.c:322
 msgid "Set initial color value"
 msgstr "Nastaví počiatočnú hodnotu farby"
 
-#: src/option.c:320 src/option.c:704 src/option.c:706 src/option.c:712
-#: src/option.c:735 src/option.c:737
+#: src/option.c:322 src/option.c:706 src/option.c:708 src/option.c:714
+#: src/option.c:737 src/option.c:739
 msgid "COLOR"
 msgstr "FARBA"
 
-#: src/option.c:322
+#: src/option.c:324
 msgid "Show system palette in color dialog"
 msgstr ""
 
-#: src/option.c:324
+#: src/option.c:326
 msgid "Set path to palette file. Default - "
 msgstr "Nastaví cestu k súboru palety. Predvolene - "
 
-#: src/option.c:326
+#: src/option.c:328
 msgid "Expand user palette"
 msgstr ""
 
-#: src/option.c:328
+#: src/option.c:330
 msgid "Show color picker"
 msgstr ""
 
-#: src/option.c:330
+#: src/option.c:332
 msgid "Set output mode to MODE. Values are hex (default) or rgb"
 msgstr ""
 
-#: src/option.c:330
+#: src/option.c:332
 msgid "MODE"
 msgstr ""
 
-#: src/option.c:332
+#: src/option.c:334
 msgid "Add opacity to output color value"
 msgstr ""
 
-#: src/option.c:338
+#: src/option.c:340
 msgid "Display drag-n-drop box"
 msgstr "Zobrazí dialóg Ťahaj a Pusť"
 
-#: src/option.c:340
+#: src/option.c:342
 msgid "Use dialog text as tooltip"
 msgstr "Použiť text dialógu ako nástrojový tip"
 
-#: src/option.c:342
+#: src/option.c:344
 msgid "Exit after NUMBER of drops"
 msgstr ""
 
-#: src/option.c:348
+#: src/option.c:350
 msgid "Display text entry or combo-box dialog"
 msgstr "Zobrazí dialóg Vstup textu alebo Rozbaľovací zoznam"
 
-#: src/option.c:350
+#: src/option.c:352
 msgid "Set the entry label"
 msgstr "Nastaví návestie položky"
 
-#: src/option.c:352
+#: src/option.c:354
 msgid "Set the entry text"
 msgstr "Nastaví text vstupu"
 
-#: src/option.c:354
+#: src/option.c:356
 msgid "Hide the entry text"
 msgstr "Skryje text vstupu"
 
-#: src/option.c:356
+#: src/option.c:358
 msgid "Use completion instead of combo-box"
 msgstr "Použije dopĺňanie namiesto rozbaľovacieho zoznamu"
 
-#: src/option.c:358
+#: src/option.c:360
 msgid "Use spin button for text entry"
 msgstr "Použije číselník (spin button) pre text vstupu"
 
-#: src/option.c:360
+#: src/option.c:362
 msgid "Set the left entry icon"
 msgstr "Nastaví ikonu na ľavej strane položky"
 
-#: src/option.c:362
+#: src/option.c:364
 msgid "Set the left entry icon action"
 msgstr "Nastaví akciu ľavej ikony"
 
-#: src/option.c:364
+#: src/option.c:366
 msgid "Set the right entry icon"
 msgstr "Nastaví ikonu na pravej strane položky"
 
-#: src/option.c:366
+#: src/option.c:368
 msgid "Set the right entry icon action"
 msgstr "Nastaví akciu pravej ikony"
 
-#: src/option.c:372
+#: src/option.c:374
 msgid "Display file selection dialog"
 msgstr "Zobrazí dialóg Výber súboru"
 
-#: src/option.c:374
+#: src/option.c:376
 msgid "Activate directory-only selection"
 msgstr "Aktivuje výber adresárov"
 
-#: src/option.c:376
+#: src/option.c:378
 msgid "Activate save mode"
 msgstr "Aktivuje režim save"
 
-#: src/option.c:378
+#: src/option.c:380
 msgid "Confirm file selection if filename already exists"
 msgstr "Potvrdiť výber súboru, ak už súbor existuje"
 
-#: src/option.c:384
+#: src/option.c:386
 msgid "Display font selection dialog"
 msgstr "Zobrazí dialóg Výber písma"
 
-#: src/option.c:386
+#: src/option.c:388
 msgid "Set text string for preview"
 msgstr ""
 
-#: src/option.c:388
+#: src/option.c:390
 msgid "Separate output of font description"
 msgstr ""
 
-#: src/option.c:394
+#: src/option.c:396
 msgid "Display form dialog"
 msgstr "Zobrazí dialóg Formulár"
 
-#: src/option.c:396
+#: src/option.c:398
 msgid "Add field to form (see man page for list of possible types)"
 msgstr ""
 
-#: src/option.c:396 src/option.c:631
+#: src/option.c:398 src/option.c:633
 msgid "LABEL[:TYPE]"
 msgstr "NÁVESTIE[:TYP]"
 
-#: src/option.c:398
+#: src/option.c:400
 msgid "Set alignment of filed labels (left, center or right)"
 msgstr "Nastaví zarovnanie menoviek polí (left, center alebo right)"
 
-#: src/option.c:400
+#: src/option.c:402
 msgid "Set number of columns in form"
 msgstr "Nastaví počet stĺpcov formulára"
 
-#: src/option.c:402
+#: src/option.c:404
 msgid "Make form fields height and columns width the same size"
 msgstr ""
 
-#: src/option.c:404
+#: src/option.c:406
 msgid "Order output fields by rows"
 msgstr ""
 
-#: src/option.c:406
+#: src/option.c:408
 #, fuzzy
 msgid "Set focused field"
 msgstr "Nastaví veľkosť kroku"
 
-#: src/option.c:408
+#: src/option.c:410
 msgid "Cycled reading of stdin data"
 msgstr ""
 
-#: src/option.c:410
+#: src/option.c:412
 msgid "Align labels on button fields"
 msgstr ""
 
-#: src/option.c:412
+#: src/option.c:414
 #, fuzzy
 msgid "Set changed action"
 msgstr "Nastaví akciu ľavého tlačidla myši"
 
-#: src/option.c:419
+#: src/option.c:421
 #, fuzzy
 msgid "Display HTML dialog"
 msgstr "Zobrazí dialóg Formulár"
 
-#: src/option.c:421
+#: src/option.c:423
 #, fuzzy
 msgid "Open specified location"
 msgstr "Použije zadaný font"
 
-#: src/option.c:423
+#: src/option.c:425
 #, fuzzy
 msgid "Turn on browser mode"
 msgstr "– Prehliadač ikon"
 
-#: src/option.c:425
+#: src/option.c:427
 msgid "Print clicked uri to stdout"
 msgstr ""
 
-#: src/option.c:427
+#: src/option.c:429
 msgid "Set encoding of input stream data"
 msgstr ""
 
-#: src/option.c:427
+#: src/option.c:429
 msgid "ENCODING"
 msgstr ""
 
-#: src/option.c:429
+#: src/option.c:431
 msgid "Set user agent string"
 msgstr ""
 
-#: src/option.c:431
+#: src/option.c:433
 msgid "Set custom user style"
 msgstr ""
 
-#: src/option.c:433
+#: src/option.c:435
 msgid "Set WebKit property"
 msgstr ""
 
-#: src/option.c:433
+#: src/option.c:435
 msgid "PROP"
 msgstr ""
 
-#: src/option.c:440
+#: src/option.c:442
 msgid "Display icons box dialog"
 msgstr "Zobrazí dialóg Ikony"
 
-#: src/option.c:442
+#: src/option.c:444
 msgid "Read data from .desktop files in specified directory"
 msgstr "Číta dáta zo súborov .desktop v zadanom adresári"
 
-#: src/option.c:442
+#: src/option.c:444
 msgid "DIR"
 msgstr ""
 
-#: src/option.c:444
+#: src/option.c:446
 msgid "Use compact (list) view"
 msgstr "Použije kompaktné (zoznam) zobrazenie"
 
-#: src/option.c:446
+#: src/option.c:448
 msgid "Use GenericName field instead of Name for icon label"
 msgstr "Pre menovku ikony použiť pole GenericName namiesto Name"
 
-#: src/option.c:448
+#: src/option.c:450
 msgid "Set the width of dialog items"
 msgstr "Nastaví šírku položiek dialógu"
 
-#: src/option.c:450
+#: src/option.c:452
 msgid "Force using specified icon size"
 msgstr ""
 
-#: src/option.c:450 src/option.c:564 src/option.c:700 src/tools.c:85
+#: src/option.c:452 src/option.c:566 src/option.c:702 src/tools.c:85
 msgid "SIZE"
 msgstr "VEĽKOSŤ"
 
-#: src/option.c:453
+#: src/option.c:455
 #, no-c-format
 msgid ""
 "Use specified pattern for launch command in terminal (default: xterm -e %s)"
 msgstr ""
 "Špecifický vzor spustenia príkazu v terminále (predvolené: xterm -e %s)"
 
-#: src/option.c:455
+#: src/option.c:457
 msgid "Sort items by name instead of filename"
 msgstr "Radí položky podľa mena namiesto mena súboru"
 
-#: src/option.c:457
+#: src/option.c:459
 msgid "Sort items in descending order"
 msgstr "Zoradí položky zostupne"
 
-#: src/option.c:459
+#: src/option.c:461
 msgid "Activate items by single click"
 msgstr "Aktivovať položku jedným kliknutím"
 
-#: src/option.c:461
+#: src/option.c:463
 msgid "Watch fot changes in directory"
 msgstr ""
 
-#: src/option.c:467
+#: src/option.c:469
 msgid "Display list dialog"
 msgstr "Zobrazí dialóg Zoznam"
 
-#: src/option.c:469
+#: src/option.c:471
 msgid "Set the column header (see man page for list of possible types)"
 msgstr ""
 
-#: src/option.c:469
+#: src/option.c:471
 msgid "COLUMN[:TYPE]"
 msgstr "STĹPEC[:TYP]"
 
-#: src/option.c:471
+#: src/option.c:473
 msgid "Enbale tree mode"
 msgstr ""
 
-#: src/option.c:473
+#: src/option.c:475
 msgid "Use checkboxes for first column"
 msgstr "V prvom stĺpci použije zaškrtávacie voľby"
 
-#: src/option.c:475
+#: src/option.c:477
 msgid "Use radioboxes for first column"
 msgstr "V prvom stĺpci použije výberové voľby"
 
-#: src/option.c:477
+#: src/option.c:479
 msgid "Don't show column headers"
 msgstr "Nezobrazuje hlavičky stĺpcov"
 
-#: src/option.c:479
+#: src/option.c:481
 msgid "Disable clickable column headers"
 msgstr ""
 
-#: src/option.c:481
+#: src/option.c:483
 msgid "Set grid lines (hor[izontal], vert[ical] or both)"
 msgstr ""
 
-#: src/option.c:483
+#: src/option.c:485
 msgid "Print all data from list"
 msgstr "Vypíše všetky dáta zoznamu"
 
-#: src/option.c:485
+#: src/option.c:487
 #, fuzzy
 msgid "Set the list of editable columns"
 msgstr "Nastaví šírku položiek dialógu"
 
-#: src/option.c:487
+#: src/option.c:489
 #, fuzzy
 msgid "Set the width of a column for start wrapping text"
 msgstr "Nastaví šírku položiek dialógu"
 
-#: src/option.c:489
+#: src/option.c:491
 #, fuzzy
 msgid "Set the list of wrapped columns"
 msgstr "Nastaví limit počtu riadkov zoznamu"
 
-#: src/option.c:491
+#: src/option.c:493
 #, fuzzy
 msgid "Set ellipsize mode for text columns (none, start, middle or end)"
 msgstr ""
 "Nastaví režim výpustky textových polí (TYP – NONE, START, MIDDLE alebo END)"
 
-#: src/option.c:493
+#: src/option.c:495
 #, fuzzy
 msgid "Set the list of ellipsized columns"
 msgstr "Nastaví limit počtu riadkov zoznamu"
 
-#: src/option.c:495
+#: src/option.c:497
 msgid ""
 "Print a specific column. By default or if 0 is specified will be printed all "
 "columns"
@@ -1133,17 +1143,17 @@ msgstr ""
 "Vypíše zadaný stĺpec. Predvolene alebo ak je zadaná 0 budú vypísané všetky "
 "stĺpce"
 
-#: src/option.c:497
+#: src/option.c:499
 msgid "Hide a specific column"
 msgstr "Skryje zadaný stĺpec"
 
-#: src/option.c:499
+#: src/option.c:501
 msgid "Set the column expandable by default. 0 sets all columns expandable"
 msgstr ""
 "Nastaví stĺpec predvolene ako rozšíriteľný. 0 nastavuje všetky stĺpce ako "
 "rozšíriteľné"
 
-#: src/option.c:501
+#: src/option.c:503
 msgid ""
 "Set the quick search column. Default is first column. Set it to 0 for "
 "disable searching"
@@ -1151,853 +1161,853 @@ msgstr ""
 "Nastaví rýchle vyhľadávacie pole. Predvolene je to prvý stĺpec. Nastavenie "
 "na 0 zakáže vyhľadávanie"
 
-#: src/option.c:503
+#: src/option.c:505
 #, fuzzy
 msgid "Set the tooltip column"
 msgstr "Nastaví ikonu okna"
 
-#: src/option.c:505
+#: src/option.c:507
 #, fuzzy
 msgid "Set the row separator column"
 msgstr "Nastaví ikonu na pravej strane položky"
 
-#: src/option.c:507
+#: src/option.c:509
 #, fuzzy
 msgid "Set the row separator value"
 msgstr "Nastaví znak výstupného oddeľovača"
 
-#: src/option.c:509
+#: src/option.c:511
 msgid "Set the limit of rows in list"
 msgstr "Nastaví limit počtu riadkov zoznamu"
 
-#: src/option.c:511
+#: src/option.c:513
 msgid "Set double-click action"
 msgstr "Nastaví akciu dvojitého kliknutia"
 
-#: src/option.c:515
+#: src/option.c:517
 #, fuzzy
 msgid "Set row action"
 msgstr "Nastaví akciu dvojitého kliknutia"
 
-#: src/option.c:517
+#: src/option.c:519
 msgid "Expand all tree nodes"
 msgstr ""
 
-#: src/option.c:519
+#: src/option.c:521
 msgid "Use regex in search"
 msgstr "Použije regulárny výraz v hľadaní"
 
-#: src/option.c:521
+#: src/option.c:523
 #, fuzzy
 msgid "Disable selection"
 msgstr "Zobrazí dialóg Výber súboru"
 
-#: src/option.c:523
+#: src/option.c:525
 msgid "Add new records on the top of a list"
 msgstr ""
 
-#: src/option.c:525
+#: src/option.c:527
 msgid "Don't use markup in tooltips"
 msgstr ""
 
-#: src/option.c:527
+#: src/option.c:529
 msgid "Use column name as a header tooltip"
 msgstr ""
 
-#: src/option.c:529
+#: src/option.c:531
 #, fuzzy
 msgid "Set columns alignment"
 msgstr "Nastaví počet stĺpcov formulára"
 
-#: src/option.c:531
+#: src/option.c:533
 #, fuzzy
 msgid "Set headers alignment"
 msgstr "Nastaví mesiac kalendára"
 
-#: src/option.c:537
+#: src/option.c:539
 msgid "Display notebook dialog"
 msgstr "Zobrazí dialóg Zápisník"
 
-#: src/option.c:539
+#: src/option.c:541
 msgid "Add a tab to notebook"
 msgstr "Pridá do zápisníka záložku"
 
-#: src/option.c:539
+#: src/option.c:541
 msgid "LABEL"
 msgstr "MENOVKA"
 
-#: src/option.c:541
+#: src/option.c:543
 #, fuzzy
 msgid "Set position of a notebook tabs (top, bottom, left or right)"
 msgstr "Zobrazí indikátor zostávajúceho času (top, bottom, left, right)"
 
-#: src/option.c:543
+#: src/option.c:545
 msgid "Set tab borders"
 msgstr "Nastaví okraje záložky"
 
-#: src/option.c:545
+#: src/option.c:547
 #, fuzzy
 msgid "Set active tab"
 msgstr "Nastaví návestie položky"
 
-#: src/option.c:547
+#: src/option.c:549
 msgid "Expand tabs"
 msgstr ""
 
-#: src/option.c:549
+#: src/option.c:551
 msgid "Use stack mode"
 msgstr ""
 
-#: src/option.c:556
+#: src/option.c:558
 msgid "Display notification"
 msgstr "Zobrazí ikonu informačnej oblasti"
 
-#: src/option.c:558 src/option.c:574
+#: src/option.c:560 src/option.c:576
 #, fuzzy
 msgid "Set initial popup menu"
 msgstr "Nastaví počiatočné písmo"
 
-#: src/option.c:560
+#: src/option.c:562
 msgid "Disable exit on middle click"
 msgstr ""
 
-#: src/option.c:562 src/option.c:576
+#: src/option.c:564 src/option.c:578
 #, fuzzy
 msgid "Doesn't show icon at startup"
 msgstr "Skryje okno v paneli úloh"
 
-#: src/option.c:564
+#: src/option.c:566
 msgid "Set icon size for fully specified icons (default - 16)"
 msgstr ""
 
-#: src/option.c:572
+#: src/option.c:574
 msgid "Display indicator icon (StatusNotifier/AppIndicator)"
 msgstr ""
 
-#: src/option.c:583
+#: src/option.c:585
 #, fuzzy
 msgid "Display paned dialog"
 msgstr "Zobrazí dialóg Posuvník"
 
-#: src/option.c:585
+#: src/option.c:587
 msgid "Set orientation (hor[izontal] or vert[ical])"
 msgstr ""
 
-#: src/option.c:587
+#: src/option.c:589
 #, fuzzy
 msgid "Set initial splitter position"
 msgstr "Nastaví počiatočné percentá"
 
-#: src/option.c:589
+#: src/option.c:591
 msgid "Set focused pane (1 or 2)"
 msgstr ""
 
-#: src/option.c:589
+#: src/option.c:591
 msgid "PANE"
 msgstr ""
 
-#: src/option.c:595
+#: src/option.c:597
 #, fuzzy
 msgid "Display picture dialog"
 msgstr "Zobrazí dialóg Zoznam"
 
-#: src/option.c:597
+#: src/option.c:599
 #, fuzzy
 msgid "Set initial size (fit or orig)"
 msgstr "Nastaví počiatočné písmo"
 
-#: src/option.c:599
+#: src/option.c:601
 msgid "Set increment for picture scaling (default - 5)"
 msgstr ""
 
-#: src/option.c:601
+#: src/option.c:603
 msgid "Set action on image changing"
 msgstr ""
 
-#: src/option.c:607
+#: src/option.c:609
 #, fuzzy
 msgid "Display popup dialog"
 msgstr "Zobrazí dialóg Zoznam"
 
-#: src/option.c:609
+#: src/option.c:611
 #, fuzzy
 msgid "Set alignment of title and text (left, center or right)"
 msgstr "Nastaví zarovnanie menoviek polí (left, center alebo right)"
 
-#: src/option.c:611
+#: src/option.c:613
 msgid "Set transparency"
 msgstr ""
 
-#: src/option.c:611
+#: src/option.c:613
 #, fuzzy
 msgid "PERCENT"
 msgstr "PERCENTÁ"
 
-#: src/option.c:613
+#: src/option.c:615
 msgid "Don't close popup by timeout"
 msgstr ""
 
-#: src/option.c:619
+#: src/option.c:621
 msgid "Display printing dialog"
 msgstr "Zobrazí dialóg Tlače"
 
-#: src/option.c:621
+#: src/option.c:623
 #, fuzzy
 msgid "Set source type (text, image or raw)"
 msgstr "Nastaví typ zdroja (TYP – TEXT, IMAGE alebo RAW)"
 
-#: src/option.c:623
+#: src/option.c:625
 msgid "Add headers to page"
 msgstr "Pridať hlavičky do stránky"
 
-#: src/option.c:629
+#: src/option.c:631
 msgid "Display progress indication dialog"
 msgstr "Zobrazí dialóg Indikátor priebehu"
 
-#: src/option.c:631
+#: src/option.c:633
 #, fuzzy
 msgid "Add the progress bar (norm, rtl, pulse, cpulse or perm)"
 msgstr "Pridá ukazovateľ priebehu (TYP – NORM, RTL alebo PULSE)"
 
-#: src/option.c:633
+#: src/option.c:635
 msgid "Watch for specific bar for auto close"
 msgstr ""
 
-#: src/option.c:635
+#: src/option.c:637
 msgid "Set alignment of bar labels (left, center or right)"
 msgstr "Nastaví zarovnanie menoviek ukazovateľov (left, center alebo right)"
 
-#: src/option.c:637
+#: src/option.c:639
 msgid "Set progress text"
 msgstr "Nastaví text ukazovateľa"
 
-#: src/option.c:639
+#: src/option.c:641
 #, fuzzy
 msgid "Hide text on progress bar"
 msgstr "Pulzujúci ukazovateľ priebehu"
 
-#: src/option.c:641
+#: src/option.c:643
 msgid "Pulsate progress bar"
 msgstr "Pulzujúci ukazovateľ priebehu"
 
-#: src/option.c:643
+#: src/option.c:645
 #, fuzzy
 msgid "Conlinuous pulsating progress bar"
 msgstr "Pulzujúci ukazovateľ priebehu"
 
-#: src/option.c:646
+#: src/option.c:648
 #, no-c-format
 msgid "Dismiss the dialog when 100% has been reached"
 msgstr "Zatvorí dialóg pri dosiahnutí 100%"
 
-#: src/option.c:649
+#: src/option.c:651
 msgid "Kill parent process if cancel button is pressed"
 msgstr "Ukončí rodičovský proces, ak je stlačený kláves Zrušiť"
 
-#: src/option.c:652
+#: src/option.c:654
 msgid "Right-To-Left progress bar direction"
 msgstr "Indikátor priebehu sprava doľava"
 
-#: src/option.c:654
+#: src/option.c:656
 msgid "Show log window"
 msgstr "Zobrazí okno záznamu"
 
-#: src/option.c:656
+#: src/option.c:658
 msgid "Expand log window"
 msgstr "Rozšíriť okno záznamu"
 
-#: src/option.c:658
+#: src/option.c:660
 msgid "Place log window above progress bar"
 msgstr "Umiestni okno záznamu nad ukazovateľ"
 
-#: src/option.c:660
+#: src/option.c:662
 msgid "Height of log window"
 msgstr "Výška okna záznamu"
 
-#: src/option.c:666
+#: src/option.c:668
 msgid "Display scale dialog"
 msgstr "Zobrazí dialóg Posuvník"
 
-#: src/option.c:668
+#: src/option.c:670
 msgid "Set initial value"
 msgstr "Nastaví východziu hodnotu"
 
-#: src/option.c:668 src/option.c:670 src/option.c:672 src/option.c:674
-#: src/option.c:678 src/option.c:745 src/option.c:747
+#: src/option.c:670 src/option.c:672 src/option.c:674 src/option.c:676
+#: src/option.c:680 src/option.c:747 src/option.c:749
 msgid "VALUE"
 msgstr "HODNOTA"
 
-#: src/option.c:670
+#: src/option.c:672
 msgid "Set minimum value"
 msgstr "Nastaví minimálnu hodnotu"
 
-#: src/option.c:672
+#: src/option.c:674
 msgid "Set maximum value"
 msgstr "Nastaví maximálnu hodnotu"
 
-#: src/option.c:674
+#: src/option.c:676
 msgid "Set step size"
 msgstr "Nastaví veľkosť kroku"
 
-#: src/option.c:676
+#: src/option.c:678
 msgid "Only allow values in step increments"
 msgstr ""
 
-#: src/option.c:678
+#: src/option.c:680
 msgid "Set paging size"
 msgstr "Nastaví veľkosť skoku"
 
-#: src/option.c:680
+#: src/option.c:682
 msgid "Print partial values"
 msgstr "Vypíše čiastočné hodnoty"
 
-#: src/option.c:682
+#: src/option.c:684
 msgid "Hide value"
 msgstr "Skryje hodnotu"
 
-#: src/option.c:684
+#: src/option.c:686
 msgid "Invert direction"
 msgstr "Obráti smer"
 
-#: src/option.c:686
+#: src/option.c:688
 msgid "Show +/- buttons in scale"
 msgstr ""
 
-#: src/option.c:688
+#: src/option.c:690
 msgid "Add mark to scale (may be used multiple times)"
 msgstr "Pridá značku do posuvníka (možno použiť viackrát)"
 
-#: src/option.c:688
+#: src/option.c:690
 msgid "NAME:VALUE"
 msgstr "MENO:HODNOTA"
 
-#: src/option.c:694
+#: src/option.c:696
 msgid "Display text information dialog"
 msgstr "Zobrazí dialóg Informačný text"
 
-#: src/option.c:696
+#: src/option.c:698
 msgid "Enable text wrapping"
 msgstr "Zapne zalamovanie textu"
 
-#: src/option.c:698
+#: src/option.c:700
 #, fuzzy
 msgid "Set justification (left, right, center or fill)"
 msgstr "Nastaví zarovnanie (TYP – left, right, center alebo fill)"
 
-#: src/option.c:700
+#: src/option.c:702
 msgid "Set text margins"
 msgstr "Nastaví okraje textu"
 
-#: src/option.c:702
+#: src/option.c:704
 #, fuzzy
 msgid "Jump to specific line"
 msgstr "Skryje zadaný stĺpec"
 
-#: src/option.c:704
+#: src/option.c:706
 msgid "Use specified color for text"
 msgstr "Použije zadanú farbu textu"
 
-#: src/option.c:706
+#: src/option.c:708
 msgid "Use specified color for background"
 msgstr "Použije zadanú farbu pozadia"
 
-#: src/option.c:708
+#: src/option.c:710
 msgid "Show cursor in read-only mode"
 msgstr ""
 
-#: src/option.c:710
+#: src/option.c:712
 msgid "Make URI clickable"
 msgstr "Urobí URI kliknuteľné"
 
-#: src/option.c:712
+#: src/option.c:714
 #, fuzzy
 msgid "Use specified color for links"
 msgstr "Použije zadanú farbu textu"
 
-#: src/option.c:714
+#: src/option.c:716
 msgid "Use pango markup"
 msgstr ""
 
-#: src/option.c:716
+#: src/option.c:718
 msgid "Save file instead of print on exit"
 msgstr ""
 
-#: src/option.c:718
+#: src/option.c:720
 msgid "Confirm save the file if text was changed"
-msgstr ""
-
-#: src/option.c:725
-#, fuzzy
-msgid "Use specified langauge for syntax highlighting"
-msgstr "Použije zadanú farbu textu"
-
-#: src/option.c:725
-msgid "LANG"
 msgstr ""
 
 #: src/option.c:727
 #, fuzzy
+msgid "Use specified langauge for syntax highlighting"
+msgstr "Použije zadanú farbu textu"
+
+#: src/option.c:727
+msgid "LANG"
+msgstr ""
+
+#: src/option.c:729
+#, fuzzy
 msgid "Use specified theme"
 msgstr "Použije zadaný font"
 
-#: src/option.c:729
+#: src/option.c:731
 msgid "Show line numbers"
 msgstr ""
 
-#: src/option.c:731
+#: src/option.c:733
 msgid "Highlight current line"
 msgstr ""
 
-#: src/option.c:733
+#: src/option.c:735
 msgid "Enable line marks"
 msgstr ""
 
-#: src/option.c:735
+#: src/option.c:737
 msgid "Set color for first type marks"
 msgstr ""
 
-#: src/option.c:737
+#: src/option.c:739
 msgid "Set color for second type marks"
 msgstr ""
 
-#: src/option.c:739
+#: src/option.c:741
 msgid "Set position of right margin"
 msgstr ""
 
-#: src/option.c:739
+#: src/option.c:741
 msgid "[POS]"
 msgstr ""
 
-#: src/option.c:741
+#: src/option.c:743
 msgid "Highlight matching brackets"
 msgstr ""
 
-#: src/option.c:743
+#: src/option.c:745
 msgid "Use autoindent"
 msgstr ""
 
-#: src/option.c:745
+#: src/option.c:747
 #, fuzzy
 msgid "Set tabulation width"
 msgstr "Nastaví šírku"
 
-#: src/option.c:747
+#: src/option.c:749
 #, fuzzy
 msgid "Set indentation width"
 msgstr "Nastaví šírku"
 
-#: src/option.c:749
+#: src/option.c:751
 msgid "Set smart Home/End behavior"
 msgstr ""
 
-#: src/option.c:751
+#: src/option.c:753
 msgid "Enable smart backspace"
 msgstr ""
 
-#: src/option.c:753
+#: src/option.c:755
 msgid "Insert spaces instead of tabs"
 msgstr ""
 
-#: src/option.c:760
+#: src/option.c:762
 msgid "Sets a filename filter"
 msgstr "Nastaví filter mien súborov"
 
-#: src/option.c:760
+#: src/option.c:762
 msgid "NAME | PATTERN1 PATTERN2 ..."
 msgstr "MENO | VZOR1 VZOR2 ..."
 
-#: src/option.c:762
+#: src/option.c:764
 #, fuzzy
 msgid "Sets a mime-type filter"
 msgstr "Nastaví filter mien súborov"
 
-#: src/option.c:762
+#: src/option.c:764
 #, fuzzy
 msgid "NAME | MIME1 MIME2 ..."
 msgstr "MENO | VZOR1 VZOR2 ..."
 
-#: src/option.c:764
+#: src/option.c:766
 #, fuzzy
 msgid "Add filter for images"
 msgstr "Pridať hlavičky do stránky"
 
-#: src/option.c:764
+#: src/option.c:766
 #, fuzzy
 msgid "[NAME]"
 msgstr "MENO:ID"
 
-#: src/option.c:770 src/tools.c:64
+#: src/option.c:772 src/tools.c:64
 msgid "Print version"
 msgstr "Vypíše verziu"
 
-#: src/option.c:772
+#: src/option.c:774
 msgid "Load additional CSS settings from file or string"
 msgstr ""
 
-#: src/option.c:775
+#: src/option.c:777
 #, fuzzy
 msgid "Load additional CSS settings from file"
 msgstr "Načíta ďalšie argumenty zo súboru"
 
-#: src/option.c:778
+#: src/option.c:780
 msgid "Set policy for horizontal scrollbars (auto, always, never)"
 msgstr ""
 
-#: src/option.c:780
+#: src/option.c:782
 msgid "Set policy for vertical scrollbars (auto, always, never)"
 msgstr ""
 
-#: src/option.c:782
+#: src/option.c:784
 msgid "Add path for search icons by name"
 msgstr ""
 
-#: src/option.c:784
+#: src/option.c:786
 msgid "Write settings to file and exit"
 msgstr ""
 
-#: src/option.c:790
+#: src/option.c:792
 msgid "Load extra arguments from file"
 msgstr "Načíta ďalšie argumenty zo súboru"
 
-#: src/option.c:1001
+#: src/option.c:1003
 #, c-format
 msgid "Mark %s doesn't have a value\n"
 msgstr "Značka %s nemá hodnotu\n"
 
-#: src/option.c:1048 src/picture.c:286
+#: src/option.c:1050 src/picture.c:286
 msgid "Images"
 msgstr ""
 
-#: src/option.c:1113
+#: src/option.c:1115
 #, fuzzy, c-format
 msgid "Unknown color mode: %s\n"
 msgstr "Neznámy príkaz '%s'\n"
 
-#: src/option.c:1132
+#: src/option.c:1134
 #, c-format
 msgid "Unknown buttons layout type: %s\n"
 msgstr "Neznámy typ vzhľadu tlačidiel: %s\n"
 
-#: src/option.c:1147
+#: src/option.c:1149
 #, c-format
 msgid "Unknown align type: %s\n"
 msgstr "Neznámy typ zarovnania: %s\n"
 
-#: src/option.c:1171
+#: src/option.c:1173
 #, c-format
 msgid "Unknown justification type: %s\n"
 msgstr "Neznámy typ zarovnania: %s\n"
 
-#: src/option.c:1188
+#: src/option.c:1190
 #, fuzzy, c-format
 msgid "Unknown tab position type: %s\n"
 msgstr "Neznámy typ zarovnania: %s\n"
 
-#: src/option.c:1225
+#: src/option.c:1227
 #, c-format
 msgid "Unknown ellipsize type: %s\n"
 msgstr "Neznámy typ výpustky: %s\n"
 
-#: src/option.c:1238
+#: src/option.c:1240
 #, fuzzy, c-format
 msgid "Unknown orientation: %s\n"
 msgstr "Neznámy signál: %s\n"
 
-#: src/option.c:1253
+#: src/option.c:1255
 #, c-format
 msgid "Unknown source type: %s\n"
 msgstr "Neznámy typ zdroja: %s\n"
 
-#: src/option.c:1264
+#: src/option.c:1266
 msgid "Progress log"
 msgstr "Spracuje záznam"
 
-#: src/option.c:1277
+#: src/option.c:1279
 #, fuzzy, c-format
 msgid "Unknown size type: %s\n"
 msgstr "Neznámy typ výpustky: %s\n"
 
-#: src/option.c:1321
+#: src/option.c:1323
 #, fuzzy, c-format
 msgid "Unknown completion type: %s\n"
 msgstr "Neznámy typ zarovnania: %s\n"
 
-#: src/option.c:1353
+#: src/option.c:1355
 #, fuzzy, c-format
 msgid "Unknown boolean format type: %s\n"
 msgstr "Neznámy typ vzhľadu tlačidiel: %s\n"
 
-#: src/option.c:1369
+#: src/option.c:1371
 #, fuzzy, c-format
 msgid "Unknown grid lines type: %s\n"
 msgstr "Neznámy typ zarovnania: %s\n"
 
-#: src/option.c:1386
+#: src/option.c:1388
 #, fuzzy, c-format
 msgid "Unknown scrollbar policy type: %s\n"
 msgstr "Neznámy typ zdroja: %s\n"
 
-#: src/option.c:1437
+#: src/option.c:1439
 #, fuzzy, c-format
 msgid "Unknown window type: %s\n"
 msgstr "Neznámy typ zarovnania: %s\n"
 
-#: src/option.c:1466
+#: src/option.c:1468
 #, fuzzy, c-format
 msgid "Unknown smart Home/End mode: %s\n"
 msgstr "Neznámy typ zdroja: %s\n"
 
-#: src/option.c:1576
+#: src/option.c:1578
 #, c-format
 msgid "Unknown signal: %s\n"
 msgstr "Neznámy signál: %s\n"
 
-#: src/option.c:1811
+#: src/option.c:1814
 msgid "File exist. Overwrite?"
 msgstr "Súbor existuje. Prepísať ho?"
 
-#: src/option.c:1953
+#: src/option.c:1956
 msgid "File was changed. Save it?"
 msgstr ""
 
-#: src/option.c:1984
+#: src/option.c:1987
 #, fuzzy
 msgid "- Yet another dialoging program"
 msgstr "Prosto ďalší program na dialógy"
 
-#: src/option.c:1988
+#: src/option.c:1991
 msgid "General options"
 msgstr "Všeobecné voľby"
 
-#: src/option.c:1988
+#: src/option.c:1991
 msgid "Show general options"
 msgstr "Zobrazí všeobecné voľby"
 
-#: src/option.c:1994
+#: src/option.c:1997
 #, fuzzy
 msgid "Common options"
 msgstr "Voľby formulára"
 
-#: src/option.c:1994
+#: src/option.c:1997
 #, fuzzy
 msgid "Show common options"
 msgstr "Zobrazí voľby formulára"
 
-#: src/option.c:2000
+#: src/option.c:2003
 #, fuzzy
 msgid "About dialog options"
 msgstr "Voľby dialógu Tlače"
 
-#: src/option.c:2000
+#: src/option.c:2003
 #, fuzzy
 msgid "Show custom about dialog options"
 msgstr "Zobrazí voľby zápisníka"
 
-#: src/option.c:2006
+#: src/option.c:2009
 #, fuzzy
 msgid "Application selection options"
 msgstr "Voľby výberu písma"
 
-#: src/option.c:2006
+#: src/option.c:2009
 #, fuzzy
 msgid "Show application selection options"
 msgstr "Zobrazí voľby výberu písma"
 
-#: src/option.c:2012
+#: src/option.c:2015
 msgid "Calendar options"
 msgstr "Voľby kalendára"
 
-#: src/option.c:2012
+#: src/option.c:2015
 msgid "Show calendar options"
 msgstr "Zobrazí voľby kalendára"
 
-#: src/option.c:2018
+#: src/option.c:2021
 msgid "Color selection options"
 msgstr "Voľby výberu farby"
 
-#: src/option.c:2018
+#: src/option.c:2021
 msgid "Show color selection options"
 msgstr "Zobrazí voľby výberu farby"
 
-#: src/option.c:2024
+#: src/option.c:2027
 msgid "DND options"
 msgstr "Voľby Ťahaj a Pusť"
 
-#: src/option.c:2024
+#: src/option.c:2027
 msgid "Show drag-n-drop options"
 msgstr "Zobrazí voľby pre Ťahaj a Pusť"
 
-#: src/option.c:2030
+#: src/option.c:2033
 msgid "Text entry options"
 msgstr "Voľby textovej položky"
 
-#: src/option.c:2030
+#: src/option.c:2033
 msgid "Show text entry options"
 msgstr "Zobrazí voľby textovej položky"
 
-#: src/option.c:2036
+#: src/option.c:2039
 msgid "File selection options"
 msgstr "Voľby výberu súboru"
 
-#: src/option.c:2036
+#: src/option.c:2039
 msgid "Show file selection options"
 msgstr "Zobrazí voľby výberu súboru"
 
-#: src/option.c:2042
+#: src/option.c:2045
 msgid "Font selection options"
 msgstr "Voľby výberu písma"
 
-#: src/option.c:2042
+#: src/option.c:2045
 msgid "Show font selection options"
 msgstr "Zobrazí voľby výberu písma"
 
-#: src/option.c:2048
+#: src/option.c:2051
 msgid "Form options"
 msgstr "Voľby formulára"
 
-#: src/option.c:2048
+#: src/option.c:2051
 msgid "Show form options"
 msgstr "Zobrazí voľby formulára"
 
-#: src/option.c:2055
+#: src/option.c:2058
 #, fuzzy
 msgid "HTML options"
 msgstr "Voľby zoznamu"
 
-#: src/option.c:2055
+#: src/option.c:2058
 #, fuzzy
 msgid "Show HTML options"
 msgstr "Zobrazí voľby formulára"
 
-#: src/option.c:2062
+#: src/option.c:2065
 msgid "Icons box options"
 msgstr "Voľby dialógu ikon"
 
-#: src/option.c:2062
+#: src/option.c:2065
 msgid "Show icons box options"
 msgstr "Zobrazí voľby dialógu ikon"
 
-#: src/option.c:2068
+#: src/option.c:2071
 msgid "List options"
 msgstr "Voľby zoznamu"
 
-#: src/option.c:2068
+#: src/option.c:2071
 msgid "Show list options"
 msgstr "Zobrazí voľby zoznamu"
 
-#: src/option.c:2074
+#: src/option.c:2077
 msgid "Notebook options"
 msgstr "Voľby zápisníka"
 
-#: src/option.c:2074
+#: src/option.c:2077
 msgid "Show notebook dialog options"
 msgstr "Zobrazí voľby zápisníka"
 
-#: src/option.c:2081
+#: src/option.c:2084
 msgid "Notification icon options"
 msgstr "Voľby informačnej ikony"
 
-#: src/option.c:2082
+#: src/option.c:2085
 msgid "Show notification icon options"
 msgstr "Zobrazí voľby informačnej ikony"
 
-#: src/option.c:2090
+#: src/option.c:2093
 #, fuzzy
 msgid "StatusNotifier/AppIndicator options"
 msgstr "Voľby informačnej ikony"
 
-#: src/option.c:2091
+#: src/option.c:2094
 #, fuzzy
 msgid "Show indicator options"
 msgstr "Zobrazí voľby dialógu Tlače"
 
-#: src/option.c:2098
+#: src/option.c:2101
 #, fuzzy
 msgid "Paned dialog options"
 msgstr "Voľby dialógu Tlače"
 
-#: src/option.c:2098
+#: src/option.c:2101
 #, fuzzy
 msgid "Show paned dialog options"
 msgstr "Zobrazí voľby dialógu Tlače"
 
-#: src/option.c:2104
+#: src/option.c:2107
 #, fuzzy
 msgid "Picture dialog options"
 msgstr "Voľby dialógu Tlače"
 
-#: src/option.c:2104
+#: src/option.c:2107
 #, fuzzy
 msgid "Show picture dialog options"
 msgstr "Zobrazí voľby dialógu Tlače"
 
-#: src/option.c:2110
+#: src/option.c:2113
 #, fuzzy
 msgid "Popup dialog options"
 msgstr "Voľby dialógu Tlače"
 
-#: src/option.c:2110
+#: src/option.c:2113
 #, fuzzy
 msgid "Show popup dialog options"
 msgstr "Zobrazí voľby dialógu Tlače"
 
-#: src/option.c:2116
+#: src/option.c:2119
 msgid "Print dialog options"
 msgstr "Voľby dialógu Tlače"
 
-#: src/option.c:2116
+#: src/option.c:2119
 msgid "Show print dialog options"
 msgstr "Zobrazí voľby dialógu Tlače"
 
-#: src/option.c:2122
+#: src/option.c:2125
 msgid "Progress options"
 msgstr "Voľby ukazovateľa priebehu"
 
-#: src/option.c:2122
+#: src/option.c:2125
 msgid "Show progress options"
 msgstr "Zobrazí voľby ukazovateľa priebehu"
 
-#: src/option.c:2128
+#: src/option.c:2131
 msgid "Scale options"
 msgstr "Voľby posuvníka"
 
-#: src/option.c:2128
+#: src/option.c:2131
 msgid "Show scale options"
 msgstr "Zobrazí voľby posuvníka"
 
-#: src/option.c:2134
+#: src/option.c:2137
 msgid "Text information options"
 msgstr "Voľby textovej informácie"
 
-#: src/option.c:2134
+#: src/option.c:2137
 msgid "Show text information options"
 msgstr "Zobrazí voľby textovej informácie"
 
-#: src/option.c:2141
+#: src/option.c:2144
 #, fuzzy
 msgid "SourceView options"
 msgstr "Voľby posuvníka"
 
-#: src/option.c:2141
+#: src/option.c:2144
 #, fuzzy
 msgid "Show SourceView options"
 msgstr "Zobrazí voľby formulára"
 
-#: src/option.c:2148
+#: src/option.c:2151
 #, fuzzy
 msgid "File filter options"
 msgstr "Voľby výberu súboru"
 
-#: src/option.c:2148
+#: src/option.c:2151
 #, fuzzy
 msgid "Show file filter options"
 msgstr "Zobrazí voľby výberu súboru"
 
-#: src/option.c:2154
+#: src/option.c:2157
 msgid "Miscellaneous options"
 msgstr "Doplnkové voľby"
 
-#: src/option.c:2154
+#: src/option.c:2157
 msgid "Show miscellaneous options"
 msgstr "Zobrazí doplnkové voľby"
 
@@ -2539,7 +2549,7 @@ msgstr ""
 msgid "Insert spaces instead of tabulation:CHK"
 msgstr ""
 
-#: src/yad-settings.sh:113 data/yad-settings.desktop.in:3
+#: src/yad-settings.sh:113 data/yad-settings.desktop.in:4
 msgid "YAD settings"
 msgstr ""
 
@@ -2559,15 +2569,15 @@ msgstr ""
 msgid "Editor"
 msgstr ""
 
-#: data/yad-icon-browser.desktop.in:3
+#: data/yad-icon-browser.desktop.in:4
 msgid "Icon Browser"
 msgstr "Prehliadač ikon"
 
-#: data/yad-icon-browser.desktop.in:4
+#: data/yad-icon-browser.desktop.in:5
 msgid "Inspect GTK Icon Theme"
 msgstr "Preskúmať tému ikon GTK"
 
-#: data/yad-settings.desktop.in:4
+#: data/yad-settings.desktop.in:5
 msgid "Simple GUI for editing YAD settings"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YAD\n"
 "Report-Msgid-Bugs-To: victor@sanana.kiev.ua\n"
-"POT-Creation-Date: 2026-06-30 16:06+0300\n"
+"POT-Creation-Date: 2026-07-06 22:04-0400\n"
 "PO-Revision-Date: 2021-11-28 19:00+0200\n"
 "Last-Translator: Victor Ananjevsky <victor@sanana.kiev.ua>\n"
 "Language-Team: \n"
@@ -94,15 +94,15 @@ msgstr "Вибрати або створити теку"
 msgid "Select date"
 msgstr "Вибрати дату"
 
-#: src/form.c:1047
+#: src/form.c:1055
 msgid "Select file"
 msgstr "Вибрати файл"
 
-#: src/form.c:1077
+#: src/form.c:1085
 msgid "Select folder"
 msgstr "Вибрати теку"
 
-#: src/form.c:1245 src/form.c:1247
+#: src/form.c:1253 src/form.c:1255
 msgid "Link"
 msgstr "Посилання"
 
@@ -141,36 +141,36 @@ msgstr "Не можу відкрити каталог %s: %s\n"
 msgid "%d sec"
 msgstr "%d сек"
 
-#: src/main.c:748 src/main.c:755
+#: src/main.c:764 src/main.c:771
 #, c-format
 msgid "Unable to parse YAD_OPTIONS: %s\n"
 msgstr "Не можу розібрати YAD_OPTIONS: %s\n"
 
-#: src/main.c:766
+#: src/main.c:782
 #, c-format
 msgid "Unable to parse command line: %s\n"
 msgstr "Не вдається розібрати командний рядок: %s\n"
 
-#: src/main.c:780
+#: src/main.c:796
 msgid ""
 "WARNING: Using splash option is deprecated, please use --window-type instead"
 msgstr ""
 "УВАГА: Опція splash застаріла, використовуйте --window-type замість неї"
 
-#: src/main.c:790
+#: src/main.c:806
 #, c-format
 msgid "Unable to change directory to %s: %s\n"
 msgstr "Не можу змінити каталог на %s: %s\n"
 
-#: src/main.c:819
+#: src/main.c:835
 msgid "WARNING: Using gtkrc option is deprecated, please use --css instead\n"
 msgstr "УВАГА: Опція gtkrc застаріла, використовуйте --css замість неї\n"
 
-#: src/main.c:893
+#: src/main.c:909
 msgid "WARNING: --plug mode not supported outside X11\n"
 msgstr "УВАГА: Опція --plug підтримується тільки в X11\n"
 
-#: src/main.c:913
+#: src/main.c:929
 msgid "WARNING: This mode not supported outside X11\n"
 msgstr "УВАГА: Цей режим підтримується тільки в X11\n"
 
@@ -268,12 +268,12 @@ msgstr "ВИСОТА"
 msgid "Set the X position of a window"
 msgstr "Задати позицію вікна по X"
 
-#: src/option.c:106 src/option.c:108 src/option.c:118 src/option.c:140
-#: src/option.c:144 src/option.c:189 src/option.c:203 src/option.c:342
-#: src/option.c:400 src/option.c:406 src/option.c:487 src/option.c:495
-#: src/option.c:497 src/option.c:499 src/option.c:501 src/option.c:503
-#: src/option.c:505 src/option.c:509 src/option.c:543 src/option.c:545
-#: src/option.c:599 src/option.c:633 src/option.c:702
+#: src/option.c:106 src/option.c:108 src/option.c:118 src/option.c:142
+#: src/option.c:146 src/option.c:191 src/option.c:205 src/option.c:344
+#: src/option.c:402 src/option.c:408 src/option.c:489 src/option.c:497
+#: src/option.c:499 src/option.c:501 src/option.c:503 src/option.c:505
+#: src/option.c:507 src/option.c:511 src/option.c:545 src/option.c:547
+#: src/option.c:601 src/option.c:635 src/option.c:704
 msgid "NUMBER"
 msgstr "ЧИСЛО"
 
@@ -301,7 +301,7 @@ msgstr "ЗАТРИМКА"
 msgid "Show remaining time indicator (top, bottom, left, right)"
 msgstr "Показник часу, який залишився (top, bottom, left, right)"
 
-#: src/option.c:114 src/option.c:587
+#: src/option.c:114 src/option.c:589
 msgid "POS"
 msgstr "ПОЗИЦІЯ"
 
@@ -309,8 +309,8 @@ msgstr "ПОЗИЦІЯ"
 msgid "Set the dialog text"
 msgstr "Задати текст діалогу"
 
-#: src/option.c:116 src/option.c:273 src/option.c:275 src/option.c:350
-#: src/option.c:352 src/option.c:386 src/option.c:507 src/option.c:637
+#: src/option.c:116 src/option.c:275 src/option.c:277 src/option.c:352
+#: src/option.c:354 src/option.c:388 src/option.c:509 src/option.c:639
 msgid "TEXT"
 msgstr "ТЕКСТ"
 
@@ -322,11 +322,11 @@ msgstr "Задати ширину текст діалогу у літерах"
 msgid "Set the dialog text alignment (left, center, right, fill)"
 msgstr "Задати вирівнювання тексту діалогу (left, center, right, fill)"
 
-#: src/option.c:120 src/option.c:132 src/option.c:185 src/option.c:235
-#: src/option.c:241 src/option.c:243 src/option.c:398 src/option.c:481
-#: src/option.c:491 src/option.c:541 src/option.c:585 src/option.c:597
-#: src/option.c:609 src/option.c:621 src/option.c:635 src/option.c:698
-#: src/option.c:749 src/option.c:778 src/option.c:780 src/tools.c:86
+#: src/option.c:120 src/option.c:132 src/option.c:187 src/option.c:237
+#: src/option.c:243 src/option.c:245 src/option.c:400 src/option.c:483
+#: src/option.c:493 src/option.c:543 src/option.c:587 src/option.c:599
+#: src/option.c:611 src/option.c:623 src/option.c:637 src/option.c:700
+#: src/option.c:751 src/option.c:780 src/option.c:782 src/tools.c:86
 msgid "TYPE"
 msgstr "ТИП"
 
@@ -334,7 +334,7 @@ msgstr "ТИП"
 msgid "Set the dialog image"
 msgstr "Задати зображення діалогу"
 
-#: src/option.c:122 src/option.c:360 src/option.c:364
+#: src/option.c:122 src/option.c:362 src/option.c:366
 msgid "IMAGE"
 msgstr "ЗОБРАЖЕННЯ"
 
@@ -342,7 +342,7 @@ msgstr "ЗОБРАЖЕННЯ"
 msgid "Use specified icon theme instead of default"
 msgstr "Використовувати вказану тему піктограм замість стандартної"
 
-#: src/option.c:124 src/option.c:727 src/browser.c:220 src/tools.c:87
+#: src/option.c:124 src/option.c:729 src/browser.c:220 src/tools.c:87
 msgid "THEME"
 msgstr "ТЕМА"
 
@@ -350,7 +350,7 @@ msgstr "ТЕМА"
 msgid "Hide main widget with expander"
 msgstr "Приховати головний віджет"
 
-#: src/option.c:126 src/option.c:378 src/option.c:654 src/option.c:718
+#: src/option.c:126 src/option.c:380 src/option.c:656 src/option.c:720
 msgid "[TEXT]"
 msgstr "[ТЕКСТ]"
 
@@ -370,629 +370,639 @@ msgstr "Не показувати кнопки"
 msgid "Set buttons layout type (spread, edge, start, end or center)"
 msgstr "Задати тип розміщення кнопок (spread, edge, start, end або center)"
 
-# # (розкидано, по краю, на початку, по центру)
 #: src/option.c:134
+#, fuzzy
+msgid "Set focus to the named button when dialog opens"
+msgstr "Показувати параметри діалогу о програмі"
+
+#: src/option.c:134
+#, fuzzy
+msgid "NAME"
+msgstr "[ІМ'Я]"
+
+# # (розкидано, по краю, на початку, по центру)
+#: src/option.c:136
 msgid "Don't use pango markup language in dialog's text"
 msgstr "Не використовувати розмітку pango в тексті"
 
-#: src/option.c:136
+#: src/option.c:138
 msgid "Don't close dialog if Escape was pressed"
 msgstr "Не закривати діалог, якшо натиснуто Escape"
 
-#: src/option.c:138
+#: src/option.c:140
 msgid "Escape acts like OK button"
 msgstr "Escape працює як натискання OK"
 
-#: src/option.c:140
+#: src/option.c:142
 msgid "Set window borders"
 msgstr "Встановити межі вікна"
 
-#: src/option.c:142
+#: src/option.c:144
 msgid "Always print result"
 msgstr "Завжди виводити результат"
 
-#: src/option.c:144
+#: src/option.c:146
 msgid "Set default return code"
 msgstr "Задати типове значення відповіді"
 
-#: src/option.c:146
+#: src/option.c:148
 msgid "Dialog text can be selected"
 msgstr "Текст діалогу може буди виділеним"
 
-#: src/option.c:148
+#: src/option.c:150
 msgid "Don't scale icons"
 msgstr "Не масштабувати піктограми"
 
-#: src/option.c:150
+#: src/option.c:152
 #, c-format
 msgid "Run commands under specified interpreter (default: bash -c '%s')"
 msgstr ""
 "Запускати команди під визначеним інтерпретатором (типово: bash -c '%s')"
 
-#: src/option.c:150 src/option.c:152 src/option.c:154 src/option.c:205
-#: src/option.c:312 src/option.c:362 src/option.c:366 src/option.c:412
-#: src/option.c:511 src/option.c:513 src/option.c:515 src/option.c:601
+#: src/option.c:152 src/option.c:154 src/option.c:156 src/option.c:207
+#: src/option.c:314 src/option.c:364 src/option.c:368 src/option.c:414
+#: src/option.c:513 src/option.c:515 src/option.c:517 src/option.c:603
 msgid "CMD"
 msgstr "КОМАНДА"
 
-#: src/option.c:152
+#: src/option.c:154
 msgid "Set URI handler"
 msgstr "Задати команду-обробник URI"
 
-#: src/option.c:154
+#: src/option.c:156
 msgid "Set command running when F1 was pressed"
 msgstr "Задати команду, що стартує по F1"
 
-#: src/option.c:156
+#: src/option.c:158
 msgid "Set working directory"
 msgstr "Задати робочій каталог"
 
-#: src/option.c:156 src/option.c:782
+#: src/option.c:158 src/option.c:784
 msgid "PATH"
 msgstr "ШЛЯХ"
 
-#: src/option.c:159
+#: src/option.c:161
 msgid "Set window sticky"
 msgstr "Вікно на всіх стільницях"
 
-#: src/option.c:161
+#: src/option.c:163
 msgid "Set window unresizable"
 msgstr "Незмінний розмір вікна"
 
-#: src/option.c:163
+#: src/option.c:165
 msgid "Place window on top"
 msgstr "Розташувати вікно над іншими"
 
-#: src/option.c:165
+#: src/option.c:167
 msgid "Place window on center of screen"
 msgstr "Розташувати вікно по центру екрана"
 
-#: src/option.c:167
+#: src/option.c:169
 msgid "Place window at the mouse position"
 msgstr "Розташувати вікно в положенні мишки"
 
-#: src/option.c:169
+#: src/option.c:171
 msgid "Set window undecorated"
 msgstr "Прибрати декорації вікна"
 
-#: src/option.c:171
+#: src/option.c:173
 msgid "Don't show window in taskbar"
 msgstr "Не показувати вікна в панелі завдань"
 
-#: src/option.c:173
+#: src/option.c:175
 msgid "Set window maximized"
 msgstr "Задати вікну максимальний розмір"
 
-#: src/option.c:175
+#: src/option.c:177
 msgid "Set window fullscreen"
 msgstr "Розгорнути вікно на весь екран"
 
-#: src/option.c:177
+#: src/option.c:179
 msgid "Don't focus dialog window"
 msgstr "Не надавати фокус вікну діалогу"
 
-#: src/option.c:179
+#: src/option.c:181
 msgid "Close window when it sets unfocused"
 msgstr "Закрити вікно при втраті фокусу"
 
-#: src/option.c:182
+#: src/option.c:184
 msgid "Open window as a splashscreen (Deprecated, see man page for details)"
 msgstr "Відкрити вікно як початковий екран (Застаріло)"
 
-#: src/option.c:185
+#: src/option.c:187
 msgid "Specify the window type for the dialog"
 msgstr "Задати тип вікна діалога"
 
-#: src/option.c:187
+#: src/option.c:189
 msgid "Special type of dialog for XEMBED"
 msgstr "Особливий режим діалогу для вбудовування"
 
-#: src/option.c:187 src/option.c:239
+#: src/option.c:189 src/option.c:241
 msgid "KEY"
 msgstr "КЛЮЧ"
 
-#: src/option.c:189
+#: src/option.c:191
 msgid "Tab number of this dialog"
 msgstr "Номер вкладки для цього діалогу"
 
-#: src/option.c:192
+#: src/option.c:194
 msgid "Send SIGNAL to parent"
 msgstr "Послати СИГНАЛ батьківському процесу"
 
-#: src/option.c:192
+#: src/option.c:194
 msgid "[SIGNAL]"
 msgstr "[СИГНАЛ]"
 
-#: src/option.c:194
+#: src/option.c:196
 msgid "Print X Window Id to the file/stderr"
 msgstr "Вивести ідентифікатор вікна в файл/stderr"
 
-#: src/option.c:194 src/option.c:324
+#: src/option.c:196 src/option.c:326
 msgid "[FILENAME]"
 msgstr "[НАЗВА ФАЙЛУ]"
 
-#: src/option.c:201
+#: src/option.c:203
 msgid "Set the format for the returned date"
 msgstr "Задати формат відображення дати"
 
-#: src/option.c:201 src/option.c:453
+#: src/option.c:203 src/option.c:455
 msgid "PATTERN"
 msgstr "ШАБЛОН"
 
-#: src/option.c:203
+#: src/option.c:205
 msgid "Set presicion of floating numbers (default - 3)"
 msgstr "Задати точність чисел з рухомою комою (типово - 3)"
 
-#: src/option.c:205
+#: src/option.c:207
 msgid "Set command handler"
 msgstr "Задати команду-обробник"
 
-#: src/option.c:207
+#: src/option.c:209
 msgid "Listen for data on stdin"
 msgstr "Читати дані зі стандартного вводу"
 
-#: src/option.c:209
+#: src/option.c:211
 msgid "Set common separator character"
 msgstr "Встановити загальний розділювач"
 
-#: src/option.c:209 src/option.c:211
+#: src/option.c:211 src/option.c:213
 msgid "SEPARATOR"
 msgstr "РОЗДІЛЮВАЧ"
 
-#: src/option.c:211
+#: src/option.c:213
 msgid "Set item separator character"
 msgstr "Встановити розділювач для елементів"
 
-#: src/option.c:213
+#: src/option.c:215
 msgid "Allow changes to text in some cases"
 msgstr "Дозволити змінювати текст у деяких режимах"
 
-#: src/option.c:215
+#: src/option.c:217
 msgid "Autoscroll to end of text"
 msgstr "Автопрокрутка в кінець тексту"
 
-#: src/option.c:217
+#: src/option.c:219
 msgid "Autoscroll to end of text (alias to tail)"
 msgstr "Автопрокрутка в кінець тексту (синонім до tail)"
 
-#: src/option.c:219
+#: src/option.c:221
 msgid "Quote dialogs output"
 msgstr "Виводити значення у лапках"
 
-#: src/option.c:221
+#: src/option.c:223
 msgid "Output number instead of text for combo-box"
 msgstr "Виводити число замість тексту для списку значень"
 
-#: src/option.c:223
+#: src/option.c:225
 msgid "Specify font name to use"
 msgstr "Задати ім'я використовуємого шрифту"
 
-#: src/option.c:223
+#: src/option.c:225
 msgid "FONTNAME"
 msgstr "НАЗВА_ШРИФТУ"
 
-#: src/option.c:225
+#: src/option.c:227
 msgid "Allow multiple selection"
 msgstr "Дозволити вибір декількох елементів"
 
-#: src/option.c:227
+#: src/option.c:229
 msgid "Enable preview"
 msgstr "Додати попередній перегляд"
 
-#: src/option.c:229
+#: src/option.c:231
 msgid "Use large preview"
 msgstr "Використовувати крупний розмір зображень попереднього перегляду"
 
-#: src/option.c:231
+#: src/option.c:233
 msgid "Show hidden files in file selection dialogs"
 msgstr "Відобразити скриті файли у діалозі вибору файла"
 
-#: src/option.c:233
+#: src/option.c:235
 msgid "Set source filename"
 msgstr "Задати ім'я файлу"
 
-#: src/option.c:233 src/option.c:308 src/option.c:775 src/option.c:790
+#: src/option.c:235 src/option.c:310 src/option.c:777 src/option.c:792
 msgid "FILENAME"
 msgstr "НАЗВА ФАЙЛУ"
 
-#: src/option.c:235
+#: src/option.c:237
 msgid "Set mime type of input data"
 msgstr "Задати тип mime для вхідних даних"
 
-#: src/option.c:237
+#: src/option.c:239
 msgid "Set vertical orientation"
 msgstr "Викорістовувати вертикальну орієнтацію"
 
-#: src/option.c:239
+#: src/option.c:241
 msgid "Identifier of embedded dialogs"
 msgstr "Ідентифікатор діалогів що вбудовуваються"
 
-#: src/option.c:241
+#: src/option.c:243
 msgid "Set extended completion for entries (any, all, or regex)"
 msgstr "Задати розширене доповнення для текстових полів (any, all або regex)"
 
-#: src/option.c:243
+#: src/option.c:245
 msgid "Set type of output for boolean values (T, t, Y, y, O, o, 1)"
 msgstr "Задати тип виводу булєвских значень (T, t, Y, y, O, o, 1)"
 
-#: src/option.c:245
+#: src/option.c:247
 msgid "Make main widget scrollable"
 msgstr "Додати прокрутку до основного віджету"
 
-#: src/option.c:247
+#: src/option.c:249
 msgid "Disable search in text and html dialogs"
 msgstr "Заборонити пошук у ділогах text та html"
 
-#: src/option.c:249
+#: src/option.c:251
 msgid "Enable file operations"
 msgstr "Дозволити файлові операції"
 
-#: src/option.c:252
+#: src/option.c:254
 msgid "Use IEC (base 1024) units with for size values"
 msgstr "Використовувати формат IEC (база 1024) для розмірів даних"
 
-#: src/option.c:256
+#: src/option.c:258
 msgid "Enable spell check for text"
 msgstr "Дозволити перевірку правопису"
 
-#: src/option.c:258
+#: src/option.c:260
 msgid "Set spell checking language"
 msgstr "Задати мову для перевірки правопису"
 
-#: src/option.c:258
+#: src/option.c:260
 msgid "LANGUAGE"
 msgstr "МОВА"
 
-#: src/option.c:265
+#: src/option.c:267
 msgid "Display about dialog"
 msgstr "Відобразити діалог о програмі"
 
-#: src/option.c:267
+#: src/option.c:269
 msgid "Set application name"
 msgstr "Задати ім'я програми"
 
-#: src/option.c:267 src/option.c:269 src/option.c:271 src/option.c:281
-#: src/option.c:429 src/option.c:431 src/option.c:529 src/option.c:531
-#: src/option.c:558 src/option.c:574 src/option.c:772
+#: src/option.c:269 src/option.c:271 src/option.c:273 src/option.c:283
+#: src/option.c:431 src/option.c:433 src/option.c:531 src/option.c:533
+#: src/option.c:560 src/option.c:576 src/option.c:774
 msgid "STRING"
 msgstr "РЯДОК"
 
-#: src/option.c:269
+#: src/option.c:271
 msgid "Set application version"
 msgstr "Задати версію програми"
 
-#: src/option.c:271
+#: src/option.c:273
 msgid "Set application copyright string"
 msgstr "Задати авторські права програми"
 
-#: src/option.c:273
+#: src/option.c:275
 msgid "Set application comments string"
 msgstr "Задати коментарій до програми"
 
-#: src/option.c:275
+#: src/option.c:277
 msgid "Set application license"
 msgstr "Задати ліцензію програми"
 
-#: src/option.c:277
+#: src/option.c:279
 msgid "Set application authors"
 msgstr "Задати авторів програми"
 
-#: src/option.c:277 src/option.c:485 src/option.c:489 src/option.c:493
+#: src/option.c:279 src/option.c:487 src/option.c:491 src/option.c:495
 msgid "LIST"
 msgstr "СПИСОК"
 
-#: src/option.c:279
+#: src/option.c:281
 msgid "Set application website"
 msgstr "Задати ведсайт програми"
 
-#: src/option.c:279
+#: src/option.c:281
 msgid "URI"
 msgstr "ЗСИЛКА"
 
-#: src/option.c:281
+#: src/option.c:283
 msgid "Set application website label"
 msgstr "Задати позначку вебсайту програми"
 
-#: src/option.c:287
+#: src/option.c:289
 msgid "Display application selection dialog"
 msgstr "Відобразити діалог для вибору додатку"
 
-#: src/option.c:289
+#: src/option.c:291
 msgid "Show fallback applications"
 msgstr "Показувати зарезервовані додатки"
 
-#: src/option.c:291
+#: src/option.c:293
 msgid "Show other applications"
 msgstr "Показувати інші додатки"
 
-#: src/option.c:293
+#: src/option.c:295
 msgid "Show all applications"
 msgstr "Показувати всі додатки"
 
-#: src/option.c:295
+#: src/option.c:297
 msgid "Output all application data"
 msgstr "Виводити розширені дані о додатку"
 
-#: src/option.c:300
+#: src/option.c:302
 msgid "Display calendar dialog"
 msgstr "Відобразити діалог для вибору дати"
 
-#: src/option.c:302
+#: src/option.c:304
 msgid "Set the calendar day"
 msgstr "Задати календарний день"
 
-#: src/option.c:302
+#: src/option.c:304
 msgid "DAY"
 msgstr "ДЕНЬ"
 
-#: src/option.c:304
+#: src/option.c:306
 msgid "Set the calendar month"
 msgstr "Задати календарний місяць"
 
-#: src/option.c:304
+#: src/option.c:306
 msgid "MONTH"
 msgstr "МІСЯЦЬ"
 
-#: src/option.c:306
+#: src/option.c:308
 msgid "Set the calendar year"
 msgstr "Задати календарний рік"
 
-#: src/option.c:306
+#: src/option.c:308
 msgid "YEAR"
 msgstr "РІК"
 
-#: src/option.c:308
+#: src/option.c:310
 msgid "Set the filename with dates details"
 msgstr "Задати назву файлу з описом дат"
 
-#: src/option.c:310
+#: src/option.c:312
 msgid "Show week numbers at the left side of calendar"
 msgstr "Відобразити нумерацію тижднів зліва"
 
-#: src/option.c:312 src/option.c:513
+#: src/option.c:314 src/option.c:515
 msgid "Set select action"
 msgstr "Дія при виділенні стрічки"
 
-#: src/option.c:318
+#: src/option.c:320
 msgid "Display color selection dialog"
 msgstr "Відобразити діалог для вибору кольору"
 
-#: src/option.c:320
+#: src/option.c:322
 msgid "Set initial color value"
 msgstr "Задати початковий колір"
 
-#: src/option.c:320 src/option.c:704 src/option.c:706 src/option.c:712
-#: src/option.c:735 src/option.c:737
+#: src/option.c:322 src/option.c:706 src/option.c:708 src/option.c:714
+#: src/option.c:737 src/option.c:739
 msgid "COLOR"
 msgstr "КОЛІР"
 
-#: src/option.c:322
+#: src/option.c:324
 msgid "Show system palette in color dialog"
 msgstr "Відобразити системну палітру"
 
-#: src/option.c:324
+#: src/option.c:326
 msgid "Set path to palette file. Default - "
 msgstr "Задати шлях до файлу палітри. Типово - "
 
-#: src/option.c:326
+#: src/option.c:328
 msgid "Expand user palette"
 msgstr "Розкривати палітру користувача"
 
-#: src/option.c:328
+#: src/option.c:330
 msgid "Show color picker"
 msgstr "Показувати кнопку вибору коліру"
 
-#: src/option.c:330
+#: src/option.c:332
 msgid "Set output mode to MODE. Values are hex (default) or rgb"
 msgstr "Встановити режим виводу в РЕЖИМ. Значення: hex (типово) або rgb"
 
-#: src/option.c:330
+#: src/option.c:332
 msgid "MODE"
 msgstr "РЕЖИМ"
 
-#: src/option.c:332
+#: src/option.c:334
 msgid "Add opacity to output color value"
 msgstr "Додати прозорість до значення кольору"
 
-#: src/option.c:338
+#: src/option.c:340
 msgid "Display drag-n-drop box"
 msgstr "Відобразити діалог для перехоплення dnd"
 
-#: src/option.c:340
+#: src/option.c:342
 msgid "Use dialog text as tooltip"
 msgstr "Використовувати текст діалогу в якості підказки"
 
-#: src/option.c:342
+#: src/option.c:344
 msgid "Exit after NUMBER of drops"
 msgstr "Вихід після певної кількості спрацювань"
 
-#: src/option.c:348
+#: src/option.c:350
 msgid "Display text entry or combo-box dialog"
 msgstr "Відобразити діалог для вводу тексту або вибору варіанта"
 
-#: src/option.c:350
+#: src/option.c:352
 msgid "Set the entry label"
 msgstr "Задати мітку поля вводу"
 
-#: src/option.c:352
+#: src/option.c:354
 msgid "Set the entry text"
 msgstr "Задати текст для поля вводу"
 
-#: src/option.c:354
+#: src/option.c:356
 msgid "Hide the entry text"
 msgstr "Приховати введений текст (Пароль)"
 
-#: src/option.c:356
+#: src/option.c:358
 msgid "Use completion instead of combo-box"
 msgstr "Використовувати автозаповнення замість списку значень"
 
-#: src/option.c:358
+#: src/option.c:360
 msgid "Use spin button for text entry"
 msgstr "Використовувати числове поле замість тексту"
 
-#: src/option.c:360
+#: src/option.c:362
 msgid "Set the left entry icon"
 msgstr "Задати ліву піктограму"
 
-#: src/option.c:362
+#: src/option.c:364
 msgid "Set the left entry icon action"
 msgstr "Дія для лівої піктограми"
 
-#: src/option.c:364
+#: src/option.c:366
 msgid "Set the right entry icon"
 msgstr "Задати праву піктограму"
 
-#: src/option.c:366
+#: src/option.c:368
 msgid "Set the right entry icon action"
 msgstr "Дія для правої піктограми"
 
-#: src/option.c:372
+#: src/option.c:374
 msgid "Display file selection dialog"
 msgstr "Відобразити діалог для вибору файла"
 
-#: src/option.c:374
+#: src/option.c:376
 msgid "Activate directory-only selection"
 msgstr "Активувати виділення тільки по каталогах"
 
-#: src/option.c:376
+#: src/option.c:378
 msgid "Activate save mode"
 msgstr "Активувати режим зберігання"
 
-#: src/option.c:378
+#: src/option.c:380
 msgid "Confirm file selection if filename already exists"
 msgstr "Підтвердити вибір файлу, якщо файл вже існує"
 
-#: src/option.c:384
+#: src/option.c:386
 msgid "Display font selection dialog"
 msgstr "Відобразити діалог для вибору шрифту"
 
-#: src/option.c:386
+#: src/option.c:388
 msgid "Set text string for preview"
 msgstr "Задати текстову стрічку для передогляду"
 
-#: src/option.c:388
+#: src/option.c:390
 msgid "Separate output of font description"
 msgstr "Розділяти вивід описа шрифта"
 
-#: src/option.c:394
+#: src/option.c:396
 msgid "Display form dialog"
 msgstr "Відобразити діалог форми вводу"
 
-#: src/option.c:396
+#: src/option.c:398
 msgid "Add field to form (see man page for list of possible types)"
 msgstr ""
 "Додати поле до форми (дивись сторінку керівництва для отримання списку "
 "можливих типів)"
 
-#: src/option.c:396 src/option.c:631
+#: src/option.c:398 src/option.c:633
 msgid "LABEL[:TYPE]"
 msgstr "МІТКА[:ТИП]"
 
-#: src/option.c:398
+#: src/option.c:400
 msgid "Set alignment of filed labels (left, center or right)"
 msgstr "Задати вирівнювання міток полів (left, center або right)"
 
-#: src/option.c:400
+#: src/option.c:402
 msgid "Set number of columns in form"
 msgstr "Задати кількість стовпчиків у формі"
 
-#: src/option.c:402
+#: src/option.c:404
 msgid "Make form fields height and columns width the same size"
 msgstr "Зробити висоту та ширину рядків однакового розміру"
 
-#: src/option.c:404
+#: src/option.c:406
 msgid "Order output fields by rows"
 msgstr "Упорядкувати виведення по рядках"
 
-#: src/option.c:406
+#: src/option.c:408
 msgid "Set focused field"
 msgstr "Задати поле що отримує фокус"
 
-#: src/option.c:408
+#: src/option.c:410
 msgid "Cycled reading of stdin data"
 msgstr "Циклічне читання зі стандартного вводу"
 
-#: src/option.c:410
+#: src/option.c:412
 msgid "Align labels on button fields"
 msgstr "Вирівнювати помітки на полях-кнопках"
 
-#: src/option.c:412
+#: src/option.c:414
 msgid "Set changed action"
 msgstr "Дія при зміні поля"
 
-#: src/option.c:419
+#: src/option.c:421
 msgid "Display HTML dialog"
 msgstr "Відобразити HTML діалог"
 
-#: src/option.c:421
+#: src/option.c:423
 msgid "Open specified location"
 msgstr "Відкрити вказану адресу"
 
-#: src/option.c:423
+#: src/option.c:425
 msgid "Turn on browser mode"
 msgstr "Ввімкнути режим навігатора"
 
-#: src/option.c:425
+#: src/option.c:427
 msgid "Print clicked uri to stdout"
 msgstr "Друкувати натиснуті зсилки"
 
-#: src/option.c:427
+#: src/option.c:429
 msgid "Set encoding of input stream data"
 msgstr "Задати кодування для вхідних даних"
 
-#: src/option.c:427
+#: src/option.c:429
 msgid "ENCODING"
 msgstr "КОДУВАННЯ"
 
-#: src/option.c:429
+#: src/option.c:431
 msgid "Set user agent string"
 msgstr "Задати стрічку агента"
 
-#: src/option.c:431
+#: src/option.c:433
 msgid "Set custom user style"
 msgstr "Задати стиль користувача"
 
-#: src/option.c:433
+#: src/option.c:435
 msgid "Set WebKit property"
 msgstr "Задати властивість WebKit"
 
-#: src/option.c:433
+#: src/option.c:435
 msgid "PROP"
 msgstr "ВЛАСТИВІСТЬ"
 
-#: src/option.c:440
+#: src/option.c:442
 msgid "Display icons box dialog"
 msgstr "Відобразити діалог з піктограмами швидкого доступу"
 
-#: src/option.c:442
+#: src/option.c:444
 msgid "Read data from .desktop files in specified directory"
 msgstr "Читати дані з файлів .desktop у вказаному каталозі"
 
-#: src/option.c:442
+#: src/option.c:444
 msgid "DIR"
 msgstr "КАТАЛОГ"
 
-#: src/option.c:444
+#: src/option.c:446
 msgid "Use compact (list) view"
 msgstr "Використовувати компактний вигляд (список)"
 
-#: src/option.c:446
+#: src/option.c:448
 msgid "Use GenericName field instead of Name for icon label"
 msgstr "Використовувати поле GenericName замість Name для назви піктограми"
 
-#: src/option.c:448
+#: src/option.c:450
 msgid "Set the width of dialog items"
 msgstr "Задати ширину елемента діалогу"
 
-#: src/option.c:450
+#: src/option.c:452
 msgid "Force using specified icon size"
 msgstr "Примусово використовувати визначений розмір піктограми"
 
-#: src/option.c:450 src/option.c:564 src/option.c:700 src/tools.c:85
+#: src/option.c:452 src/option.c:566 src/option.c:702 src/tools.c:85
 msgid "SIZE"
 msgstr "РОЗМІР"
 
-#: src/option.c:453
+#: src/option.c:455
 #, no-c-format
 msgid ""
 "Use specified pattern for launch command in terminal (default: xterm -e %s)"
@@ -1000,86 +1010,86 @@ msgstr ""
 "Використовувати визначений шаблон для запуску команди в терміналі (типово: "
 "xterm -e %s)"
 
-#: src/option.c:455
+#: src/option.c:457
 msgid "Sort items by name instead of filename"
 msgstr "Сортувати по полю Назва замість назви файлу"
 
-#: src/option.c:457
+#: src/option.c:459
 msgid "Sort items in descending order"
 msgstr "Сортувати в порядку спадання"
 
-#: src/option.c:459
+#: src/option.c:461
 msgid "Activate items by single click"
 msgstr "Активувати елемент одним натисненням"
 
-#: src/option.c:461
+#: src/option.c:463
 msgid "Watch fot changes in directory"
 msgstr "Слідкувати за змінами в каталозі"
 
-#: src/option.c:467
+#: src/option.c:469
 msgid "Display list dialog"
 msgstr "Відобразити діалог зі списком"
 
-#: src/option.c:469
+#: src/option.c:471
 msgid "Set the column header (see man page for list of possible types)"
 msgstr ""
 "Задати заголовок стовпчика (дивись сторінку керівництва для отримання списку "
 "типів)"
 
-#: src/option.c:469
+#: src/option.c:471
 msgid "COLUMN[:TYPE]"
 msgstr "СТОВПЧИК[:ТИП]"
 
-#: src/option.c:471
+#: src/option.c:473
 msgid "Enbale tree mode"
 msgstr "Режим дерева"
 
-#: src/option.c:473
+#: src/option.c:475
 msgid "Use checkboxes for first column"
 msgstr "Використовувати відмітки для першого стовпчика"
 
-#: src/option.c:475
+#: src/option.c:477
 msgid "Use radioboxes for first column"
 msgstr "Використовувати перемикач для першого стовпчика"
 
-#: src/option.c:477
+#: src/option.c:479
 msgid "Don't show column headers"
 msgstr "Не показувати заголовки стовпчиків"
 
-#: src/option.c:479
+#: src/option.c:481
 msgid "Disable clickable column headers"
 msgstr "Заборонити натискати на заголовок"
 
-#: src/option.c:481
+#: src/option.c:483
 msgid "Set grid lines (hor[izontal], vert[ical] or both)"
 msgstr "Задати роздільні лінії (hor[izontal], vert[ical] або both)"
 
-#: src/option.c:483
+#: src/option.c:485
 msgid "Print all data from list"
 msgstr "Виводити таблицю повністю"
 
-#: src/option.c:485
+#: src/option.c:487
 msgid "Set the list of editable columns"
 msgstr "Задати список стопчиків для редагування"
 
-#: src/option.c:487
+#: src/option.c:489
 msgid "Set the width of a column for start wrapping text"
 msgstr "Задати ширину стовпчика для переносу тексту"
 
-#: src/option.c:489
+#: src/option.c:491
 msgid "Set the list of wrapped columns"
 msgstr "Задати список стовпчиків для переносу"
 
-#: src/option.c:491
+#: src/option.c:493
 msgid "Set ellipsize mode for text columns (none, start, middle or end)"
 msgstr ""
 "Задати тип урізання для текстових стовпчиків (none, start, middle або end)"
 
-#: src/option.c:493
+#: src/option.c:495
 msgid "Set the list of ellipsized columns"
 msgstr "Задати список стовпчиків для урізання"
 
-#: src/option.c:495
+#: src/option.c:497
 msgid ""
 "Print a specific column. By default or if 0 is specified will be printed all "
 "columns"
@@ -1087,814 +1097,814 @@ msgstr ""
 "Виводити визначений стовпчик. Типово, або якщо вказано 0, будуть виведені "
 "усі стовпчики"
 
-#: src/option.c:497
+#: src/option.c:499
 msgid "Hide a specific column"
 msgstr "Сховати вказаний стовпчик"
 
-#: src/option.c:499
+#: src/option.c:501
 msgid "Set the column expandable by default. 0 sets all columns expandable"
 msgstr "Задати стовпчик, який типово розширюється. 0 розширює всі стовпчики"
 
-#: src/option.c:501
+#: src/option.c:503
 msgid ""
 "Set the quick search column. Default is first column. Set it to 0 for "
 "disable searching"
 msgstr ""
 "Задати стовпчик швидкого пошуку. Типово це перший стовпчик. 0 забороняє пошук"
 
-#: src/option.c:503
+#: src/option.c:505
 msgid "Set the tooltip column"
 msgstr "Задати стовпчик підказок"
 
-#: src/option.c:505
+#: src/option.c:507
 msgid "Set the row separator column"
 msgstr "Задати стовпчик розділювача стрічок"
 
-#: src/option.c:507
+#: src/option.c:509
 msgid "Set the row separator value"
 msgstr "Задати значення розділювача стрічок"
 
-#: src/option.c:509
+#: src/option.c:511
 msgid "Set the limit of rows in list"
 msgstr "Задати кількість рядків у списку"
 
-#: src/option.c:511
+#: src/option.c:513
 msgid "Set double-click action"
 msgstr "Дія для подвійного натискання мишки"
 
-#: src/option.c:515
+#: src/option.c:517
 msgid "Set row action"
 msgstr "Дія над стрічкою"
 
-#: src/option.c:517
+#: src/option.c:519
 msgid "Expand all tree nodes"
 msgstr "Розгорнути всі гілки дерева"
 
-#: src/option.c:519
+#: src/option.c:521
 msgid "Use regex in search"
 msgstr "Використовувати регулярні вирази в пошуку"
 
-#: src/option.c:521
+#: src/option.c:523
 msgid "Disable selection"
 msgstr "Заборонити виділення"
 
-#: src/option.c:523
+#: src/option.c:525
 msgid "Add new records on the top of a list"
 msgstr "Додавати нові стрічки на початку таблиці"
 
-#: src/option.c:525
+#: src/option.c:527
 msgid "Don't use markup in tooltips"
 msgstr "Не використовувати розмітку у підказках"
 
-#: src/option.c:527
+#: src/option.c:529
 msgid "Use column name as a header tooltip"
 msgstr "Використовувати ім'я стовпчика як текст підказки"
 
-#: src/option.c:529
+#: src/option.c:531
 msgid "Set columns alignment"
 msgstr "Задати вирівнювання стовпчиків"
 
-#: src/option.c:531
+#: src/option.c:533
 msgid "Set headers alignment"
 msgstr "Задати вирівнювання заголовків"
 
-#: src/option.c:537
+#: src/option.c:539
 msgid "Display notebook dialog"
 msgstr "Відобразити діалог із вкладинками"
 
-#: src/option.c:539
+#: src/option.c:541
 msgid "Add a tab to notebook"
 msgstr "Додати вкладку"
 
-#: src/option.c:539
+#: src/option.c:541
 msgid "LABEL"
 msgstr "МІТКА"
 
-#: src/option.c:541
+#: src/option.c:543
 msgid "Set position of a notebook tabs (top, bottom, left or right)"
 msgstr "Задати позицію ярлика вкладки (top, bottom, left, або right)"
 
-#: src/option.c:543
+#: src/option.c:545
 msgid "Set tab borders"
 msgstr "Задати межі вкладок"
 
-#: src/option.c:545
+#: src/option.c:547
 msgid "Set active tab"
 msgstr "Задати активну вкладку"
 
-#: src/option.c:547
+#: src/option.c:549
 msgid "Expand tabs"
 msgstr "Розширювати вкладки"
 
-#: src/option.c:549
+#: src/option.c:551
 msgid "Use stack mode"
 msgstr "Використовувати режим стеку"
 
-#: src/option.c:556
+#: src/option.c:558
 msgid "Display notification"
 msgstr "Відобразити діалог повідомлень"
 
-#: src/option.c:558 src/option.c:574
+#: src/option.c:560 src/option.c:576
 msgid "Set initial popup menu"
 msgstr "Задати початкове меню"
 
-#: src/option.c:560
+#: src/option.c:562
 msgid "Disable exit on middle click"
 msgstr "Заборонити вихід середньою кнопкою мишки"
 
-#: src/option.c:562 src/option.c:576
+#: src/option.c:564 src/option.c:578
 msgid "Doesn't show icon at startup"
 msgstr "Не показувати піктограму при старті"
 
-#: src/option.c:564
+#: src/option.c:566
 msgid "Set icon size for fully specified icons (default - 16)"
 msgstr ""
 "Задати розмір піктограми для повністю визначених піктограм (типово - 16)"
 
-#: src/option.c:572
+#: src/option.c:574
 msgid "Display indicator icon (StatusNotifier/AppIndicator)"
 msgstr "Відобразити піктограму додатку"
 
-#: src/option.c:583
+#: src/option.c:585
 msgid "Display paned dialog"
 msgstr "Відобразити діалог з панелями"
 
-#: src/option.c:585
+#: src/option.c:587
 msgid "Set orientation (hor[izontal] or vert[ical])"
 msgstr "Задати оріентицію (hor[izontal] або vert[ical])"
 
-#: src/option.c:587
+#: src/option.c:589
 msgid "Set initial splitter position"
 msgstr "Задати початкову позицію розділювача"
 
-#: src/option.c:589
+#: src/option.c:591
 msgid "Set focused pane (1 or 2)"
 msgstr "Задати панель що отримує фокус"
 
-#: src/option.c:589
+#: src/option.c:591
 msgid "PANE"
 msgstr "ПАНЕЛЬ"
 
-#: src/option.c:595
+#: src/option.c:597
 msgid "Display picture dialog"
 msgstr "Відобразити діалог з картинкою"
 
-#: src/option.c:597
+#: src/option.c:599
 msgid "Set initial size (fit or orig)"
 msgstr "Задати початковий розмір картинки"
 
-#: src/option.c:599
+#: src/option.c:601
 msgid "Set increment for picture scaling (default - 5)"
 msgstr "Задати інкремент для зміни розміру картинки (типово - 5)"
 
-#: src/option.c:601
+#: src/option.c:603
 msgid "Set action on image changing"
 msgstr "Задати команду при зиміні зображення"
 
-#: src/option.c:607
+#: src/option.c:609
 msgid "Display popup dialog"
 msgstr "Відобразити спливаючий діалог"
 
-#: src/option.c:609
+#: src/option.c:611
 msgid "Set alignment of title and text (left, center or right)"
 msgstr "Задати вирівнювання для заголовка та тексту (left, center або right)"
 
-#: src/option.c:611
+#: src/option.c:613
 msgid "Set transparency"
 msgstr "Задати прозорість"
 
-#: src/option.c:611
+#: src/option.c:613
 msgid "PERCENT"
 msgstr "ПРОЦЕНТ"
 
-#: src/option.c:613
+#: src/option.c:615
 msgid "Don't close popup by timeout"
 msgstr "Не закривати діалог по часу"
 
-#: src/option.c:619
+#: src/option.c:621
 msgid "Display printing dialog"
 msgstr "Відобразити діалог друку"
 
-#: src/option.c:621
+#: src/option.c:623
 msgid "Set source type (text, image or raw)"
 msgstr "Задати тип даних (text, image або raw)"
 
-#: src/option.c:623
+#: src/option.c:625
 msgid "Add headers to page"
 msgstr "Додати колонтитули до сторінки"
 
-#: src/option.c:629
+#: src/option.c:631
 msgid "Display progress indication dialog"
 msgstr "Відобразити діалог прогресу"
 
-#: src/option.c:631
+#: src/option.c:633
 msgid "Add the progress bar (norm, rtl, pulse, cpulse or perm)"
 msgstr "Додати індикатор виконання (norm, rtl, pulse, cpulse або perm)"
 
-#: src/option.c:633
+#: src/option.c:635
 msgid "Watch for specific bar for auto close"
 msgstr "Слідкувати за певним індикатором для автозакриття"
 
-#: src/option.c:635
+#: src/option.c:637
 msgid "Set alignment of bar labels (left, center or right)"
 msgstr "Задати вирівнювання міток індикаторів (left, center або right)"
 
-#: src/option.c:637
+#: src/option.c:639
 msgid "Set progress text"
 msgstr "Показувати текст на індикаторі"
 
-#: src/option.c:639
+#: src/option.c:641
 msgid "Hide text on progress bar"
 msgstr "Сховати текст на індикаторі"
 
-#: src/option.c:641
+#: src/option.c:643
 msgid "Pulsate progress bar"
 msgstr "Пульсуючий індикатор виконання"
 
-#: src/option.c:643
+#: src/option.c:645
 msgid "Conlinuous pulsating progress bar"
 msgstr "Постійно пульсуючий індикатор виконання"
 
-#: src/option.c:646
+#: src/option.c:648
 #, no-c-format
 msgid "Dismiss the dialog when 100% has been reached"
 msgstr "Закрити діалог по досягненні 100%"
 
-#: src/option.c:649
+#: src/option.c:651
 msgid "Kill parent process if cancel button is pressed"
 msgstr "Завершити батьківський процес, якщо натиснута кнопка відміни"
 
-#: src/option.c:652
+#: src/option.c:654
 msgid "Right-To-Left progress bar direction"
 msgstr "Напрямок індикатору Справа-Наліво"
 
-#: src/option.c:654
+#: src/option.c:656
 msgid "Show log window"
 msgstr "Відобразити вікно журналу"
 
-#: src/option.c:656
+#: src/option.c:658
 msgid "Expand log window"
 msgstr "Розгорнути вікно журналу"
 
-#: src/option.c:658
+#: src/option.c:660
 msgid "Place log window above progress bar"
 msgstr "Розмістити вікно жуналу поверх індикатора виконання"
 
-#: src/option.c:660
+#: src/option.c:662
 msgid "Height of log window"
 msgstr "Висота вікна журналу"
 
-#: src/option.c:666
+#: src/option.c:668
 msgid "Display scale dialog"
 msgstr "Відобразити діалог масштабу"
 
-#: src/option.c:668
+#: src/option.c:670
 msgid "Set initial value"
 msgstr "Задати початкове значення"
 
-#: src/option.c:668 src/option.c:670 src/option.c:672 src/option.c:674
-#: src/option.c:678 src/option.c:745 src/option.c:747
+#: src/option.c:670 src/option.c:672 src/option.c:674 src/option.c:676
+#: src/option.c:680 src/option.c:747 src/option.c:749
 msgid "VALUE"
 msgstr "ЗНАЧЕННЯ"
 
-#: src/option.c:670
+#: src/option.c:672
 msgid "Set minimum value"
 msgstr "Задати мінімальне значення"
 
-#: src/option.c:672
+#: src/option.c:674
 msgid "Set maximum value"
 msgstr "Задати максимальне значення"
 
-#: src/option.c:674
+#: src/option.c:676
 msgid "Set step size"
 msgstr "Задати крок"
 
-#: src/option.c:676
+#: src/option.c:678
 msgid "Only allow values in step increments"
 msgstr "Дозволити переміщення тільки за кроком"
 
-#: src/option.c:678
+#: src/option.c:680
 msgid "Set paging size"
 msgstr "Задати крок сторінки"
 
-#: src/option.c:680
+#: src/option.c:682
 msgid "Print partial values"
 msgstr "Виводити часткові значення"
 
-#: src/option.c:682
+#: src/option.c:684
 msgid "Hide value"
 msgstr "Сховати значення"
 
-#: src/option.c:684
+#: src/option.c:686
 msgid "Invert direction"
 msgstr "Зворотній напрямок"
 
-#: src/option.c:686
+#: src/option.c:688
 msgid "Show +/- buttons in scale"
 msgstr "Відобразити кнопки +/-"
 
-#: src/option.c:688
+#: src/option.c:690
 msgid "Add mark to scale (may be used multiple times)"
 msgstr "Додати мітку шкали (може використовуватись декілька разів)"
 
-#: src/option.c:688
+#: src/option.c:690
 msgid "NAME:VALUE"
 msgstr "НАЗВА:ЗНАЧЕННЯ"
 
-#: src/option.c:694
+#: src/option.c:696
 msgid "Display text information dialog"
 msgstr "Відобразити діалог з текстовою інформацією"
 
-#: src/option.c:696
+#: src/option.c:698
 msgid "Enable text wrapping"
 msgstr "Дозволити перенос тексту"
 
-#: src/option.c:698
+#: src/option.c:700
 msgid "Set justification (left, right, center or fill)"
 msgstr "Встановити вирівнювання (left, right, center або fill)"
 
-#: src/option.c:700
+#: src/option.c:702
 msgid "Set text margins"
 msgstr "Встановити відступи"
 
-#: src/option.c:702
+#: src/option.c:704
 msgid "Jump to specific line"
 msgstr "Перейти на вказаний рядок"
 
-#: src/option.c:704
+#: src/option.c:706
 msgid "Use specified color for text"
 msgstr "Використовувати вказаний колір для тексту"
 
-#: src/option.c:706
+#: src/option.c:708
 msgid "Use specified color for background"
 msgstr "Використовувати вказаний колір для фону"
 
-#: src/option.c:708
+#: src/option.c:710
 msgid "Show cursor in read-only mode"
 msgstr "Відображувати курсор у режимі тільки для читання"
 
-#: src/option.c:710
+#: src/option.c:712
 msgid "Make URI clickable"
 msgstr "Зробити посилання активними"
 
-#: src/option.c:712
+#: src/option.c:714
 msgid "Use specified color for links"
 msgstr "Використовувати вказаний колір для посилань"
 
-#: src/option.c:714
+#: src/option.c:716
 msgid "Use pango markup"
 msgstr "Використовувати розмітку pango"
 
-#: src/option.c:716
+#: src/option.c:718
 msgid "Save file instead of print on exit"
 msgstr "Зберігати файл замість виводу на виході"
 
-#: src/option.c:718
+#: src/option.c:720
 msgid "Confirm save the file if text was changed"
 msgstr "Підтвердити зберігання файлу, якщо він був змінений"
 
-#: src/option.c:725
+#: src/option.c:727
 msgid "Use specified langauge for syntax highlighting"
 msgstr "Використовувати вказану мову для підсвітки синтаксису"
 
-#: src/option.c:725
+#: src/option.c:727
 msgid "LANG"
 msgstr "МОВА"
 
-#: src/option.c:727
+#: src/option.c:729
 msgid "Use specified theme"
 msgstr "Використовувати вказану тему"
 
-#: src/option.c:729
+#: src/option.c:731
 msgid "Show line numbers"
 msgstr "Відображати номера строк"
 
-#: src/option.c:731
+#: src/option.c:733
 msgid "Highlight current line"
 msgstr "Виділяти активну строку"
 
-#: src/option.c:733
+#: src/option.c:735
 msgid "Enable line marks"
 msgstr "Дозволити позначки строк"
 
-#: src/option.c:735
+#: src/option.c:737
 msgid "Set color for first type marks"
 msgstr "Задати колір для поміток першого типу"
 
-#: src/option.c:737
+#: src/option.c:739
 msgid "Set color for second type marks"
 msgstr "Задати колір для поміток другого типу"
 
-#: src/option.c:739
+#: src/option.c:741
 msgid "Set position of right margin"
 msgstr "Задати позицію правого поля"
 
-#: src/option.c:739
+#: src/option.c:741
 msgid "[POS]"
 msgstr "[ПОЗИЦІЯ]"
 
-#: src/option.c:741
+#: src/option.c:743
 msgid "Highlight matching brackets"
 msgstr "Виділяти відповідні дужки"
 
-#: src/option.c:743
+#: src/option.c:745
 msgid "Use autoindent"
 msgstr "Використовувати автовирівнювання"
 
-#: src/option.c:745
+#: src/option.c:747
 msgid "Set tabulation width"
 msgstr "Задати ширину табуляції"
 
-#: src/option.c:747
+#: src/option.c:749
 msgid "Set indentation width"
 msgstr "Задати ширину вирівнювання"
 
-#: src/option.c:749
+#: src/option.c:751
 msgid "Set smart Home/End behavior"
 msgstr "Задати поведінку розумних Home/End"
 
-#: src/option.c:751
+#: src/option.c:753
 msgid "Enable smart backspace"
 msgstr "Використовувати розумній backspace"
 
-#: src/option.c:753
+#: src/option.c:755
 msgid "Insert spaces instead of tabs"
 msgstr "Вставляти пробіл замість табуляції"
 
-#: src/option.c:760
+#: src/option.c:762
 msgid "Sets a filename filter"
 msgstr "Задати фільтр файлів по масці"
 
-#: src/option.c:760
+#: src/option.c:762
 msgid "NAME | PATTERN1 PATTERN2 ..."
 msgstr "НАЗВА | ШАБЛОН1 ШАБЛОН2 ..."
 
-#: src/option.c:762
+#: src/option.c:764
 msgid "Sets a mime-type filter"
 msgstr "Задати фільтр файлів по типу mime"
 
-#: src/option.c:762
+#: src/option.c:764
 msgid "NAME | MIME1 MIME2 ..."
 msgstr "НАЗВА | ТИП1 ТИП2 ..."
 
-#: src/option.c:764
+#: src/option.c:766
 msgid "Add filter for images"
 msgstr "Додати фільтр для зображень"
 
-#: src/option.c:764
+#: src/option.c:766
 msgid "[NAME]"
 msgstr "[ІМ'Я]"
 
-#: src/option.c:770 src/tools.c:64
+#: src/option.c:772 src/tools.c:64
 msgid "Print version"
 msgstr "Вивести версію"
 
-#: src/option.c:772
+#: src/option.c:774
 msgid "Load additional CSS settings from file or string"
 msgstr "Завантажити додаткові налаштування CSS з файлу або строки"
 
-#: src/option.c:775
+#: src/option.c:777
 msgid "Load additional CSS settings from file"
 msgstr "Завантажити додаткові налаштування CSS з файлу"
 
-#: src/option.c:778
+#: src/option.c:780
 msgid "Set policy for horizontal scrollbars (auto, always, never)"
 msgstr "Задати тип горизонтальної прокрутки (auto, always, never)"
 
-#: src/option.c:780
+#: src/option.c:782
 msgid "Set policy for vertical scrollbars (auto, always, never)"
 msgstr "Задати тип вертикальної прокрутки (auto, always, never)"
 
-#: src/option.c:782
+#: src/option.c:784
 msgid "Add path for search icons by name"
 msgstr "Додати шлях для пошуку піктограм"
 
-#: src/option.c:784
+#: src/option.c:786
 msgid "Write settings to file and exit"
 msgstr "Записати налаштування до файлу та вийти"
 
-#: src/option.c:790
+#: src/option.c:792
 msgid "Load extra arguments from file"
 msgstr "Завантажити додаткові аргументи з файлу"
 
-#: src/option.c:1001
+#: src/option.c:1003
 #, c-format
 msgid "Mark %s doesn't have a value\n"
 msgstr "Помітці %s не надано значення\n"
 
-#: src/option.c:1048 src/picture.c:286
+#: src/option.c:1050 src/picture.c:286
 msgid "Images"
 msgstr "Зображення"
 
-#: src/option.c:1113
+#: src/option.c:1115
 #, c-format
 msgid "Unknown color mode: %s\n"
 msgstr "Невідомий режим кольору: '%s'\n"
 
-#: src/option.c:1132
+#: src/option.c:1134
 #, c-format
 msgid "Unknown buttons layout type: %s\n"
 msgstr "Невідомий тип розміщення кнопок: %s\n"
 
-#: src/option.c:1147
+#: src/option.c:1149
 #, c-format
 msgid "Unknown align type: %s\n"
 msgstr "Невідомий тип вирівнювання: %s\n"
 
-#: src/option.c:1171
+#: src/option.c:1173
 #, c-format
 msgid "Unknown justification type: %s\n"
 msgstr "Невідомий тип вирівнювання: %s\n"
 
-#: src/option.c:1188
+#: src/option.c:1190
 #, c-format
 msgid "Unknown tab position type: %s\n"
 msgstr "Невідомий тип позиції вкладки: %s\n"
 
-#: src/option.c:1225
+#: src/option.c:1227
 #, c-format
 msgid "Unknown ellipsize type: %s\n"
 msgstr "Невідомий тип урізання: %s\n"
 
-#: src/option.c:1238
+#: src/option.c:1240
 #, c-format
 msgid "Unknown orientation: %s\n"
 msgstr "Невідома орієнтація: %s\n"
 
-#: src/option.c:1253
+#: src/option.c:1255
 #, c-format
 msgid "Unknown source type: %s\n"
 msgstr "Невідомий тип даних: %s\n"
 
-#: src/option.c:1264
+#: src/option.c:1266
 msgid "Progress log"
 msgstr "Вікно журналу"
 
-#: src/option.c:1277
+#: src/option.c:1279
 #, c-format
 msgid "Unknown size type: %s\n"
 msgstr "Невідомий тип розміру: %s\n"
 
-#: src/option.c:1321
+#: src/option.c:1323
 #, c-format
 msgid "Unknown completion type: %s\n"
 msgstr "Невідомий тип доповнення: %s\n"
 
-#: src/option.c:1353
+#: src/option.c:1355
 #, c-format
 msgid "Unknown boolean format type: %s\n"
 msgstr "Невідомий тип булєвських значень: %s\n"
 
-#: src/option.c:1369
+#: src/option.c:1371
 #, c-format
 msgid "Unknown grid lines type: %s\n"
 msgstr "Невідомий тип розподільних ліній: %s\n"
 
-#: src/option.c:1386
+#: src/option.c:1388
 #, c-format
 msgid "Unknown scrollbar policy type: %s\n"
 msgstr "Невідомий тип прокрутки: %s\n"
 
-#: src/option.c:1437
+#: src/option.c:1439
 #, c-format
 msgid "Unknown window type: %s\n"
 msgstr "Невідомий тип вікна: %s\n"
 
-#: src/option.c:1466
+#: src/option.c:1468
 #, c-format
 msgid "Unknown smart Home/End mode: %s\n"
 msgstr "Невідомий режим розумних Home/End: '%s'\n"
 
-#: src/option.c:1576
+#: src/option.c:1578
 #, c-format
 msgid "Unknown signal: %s\n"
 msgstr "Невідомий сигнал: %s\n"
 
-#: src/option.c:1811
+#: src/option.c:1814
 msgid "File exist. Overwrite?"
 msgstr "Файл існує. Перезаписати?"
 
-#: src/option.c:1953
+#: src/option.c:1956
 msgid "File was changed. Save it?"
 msgstr "Файл був змінений. Зберегти його?"
 
-#: src/option.c:1984
+#: src/option.c:1987
 msgid "- Yet another dialoging program"
 msgstr "- Програма для відображення діалогів"
 
-#: src/option.c:1988
+#: src/option.c:1991
 msgid "General options"
 msgstr "Основні параметри"
 
-#: src/option.c:1988
+#: src/option.c:1991
 msgid "Show general options"
 msgstr "Показувати основні параметри"
 
-#: src/option.c:1994
+#: src/option.c:1997
 msgid "Common options"
 msgstr "Загальні параметри"
 
-#: src/option.c:1994
+#: src/option.c:1997
 msgid "Show common options"
 msgstr "Показувати загальні параметри діалогів"
 
-#: src/option.c:2000
+#: src/option.c:2003
 msgid "About dialog options"
 msgstr "Параметри діалогу о програмі"
 
-#: src/option.c:2000
+#: src/option.c:2003
 msgid "Show custom about dialog options"
 msgstr "Показувати параметри діалогу о програмі"
 
-#: src/option.c:2006
+#: src/option.c:2009
 msgid "Application selection options"
 msgstr "Параметри діалогу вибору додатка"
 
-#: src/option.c:2006
+#: src/option.c:2009
 msgid "Show application selection options"
 msgstr "Показувати параметри діалоги вибору додатка"
 
-#: src/option.c:2012
+#: src/option.c:2015
 msgid "Calendar options"
 msgstr "Параметри календаря"
 
-#: src/option.c:2012
+#: src/option.c:2015
 msgid "Show calendar options"
 msgstr "Показувати параметри календаря"
 
-#: src/option.c:2018
+#: src/option.c:2021
 msgid "Color selection options"
 msgstr "Параметри діалогу вибору кольору"
 
-#: src/option.c:2018
+#: src/option.c:2021
 msgid "Show color selection options"
 msgstr "Показувати параметри діалогу вибору кольору"
 
-#: src/option.c:2024
+#: src/option.c:2027
 msgid "DND options"
 msgstr "Параметри DND"
 
-#: src/option.c:2024
+#: src/option.c:2027
 msgid "Show drag-n-drop options"
 msgstr "Показувати параметри dnd"
 
-#: src/option.c:2030
+#: src/option.c:2033
 msgid "Text entry options"
 msgstr "Параметри вводу тексту"
 
-#: src/option.c:2030
+#: src/option.c:2033
 msgid "Show text entry options"
 msgstr "Показувати параметри вводу тексту"
 
-#: src/option.c:2036
+#: src/option.c:2039
 msgid "File selection options"
 msgstr "Параметри діалогу вибору файлів"
 
-#: src/option.c:2036
+#: src/option.c:2039
 msgid "Show file selection options"
 msgstr "Показувати параметри діалогу вибору файлів"
 
-#: src/option.c:2042
+#: src/option.c:2045
 msgid "Font selection options"
 msgstr "Параметри діалогу вибору шрифту"
 
-#: src/option.c:2042
+#: src/option.c:2045
 msgid "Show font selection options"
 msgstr "Показувати параметри діалоги вибору шрифту"
 
-#: src/option.c:2048
+#: src/option.c:2051
 msgid "Form options"
 msgstr "Параметри діалогу форми"
 
-#: src/option.c:2048
+#: src/option.c:2051
 msgid "Show form options"
 msgstr "Показувати параметри діалогу форми"
 
-#: src/option.c:2055
+#: src/option.c:2058
 msgid "HTML options"
 msgstr "Параметри HTML діалогу"
 
-#: src/option.c:2055
+#: src/option.c:2058
 msgid "Show HTML options"
 msgstr "Показувати параметри HTML діалогу"
 
-#: src/option.c:2062
+#: src/option.c:2065
 msgid "Icons box options"
 msgstr "Параметри діалогу піктограм"
 
-#: src/option.c:2062
+#: src/option.c:2065
 msgid "Show icons box options"
 msgstr "Показувати параметри діалогу піктограм швидкого доступу"
 
-#: src/option.c:2068
+#: src/option.c:2071
 msgid "List options"
 msgstr "Параметри списку"
 
-#: src/option.c:2068
+#: src/option.c:2071
 msgid "Show list options"
 msgstr "Показувати параметри списку"
 
-#: src/option.c:2074
+#: src/option.c:2077
 msgid "Notebook options"
 msgstr "Параметри діалогу з вкладками"
 
-#: src/option.c:2074
+#: src/option.c:2077
 msgid "Show notebook dialog options"
 msgstr "Показувати параметри діалогу з вкладками"
 
-#: src/option.c:2081
+#: src/option.c:2084
 msgid "Notification icon options"
 msgstr "Параметри піктограми сповіщень"
 
-#: src/option.c:2082
+#: src/option.c:2085
 msgid "Show notification icon options"
 msgstr "Показувати параметри піктограми сповіщень"
 
-#: src/option.c:2090
+#: src/option.c:2093
 msgid "StatusNotifier/AppIndicator options"
 msgstr "Параметри піктограми додатку"
 
-#: src/option.c:2091
+#: src/option.c:2094
 msgid "Show indicator options"
 msgstr "Показувати параметри піктограми додатку"
 
-#: src/option.c:2098
+#: src/option.c:2101
 msgid "Paned dialog options"
 msgstr "Параметри діалогу з панелями"
 
-#: src/option.c:2098
+#: src/option.c:2101
 msgid "Show paned dialog options"
 msgstr "Показувати параметри діалогу з панелями"
 
-#: src/option.c:2104
+#: src/option.c:2107
 msgid "Picture dialog options"
 msgstr "Параметри діалогу з картинкою"
 
-#: src/option.c:2104
+#: src/option.c:2107
 msgid "Show picture dialog options"
 msgstr "Показувати параметри діалогу відображення картинки"
 
-#: src/option.c:2110
+#: src/option.c:2113
 msgid "Popup dialog options"
 msgstr "Параметри спливаючого діалогу"
 
-#: src/option.c:2110
+#: src/option.c:2113
 msgid "Show popup dialog options"
 msgstr "Показувати параметри спливаючого діалогу"
 
-#: src/option.c:2116
+#: src/option.c:2119
 msgid "Print dialog options"
 msgstr "Параметри діалогу друку"
 
-#: src/option.c:2116
+#: src/option.c:2119
 msgid "Show print dialog options"
 msgstr "Показувати параметри діалогу друку"
 
-#: src/option.c:2122
+#: src/option.c:2125
 msgid "Progress options"
 msgstr "Параметри прогресу"
 
-#: src/option.c:2122
+#: src/option.c:2125
 msgid "Show progress options"
 msgstr "Показувати параметри прогресу"
 
-#: src/option.c:2128
+#: src/option.c:2131
 msgid "Scale options"
 msgstr "Параметри масштабу"
 
-#: src/option.c:2128
+#: src/option.c:2131
 msgid "Show scale options"
 msgstr "Показувати параметри масштабу"
 
-#: src/option.c:2134
+#: src/option.c:2137
 msgid "Text information options"
 msgstr "Параметри текстової інформації"
 
-#: src/option.c:2134
+#: src/option.c:2137
 msgid "Show text information options"
 msgstr "Показувати параметри текстової інформації"
 
-#: src/option.c:2141
+#: src/option.c:2144
 msgid "SourceView options"
 msgstr "Параметри SourceView"
 
-#: src/option.c:2141
+#: src/option.c:2144
 msgid "Show SourceView options"
 msgstr "Показувати параметри SourceView"
 
-#: src/option.c:2148
+#: src/option.c:2151
 msgid "File filter options"
 msgstr "Параметри фільтрів для діалогу вибору файлів"
 
-#: src/option.c:2148
+#: src/option.c:2151
 msgid "Show file filter options"
 msgstr "Показувати параметри фільтрів для діалогу вибору файлів"
 
-#: src/option.c:2154
+#: src/option.c:2157
 msgid "Miscellaneous options"
 msgstr "Додаткові параметри"
 
-#: src/option.c:2154
+#: src/option.c:2157
 msgid "Show miscellaneous options"
 msgstr "Показувати додаткові параметри"
 
@@ -2418,7 +2428,7 @@ msgstr "Ширина вирівнювання::NUM"
 msgid "Insert spaces instead of tabulation:CHK"
 msgstr "Вставляти пробіли замість табуляції:CHK"
 
-#: src/yad-settings.sh:113 data/yad-settings.desktop.in:3
+#: src/yad-settings.sh:113 data/yad-settings.desktop.in:4
 msgid "YAD settings"
 msgstr "Налаштування YAD"
 
@@ -2439,14 +2449,14 @@ msgid "Editor"
 msgstr "Редактор"
 
 # Translation of .desktop files
-#: data/yad-icon-browser.desktop.in:3
+#: data/yad-icon-browser.desktop.in:4
 msgid "Icon Browser"
 msgstr "Навігатор піктограм"
 
-#: data/yad-icon-browser.desktop.in:4
+#: data/yad-icon-browser.desktop.in:5
 msgid "Inspect GTK Icon Theme"
 msgstr "Перегляд теми піктограм GTK"
 
-#: data/yad-settings.desktop.in:4
+#: data/yad-settings.desktop.in:5
 msgid "Simple GUI for editing YAD settings"
 msgstr "Простий інтерфейс для редагування налаштувань YAD"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: yad 0.17.0\n"
 "Report-Msgid-Bugs-To: victor@sanana.kiev.ua\n"
-"POT-Creation-Date: 2026-06-30 16:06+0300\n"
+"POT-Creation-Date: 2026-07-06 22:04-0400\n"
 "PO-Revision-Date: 2012-02-28 16:08+0800\n"
 "Last-Translator: Wei-Lun Chao <chaoweilun@gmail.com>\n"
 "Language-Team: Chinese (traditional) <zh-l10n@linux.org.tw>\n"
@@ -87,15 +87,15 @@ msgstr "選取或建立資料夾"
 msgid "Select date"
 msgstr "選取日期"
 
-#: src/form.c:1047
+#: src/form.c:1055
 msgid "Select file"
 msgstr "選取檔案"
 
-#: src/form.c:1077
+#: src/form.c:1085
 msgid "Select folder"
 msgstr "選取資料夾"
 
-#: src/form.c:1245 src/form.c:1247
+#: src/form.c:1253 src/form.c:1255
 msgid "Link"
 msgstr ""
 
@@ -136,35 +136,35 @@ msgstr "無法開啟目錄 %s：%s\n"
 msgid "%d sec"
 msgstr "%d 秒"
 
-#: src/main.c:748 src/main.c:755
+#: src/main.c:764 src/main.c:771
 #, fuzzy, c-format
 msgid "Unable to parse YAD_OPTIONS: %s\n"
 msgstr "無法剖析檔案 %s：%s\n"
 
-#: src/main.c:766
+#: src/main.c:782
 #, c-format
 msgid "Unable to parse command line: %s\n"
 msgstr "無法剖析命令列：%s\n"
 
-#: src/main.c:780
+#: src/main.c:796
 msgid ""
 "WARNING: Using splash option is deprecated, please use --window-type instead"
 msgstr ""
 
-#: src/main.c:790
+#: src/main.c:806
 #, fuzzy, c-format
 msgid "Unable to change directory to %s: %s\n"
 msgstr "無法開啟目錄 %s：%s\n"
 
-#: src/main.c:819
+#: src/main.c:835
 msgid "WARNING: Using gtkrc option is deprecated, please use --css instead\n"
 msgstr ""
 
-#: src/main.c:893
+#: src/main.c:909
 msgid "WARNING: --plug mode not supported outside X11\n"
 msgstr ""
 
-#: src/main.c:913
+#: src/main.c:929
 msgid "WARNING: This mode not supported outside X11\n"
 msgstr ""
 
@@ -265,12 +265,12 @@ msgstr "高度"
 msgid "Set the X position of a window"
 msgstr ""
 
-#: src/option.c:106 src/option.c:108 src/option.c:118 src/option.c:140
-#: src/option.c:144 src/option.c:189 src/option.c:203 src/option.c:342
-#: src/option.c:400 src/option.c:406 src/option.c:487 src/option.c:495
-#: src/option.c:497 src/option.c:499 src/option.c:501 src/option.c:503
-#: src/option.c:505 src/option.c:509 src/option.c:543 src/option.c:545
-#: src/option.c:599 src/option.c:633 src/option.c:702
+#: src/option.c:106 src/option.c:108 src/option.c:118 src/option.c:142
+#: src/option.c:146 src/option.c:191 src/option.c:205 src/option.c:344
+#: src/option.c:402 src/option.c:408 src/option.c:489 src/option.c:497
+#: src/option.c:499 src/option.c:501 src/option.c:503 src/option.c:505
+#: src/option.c:507 src/option.c:511 src/option.c:545 src/option.c:547
+#: src/option.c:601 src/option.c:635 src/option.c:704
 msgid "NUMBER"
 msgstr "編號"
 
@@ -298,7 +298,7 @@ msgstr "逾時"
 msgid "Show remaining time indicator (top, bottom, left, right)"
 msgstr "顯示剩餘時間指示器 (頂端、底部、左側、右側)"
 
-#: src/option.c:114 src/option.c:587
+#: src/option.c:114 src/option.c:589
 msgid "POS"
 msgstr "位置"
 
@@ -306,8 +306,8 @@ msgstr "位置"
 msgid "Set the dialog text"
 msgstr "設定對話框文字"
 
-#: src/option.c:116 src/option.c:273 src/option.c:275 src/option.c:350
-#: src/option.c:352 src/option.c:386 src/option.c:507 src/option.c:637
+#: src/option.c:116 src/option.c:275 src/option.c:277 src/option.c:352
+#: src/option.c:354 src/option.c:388 src/option.c:509 src/option.c:639
 msgid "TEXT"
 msgstr "文字"
 
@@ -321,11 +321,11 @@ msgstr "設定對話框文字"
 msgid "Set the dialog text alignment (left, center, right, fill)"
 msgstr "設定對話框文字對齊 (靠左、置中，靠右)"
 
-#: src/option.c:120 src/option.c:132 src/option.c:185 src/option.c:235
-#: src/option.c:241 src/option.c:243 src/option.c:398 src/option.c:481
-#: src/option.c:491 src/option.c:541 src/option.c:585 src/option.c:597
-#: src/option.c:609 src/option.c:621 src/option.c:635 src/option.c:698
-#: src/option.c:749 src/option.c:778 src/option.c:780 src/tools.c:86
+#: src/option.c:120 src/option.c:132 src/option.c:187 src/option.c:237
+#: src/option.c:243 src/option.c:245 src/option.c:400 src/option.c:483
+#: src/option.c:493 src/option.c:543 src/option.c:587 src/option.c:599
+#: src/option.c:611 src/option.c:623 src/option.c:637 src/option.c:700
+#: src/option.c:751 src/option.c:780 src/option.c:782 src/tools.c:86
 msgid "TYPE"
 msgstr "型態"
 
@@ -333,7 +333,7 @@ msgstr "型態"
 msgid "Set the dialog image"
 msgstr "設定對話框圖像"
 
-#: src/option.c:122 src/option.c:360 src/option.c:364
+#: src/option.c:122 src/option.c:362 src/option.c:366
 msgid "IMAGE"
 msgstr "圖像"
 
@@ -341,7 +341,7 @@ msgstr "圖像"
 msgid "Use specified icon theme instead of default"
 msgstr "使用指定的圖示布景主題以代替預設"
 
-#: src/option.c:124 src/option.c:727 src/browser.c:220 src/tools.c:87
+#: src/option.c:124 src/option.c:729 src/browser.c:220 src/tools.c:87
 msgid "THEME"
 msgstr "布景主題"
 
@@ -349,7 +349,7 @@ msgstr "布景主題"
 msgid "Hide main widget with expander"
 msgstr "以擴充元件隱藏主要視窗元件"
 
-#: src/option.c:126 src/option.c:378 src/option.c:654 src/option.c:718
+#: src/option.c:126 src/option.c:380 src/option.c:656 src/option.c:720
 msgid "[TEXT]"
 msgstr "[文字]"
 
@@ -370,1624 +370,1634 @@ msgid "Set buttons layout type (spread, edge, start, end or center)"
 msgstr ""
 
 #: src/option.c:134
+#, fuzzy
+msgid "Set focus to the named button when dialog opens"
+msgstr "顯示列印對話框選項"
+
+#: src/option.c:134
+#, fuzzy
+msgid "NAME"
+msgstr "名稱:識別號"
+
+#: src/option.c:136
 msgid "Don't use pango markup language in dialog's text"
 msgstr "在對話框文字中不使用 pango 標記語言"
 
-#: src/option.c:136
+#: src/option.c:138
 msgid "Don't close dialog if Escape was pressed"
 msgstr ""
 
-#: src/option.c:138
+#: src/option.c:140
 msgid "Escape acts like OK button"
 msgstr ""
 
-#: src/option.c:140
+#: src/option.c:142
 msgid "Set window borders"
 msgstr "設定視窗邊線"
 
-#: src/option.c:142
+#: src/option.c:144
 msgid "Always print result"
 msgstr "一律印出結果"
 
-#: src/option.c:144
+#: src/option.c:146
 #, fuzzy
 msgid "Set default return code"
 msgstr "設定回傳日期的格式"
 
-#: src/option.c:146
+#: src/option.c:148
 msgid "Dialog text can be selected"
 msgstr "可以選取對話框文字"
 
-#: src/option.c:148
+#: src/option.c:150
 #, fuzzy
 msgid "Don't scale icons"
 msgstr "顯示尺度選項"
 
-#: src/option.c:150
+#: src/option.c:152
 #, c-format
 msgid "Run commands under specified interpreter (default: bash -c '%s')"
 msgstr ""
 
-#: src/option.c:150 src/option.c:152 src/option.c:154 src/option.c:205
-#: src/option.c:312 src/option.c:362 src/option.c:366 src/option.c:412
-#: src/option.c:511 src/option.c:513 src/option.c:515 src/option.c:601
+#: src/option.c:152 src/option.c:154 src/option.c:156 src/option.c:207
+#: src/option.c:314 src/option.c:364 src/option.c:368 src/option.c:414
+#: src/option.c:513 src/option.c:515 src/option.c:517 src/option.c:603
 msgid "CMD"
 msgstr "命令"
 
-#: src/option.c:152
+#: src/option.c:154
 msgid "Set URI handler"
 msgstr ""
 
-#: src/option.c:154
+#: src/option.c:156
 msgid "Set command running when F1 was pressed"
 msgstr ""
 
-#: src/option.c:156
+#: src/option.c:158
 #, fuzzy
 msgid "Set working directory"
 msgstr "設定視窗無裝飾"
 
-#: src/option.c:156 src/option.c:782
+#: src/option.c:158 src/option.c:784
 #, fuzzy
 msgid "PATH"
 msgstr "圖示路徑"
 
-#: src/option.c:159
+#: src/option.c:161
 msgid "Set window sticky"
 msgstr "設定視窗黏著"
 
-#: src/option.c:161
+#: src/option.c:163
 msgid "Set window unresizable"
 msgstr "設定視窗不可調整大小"
 
-#: src/option.c:163
+#: src/option.c:165
 msgid "Place window on top"
 msgstr "視窗置於頂端"
 
-#: src/option.c:165
+#: src/option.c:167
 msgid "Place window on center of screen"
 msgstr "視窗置於螢幕的中央"
 
-#: src/option.c:167
+#: src/option.c:169
 msgid "Place window at the mouse position"
 msgstr "視窗置於滑鼠所在位置"
 
-#: src/option.c:169
+#: src/option.c:171
 msgid "Set window undecorated"
 msgstr "設定視窗無裝飾"
 
-#: src/option.c:171
+#: src/option.c:173
 msgid "Don't show window in taskbar"
 msgstr "在工作列中不顯示視窗"
 
-#: src/option.c:173
+#: src/option.c:175
 #, fuzzy
 msgid "Set window maximized"
 msgstr "設定視窗不可調整大小"
 
-#: src/option.c:175
+#: src/option.c:177
 #, fuzzy
 msgid "Set window fullscreen"
 msgstr "設定視窗不可調整大小"
 
-#: src/option.c:177
+#: src/option.c:179
 msgid "Don't focus dialog window"
 msgstr ""
 
-#: src/option.c:179
+#: src/option.c:181
 msgid "Close window when it sets unfocused"
 msgstr ""
 
-#: src/option.c:182
+#: src/option.c:184
 msgid "Open window as a splashscreen (Deprecated, see man page for details)"
 msgstr ""
 
-#: src/option.c:185
+#: src/option.c:187
 msgid "Specify the window type for the dialog"
 msgstr ""
 
-#: src/option.c:187
+#: src/option.c:189
 msgid "Special type of dialog for XEMBED"
 msgstr ""
 
-#: src/option.c:187 src/option.c:239
+#: src/option.c:189 src/option.c:241
 msgid "KEY"
 msgstr ""
 
-#: src/option.c:189
+#: src/option.c:191
 msgid "Tab number of this dialog"
-msgstr ""
-
-#: src/option.c:192
-#, fuzzy
-msgid "Send SIGNAL to parent"
-msgstr "發送 TERM 到上層"
-
-#: src/option.c:192
-msgid "[SIGNAL]"
 msgstr ""
 
 #: src/option.c:194
 #, fuzzy
+msgid "Send SIGNAL to parent"
+msgstr "發送 TERM 到上層"
+
+#: src/option.c:194
+msgid "[SIGNAL]"
+msgstr ""
+
+#: src/option.c:196
+#, fuzzy
 msgid "Print X Window Id to the file/stderr"
 msgstr "印出 X 視窗識別號到標準勘誤"
 
-#: src/option.c:194 src/option.c:324
+#: src/option.c:196 src/option.c:326
 #, fuzzy
 msgid "[FILENAME]"
 msgstr "檔名"
 
-#: src/option.c:201
+#: src/option.c:203
 msgid "Set the format for the returned date"
 msgstr "設定回傳日期的格式"
 
-#: src/option.c:201 src/option.c:453
+#: src/option.c:203 src/option.c:455
 msgid "PATTERN"
 msgstr "胚騰"
 
-#: src/option.c:203
+#: src/option.c:205
 msgid "Set presicion of floating numbers (default - 3)"
 msgstr ""
 
-#: src/option.c:205
+#: src/option.c:207
 msgid "Set command handler"
 msgstr ""
 
-#: src/option.c:207
+#: src/option.c:209
 #, fuzzy
 msgid "Listen for data on stdin"
 msgstr "聽取來自標準輸入的命令"
 
-#: src/option.c:209
+#: src/option.c:211
 #, fuzzy
 msgid "Set common separator character"
 msgstr "設定輸出的分隔字元"
 
-#: src/option.c:209 src/option.c:211
+#: src/option.c:211 src/option.c:213
 msgid "SEPARATOR"
 msgstr "分隔符號"
 
-#: src/option.c:211
+#: src/option.c:213
 #, fuzzy
 msgid "Set item separator character"
 msgstr "設定輸出的分隔字元"
 
-#: src/option.c:213
+#: src/option.c:215
 #, fuzzy
 msgid "Allow changes to text in some cases"
 msgstr "允許變更複合方塊中的文字"
 
-#: src/option.c:215
-msgid "Autoscroll to end of text"
-msgstr "自動捲動到文末"
-
 #: src/option.c:217
-#, fuzzy
-msgid "Autoscroll to end of text (alias to tail)"
+msgid "Autoscroll to end of text"
 msgstr "自動捲動到文末"
 
 #: src/option.c:219
 #, fuzzy
+msgid "Autoscroll to end of text (alias to tail)"
+msgstr "自動捲動到文末"
+
+#: src/option.c:221
+#, fuzzy
 msgid "Quote dialogs output"
 msgstr "設定對話框文字"
 
-#: src/option.c:221
+#: src/option.c:223
 #, fuzzy
 msgid "Output number instead of text for combo-box"
 msgstr "使用完整輸入以代替複合方塊"
 
-#: src/option.c:223
+#: src/option.c:225
 msgid "Specify font name to use"
 msgstr ""
 
-#: src/option.c:223
+#: src/option.c:225
 msgid "FONTNAME"
 msgstr "字型名稱"
 
-#: src/option.c:225
+#: src/option.c:227
 #, fuzzy
 msgid "Allow multiple selection"
 msgstr "允許選取多列"
 
-#: src/option.c:227
+#: src/option.c:229
 #, fuzzy
 msgid "Enable preview"
 msgstr "在列印對話框中啟用預覽"
 
-#: src/option.c:229
+#: src/option.c:231
 #, fuzzy
 msgid "Use large preview"
 msgstr "在列印對話框中啟用預覽"
 
-#: src/option.c:231
+#: src/option.c:233
 #, fuzzy
 msgid "Show hidden files in file selection dialogs"
 msgstr "顯示檔案選取對話框"
 
-#: src/option.c:233
+#: src/option.c:235
 #, fuzzy
 msgid "Set source filename"
 msgstr "來源檔名"
 
-#: src/option.c:233 src/option.c:308 src/option.c:775 src/option.c:790
+#: src/option.c:235 src/option.c:310 src/option.c:777 src/option.c:792
 msgid "FILENAME"
 msgstr "檔名"
 
-#: src/option.c:235
+#: src/option.c:237
 msgid "Set mime type of input data"
 msgstr ""
 
-#: src/option.c:237
+#: src/option.c:239
 #, fuzzy
 msgid "Set vertical orientation"
 msgstr "設定按一下滑鼠左鍵的動作"
 
-#: src/option.c:239
+#: src/option.c:241
 msgid "Identifier of embedded dialogs"
 msgstr ""
 
-#: src/option.c:241
+#: src/option.c:243
 msgid "Set extended completion for entries (any, all, or regex)"
 msgstr ""
 
-#: src/option.c:243
+#: src/option.c:245
 msgid "Set type of output for boolean values (T, t, Y, y, O, o, 1)"
 msgstr ""
 
-#: src/option.c:245
+#: src/option.c:247
 #, fuzzy
 msgid "Make main widget scrollable"
 msgstr "讓 URI 可點選"
 
-#: src/option.c:247
+#: src/option.c:249
 msgid "Disable search in text and html dialogs"
 msgstr ""
 
-#: src/option.c:249
+#: src/option.c:251
 #, fuzzy
 msgid "Enable file operations"
 msgstr "尺度選項"
 
-#: src/option.c:252
+#: src/option.c:254
 msgid "Use IEC (base 1024) units with for size values"
 msgstr ""
 
-#: src/option.c:256
+#: src/option.c:258
 #, fuzzy
 msgid "Enable spell check for text"
 msgstr "使用指定的文字顏色"
 
-#: src/option.c:258
+#: src/option.c:260
 msgid "Set spell checking language"
 msgstr ""
 
-#: src/option.c:258
+#: src/option.c:260
 msgid "LANGUAGE"
 msgstr ""
 
-#: src/option.c:265
+#: src/option.c:267
 #, fuzzy
 msgid "Display about dialog"
 msgstr "顯示清單對話框"
 
-#: src/option.c:267
+#: src/option.c:269
 msgid "Set application name"
 msgstr ""
 
-#: src/option.c:267 src/option.c:269 src/option.c:271 src/option.c:281
-#: src/option.c:429 src/option.c:431 src/option.c:529 src/option.c:531
-#: src/option.c:558 src/option.c:574 src/option.c:772
+#: src/option.c:269 src/option.c:271 src/option.c:273 src/option.c:283
+#: src/option.c:431 src/option.c:433 src/option.c:531 src/option.c:533
+#: src/option.c:560 src/option.c:576 src/option.c:774
 msgid "STRING"
 msgstr ""
 
-#: src/option.c:269
+#: src/option.c:271
 msgid "Set application version"
 msgstr ""
 
-#: src/option.c:271
+#: src/option.c:273
 msgid "Set application copyright string"
 msgstr ""
 
-#: src/option.c:273
+#: src/option.c:275
 msgid "Set application comments string"
 msgstr ""
 
-#: src/option.c:275
+#: src/option.c:277
 msgid "Set application license"
 msgstr ""
 
-#: src/option.c:277
+#: src/option.c:279
 msgid "Set application authors"
 msgstr ""
 
-#: src/option.c:277 src/option.c:485 src/option.c:489 src/option.c:493
+#: src/option.c:279 src/option.c:487 src/option.c:491 src/option.c:495
 msgid "LIST"
 msgstr ""
 
-#: src/option.c:279
+#: src/option.c:281
 #, fuzzy
 msgid "Set application website"
 msgstr "設定換頁大小"
 
-#: src/option.c:279
+#: src/option.c:281
 msgid "URI"
 msgstr ""
 
-#: src/option.c:281
+#: src/option.c:283
 msgid "Set application website label"
 msgstr ""
 
-#: src/option.c:287
+#: src/option.c:289
 #, fuzzy
 msgid "Display application selection dialog"
 msgstr "顯示字型選擇對話框"
 
-#: src/option.c:289
+#: src/option.c:291
 #, fuzzy
 msgid "Show fallback applications"
 msgstr "顯示行事曆選項"
 
-#: src/option.c:291
+#: src/option.c:293
 #, fuzzy
 msgid "Show other applications"
 msgstr "顯示表單選項"
 
-#: src/option.c:293
+#: src/option.c:295
 #, fuzzy
 msgid "Show all applications"
 msgstr "顯示尺度選項"
 
-#: src/option.c:295
+#: src/option.c:297
 msgid "Output all application data"
 msgstr ""
 
-#: src/option.c:300
+#: src/option.c:302
 msgid "Display calendar dialog"
 msgstr "顯示行事曆對話框"
 
-#: src/option.c:302
+#: src/option.c:304
 msgid "Set the calendar day"
 msgstr "設定行事曆的日"
 
-#: src/option.c:302
+#: src/option.c:304
 msgid "DAY"
 msgstr "日"
 
-#: src/option.c:304
+#: src/option.c:306
 msgid "Set the calendar month"
 msgstr "設定行事曆的月"
 
-#: src/option.c:304
+#: src/option.c:306
 msgid "MONTH"
 msgstr "月"
 
-#: src/option.c:306
+#: src/option.c:308
 msgid "Set the calendar year"
 msgstr "設定行事曆的年"
 
-#: src/option.c:306
+#: src/option.c:308
 msgid "YEAR"
 msgstr "年"
 
-#: src/option.c:308
+#: src/option.c:310
 msgid "Set the filename with dates details"
 msgstr "以約會細節設定檔名"
 
-#: src/option.c:310
+#: src/option.c:312
 msgid "Show week numbers at the left side of calendar"
 msgstr ""
 
-#: src/option.c:312 src/option.c:513
+#: src/option.c:314 src/option.c:515
 #, fuzzy
 msgid "Set select action"
 msgstr "設定按一下滑鼠左鍵的動作"
 
-#: src/option.c:318
+#: src/option.c:320
 msgid "Display color selection dialog"
 msgstr "顯示顏色選擇對話框"
 
-#: src/option.c:320
+#: src/option.c:322
 msgid "Set initial color value"
 msgstr "設定初始顏色值"
 
-#: src/option.c:320 src/option.c:704 src/option.c:706 src/option.c:712
-#: src/option.c:735 src/option.c:737
+#: src/option.c:322 src/option.c:706 src/option.c:708 src/option.c:714
+#: src/option.c:737 src/option.c:739
 msgid "COLOR"
 msgstr "顏色"
 
-#: src/option.c:322
+#: src/option.c:324
 msgid "Show system palette in color dialog"
 msgstr ""
 
-#: src/option.c:324
+#: src/option.c:326
 msgid "Set path to palette file. Default - "
 msgstr "設定調色盤檔案的路徑。預設 - "
 
-#: src/option.c:326
+#: src/option.c:328
 msgid "Expand user palette"
 msgstr ""
 
-#: src/option.c:328
+#: src/option.c:330
 msgid "Show color picker"
 msgstr ""
 
-#: src/option.c:330
+#: src/option.c:332
 msgid "Set output mode to MODE. Values are hex (default) or rgb"
 msgstr ""
 
-#: src/option.c:330
+#: src/option.c:332
 msgid "MODE"
 msgstr ""
 
-#: src/option.c:332
+#: src/option.c:334
 msgid "Add opacity to output color value"
 msgstr ""
 
-#: src/option.c:338
+#: src/option.c:340
 msgid "Display drag-n-drop box"
 msgstr "顯示拖放框"
 
-#: src/option.c:340
+#: src/option.c:342
 msgid "Use dialog text as tooltip"
 msgstr "使用對話框文字做為提示框"
 
-#: src/option.c:342
+#: src/option.c:344
 msgid "Exit after NUMBER of drops"
 msgstr ""
 
-#: src/option.c:348
+#: src/option.c:350
 msgid "Display text entry or combo-box dialog"
 msgstr "顯示文字輸入框或複合方塊對話框"
 
-#: src/option.c:350
+#: src/option.c:352
 msgid "Set the entry label"
 msgstr "設定輸入框標籤"
 
-#: src/option.c:352
+#: src/option.c:354
 msgid "Set the entry text"
 msgstr "設定輸入框文字"
 
-#: src/option.c:354
+#: src/option.c:356
 msgid "Hide the entry text"
 msgstr "隱藏輸入框文字"
 
-#: src/option.c:356
+#: src/option.c:358
 msgid "Use completion instead of combo-box"
 msgstr "使用完整輸入以代替複合方塊"
 
-#: src/option.c:358
+#: src/option.c:360
 msgid "Use spin button for text entry"
 msgstr "使用微調按鈕於文字輸入框"
 
-#: src/option.c:360
+#: src/option.c:362
 msgid "Set the left entry icon"
 msgstr "設定左側輸入框圖示"
 
-#: src/option.c:362
+#: src/option.c:364
 msgid "Set the left entry icon action"
 msgstr "設定左側輸入框圖示動作"
 
-#: src/option.c:364
+#: src/option.c:366
 msgid "Set the right entry icon"
 msgstr "設定右側輸入框圖示"
 
-#: src/option.c:366
+#: src/option.c:368
 msgid "Set the right entry icon action"
 msgstr "設定右側輸入框圖示動作"
 
-#: src/option.c:372
+#: src/option.c:374
 msgid "Display file selection dialog"
 msgstr "顯示檔案選取對話框"
 
-#: src/option.c:374
+#: src/option.c:376
 msgid "Activate directory-only selection"
 msgstr "啟用只能選擇目錄"
 
-#: src/option.c:376
+#: src/option.c:378
 msgid "Activate save mode"
 msgstr "啟用儲存模式"
 
-#: src/option.c:378
+#: src/option.c:380
 msgid "Confirm file selection if filename already exists"
 msgstr "如果檔名已經存在要確認檔案的選取"
 
-#: src/option.c:384
+#: src/option.c:386
 msgid "Display font selection dialog"
 msgstr "顯示字型選擇對話框"
 
-#: src/option.c:386
+#: src/option.c:388
 msgid "Set text string for preview"
 msgstr ""
 
-#: src/option.c:388
+#: src/option.c:390
 msgid "Separate output of font description"
 msgstr ""
 
-#: src/option.c:394
+#: src/option.c:396
 msgid "Display form dialog"
 msgstr "顯示表單對話框"
 
-#: src/option.c:396
+#: src/option.c:398
 msgid "Add field to form (see man page for list of possible types)"
 msgstr ""
 
-#: src/option.c:396 src/option.c:631
+#: src/option.c:398 src/option.c:633
 msgid "LABEL[:TYPE]"
 msgstr "標籤[:型態]"
 
-#: src/option.c:398
+#: src/option.c:400
 #, fuzzy
 msgid "Set alignment of filed labels (left, center or right)"
 msgstr "設定欄位標籤的對齊 (靠左、置中或靠右)"
 
-#: src/option.c:400
+#: src/option.c:402
 msgid "Set number of columns in form"
 msgstr "設定表單中的欄數量"
 
-#: src/option.c:402
+#: src/option.c:404
 msgid "Make form fields height and columns width the same size"
 msgstr ""
 
-#: src/option.c:404
+#: src/option.c:406
 msgid "Order output fields by rows"
 msgstr ""
 
-#: src/option.c:406
+#: src/option.c:408
 #, fuzzy
 msgid "Set focused field"
 msgstr "設定步增值"
 
-#: src/option.c:408
+#: src/option.c:410
 msgid "Cycled reading of stdin data"
 msgstr ""
 
-#: src/option.c:410
+#: src/option.c:412
 msgid "Align labels on button fields"
 msgstr ""
 
-#: src/option.c:412
+#: src/option.c:414
 #, fuzzy
 msgid "Set changed action"
 msgstr "設定按一下滑鼠左鍵的動作"
 
-#: src/option.c:419
+#: src/option.c:421
 #, fuzzy
 msgid "Display HTML dialog"
 msgstr "顯示表單對話框"
 
-#: src/option.c:421
+#: src/option.c:423
 #, fuzzy
 msgid "Open specified location"
 msgstr "使用指定的字型"
 
-#: src/option.c:423
+#: src/option.c:425
 #, fuzzy
 msgid "Turn on browser mode"
 msgstr "- 圖示瀏覽器"
 
-#: src/option.c:425
+#: src/option.c:427
 msgid "Print clicked uri to stdout"
 msgstr ""
 
-#: src/option.c:427
+#: src/option.c:429
 msgid "Set encoding of input stream data"
 msgstr ""
 
-#: src/option.c:427
+#: src/option.c:429
 msgid "ENCODING"
 msgstr ""
 
-#: src/option.c:429
+#: src/option.c:431
 msgid "Set user agent string"
 msgstr ""
 
-#: src/option.c:431
+#: src/option.c:433
 msgid "Set custom user style"
 msgstr ""
 
-#: src/option.c:433
+#: src/option.c:435
 msgid "Set WebKit property"
 msgstr ""
 
-#: src/option.c:433
+#: src/option.c:435
 msgid "PROP"
 msgstr ""
 
-#: src/option.c:440
+#: src/option.c:442
 msgid "Display icons box dialog"
 msgstr "顯示圖示方塊對話框"
 
-#: src/option.c:442
+#: src/option.c:444
 msgid "Read data from .desktop files in specified directory"
 msgstr "在指定的目錄中從 .desktop 檔案讀取資料"
 
-#: src/option.c:442
+#: src/option.c:444
 msgid "DIR"
 msgstr ""
 
-#: src/option.c:444
+#: src/option.c:446
 msgid "Use compact (list) view"
 msgstr "使用壓縮 (清單) 檢視"
 
-#: src/option.c:446
+#: src/option.c:448
 msgid "Use GenericName field instead of Name for icon label"
 msgstr "使用 GenericName 欄位以代替 Name 做為圖示標籤"
 
-#: src/option.c:448
+#: src/option.c:450
 msgid "Set the width of dialog items"
 msgstr "設定對話框項目的寬度"
 
-#: src/option.c:450
+#: src/option.c:452
 msgid "Force using specified icon size"
 msgstr ""
 
-#: src/option.c:450 src/option.c:564 src/option.c:700 src/tools.c:85
+#: src/option.c:452 src/option.c:566 src/option.c:702 src/tools.c:85
 msgid "SIZE"
 msgstr "大小"
 
-#: src/option.c:453
+#: src/option.c:455
 #, no-c-format
 msgid ""
 "Use specified pattern for launch command in terminal (default: xterm -e %s)"
 msgstr "使用指定的胚騰以在終端機中啟動命令 (預設：xterm -e %s)"
 
-#: src/option.c:455
+#: src/option.c:457
 msgid "Sort items by name instead of filename"
 msgstr "依名稱而非檔名排序項目"
 
-#: src/option.c:457
+#: src/option.c:459
 msgid "Sort items in descending order"
 msgstr "以遞降排序項目"
 
-#: src/option.c:459
+#: src/option.c:461
 msgid "Activate items by single click"
 msgstr ""
 
-#: src/option.c:461
+#: src/option.c:463
 msgid "Watch fot changes in directory"
 msgstr ""
 
-#: src/option.c:467
+#: src/option.c:469
 msgid "Display list dialog"
 msgstr "顯示清單對話框"
 
-#: src/option.c:469
+#: src/option.c:471
 msgid "Set the column header (see man page for list of possible types)"
 msgstr ""
 
-#: src/option.c:469
+#: src/option.c:471
 msgid "COLUMN[:TYPE]"
 msgstr "欄[:型態]"
 
-#: src/option.c:471
+#: src/option.c:473
 msgid "Enbale tree mode"
 msgstr ""
 
-#: src/option.c:473
+#: src/option.c:475
 #, fuzzy
 msgid "Use checkboxes for first column"
 msgstr "首欄使用核取方塊"
 
-#: src/option.c:475
+#: src/option.c:477
 #, fuzzy
 msgid "Use radioboxes for first column"
 msgstr "首欄使用核取方塊"
 
-#: src/option.c:477
+#: src/option.c:479
 msgid "Don't show column headers"
 msgstr "不顯示欄標題"
 
-#: src/option.c:479
+#: src/option.c:481
 msgid "Disable clickable column headers"
 msgstr ""
 
-#: src/option.c:481
+#: src/option.c:483
 msgid "Set grid lines (hor[izontal], vert[ical] or both)"
 msgstr ""
 
-#: src/option.c:483
+#: src/option.c:485
 msgid "Print all data from list"
 msgstr "從清單印出所有資料"
 
-#: src/option.c:485
+#: src/option.c:487
 #, fuzzy
 msgid "Set the list of editable columns"
 msgstr "設定對話框項目的寬度"
 
-#: src/option.c:487
+#: src/option.c:489
 #, fuzzy
 msgid "Set the width of a column for start wrapping text"
 msgstr "設定對話框項目的寬度"
 
-#: src/option.c:489
+#: src/option.c:491
 #, fuzzy
 msgid "Set the list of wrapped columns"
 msgstr "設定清單中列數的限制"
 
-#: src/option.c:491
+#: src/option.c:493
 #, fuzzy
 msgid "Set ellipsize mode for text columns (none, start, middle or end)"
 msgstr "設定文字欄的省略模式 (型態 - NONE, START, MIDDLE 或 END)"
 
-#: src/option.c:493
+#: src/option.c:495
 #, fuzzy
 msgid "Set the list of ellipsized columns"
 msgstr "設定清單中列數的限制"
 
-#: src/option.c:495
+#: src/option.c:497
 msgid ""
 "Print a specific column. By default or if 0 is specified will be printed all "
 "columns"
 msgstr "印出特定的欄。按照預設或是如果指定為 0 將印出所有欄"
 
-#: src/option.c:497
+#: src/option.c:499
 msgid "Hide a specific column"
 msgstr "隱藏特定欄"
 
-#: src/option.c:499
+#: src/option.c:501
 msgid "Set the column expandable by default. 0 sets all columns expandable"
 msgstr "設定欄預設可擴展。0 將設定所有欄為可擴展"
 
-#: src/option.c:501
+#: src/option.c:503
 msgid ""
 "Set the quick search column. Default is first column. Set it to 0 for "
 "disable searching"
 msgstr "設定快速搜尋欄。預設是首欄。設定它為 0 表示停用搜尋"
 
-#: src/option.c:503
+#: src/option.c:505
 #, fuzzy
 msgid "Set the tooltip column"
 msgstr "設定視窗圖示"
 
-#: src/option.c:505
+#: src/option.c:507
 #, fuzzy
 msgid "Set the row separator column"
 msgstr "設定右側輸入框圖示"
 
-#: src/option.c:507
+#: src/option.c:509
 #, fuzzy
 msgid "Set the row separator value"
 msgstr "設定輸出的分隔字元"
 
-#: src/option.c:509
+#: src/option.c:511
 msgid "Set the limit of rows in list"
 msgstr "設定清單中列數的限制"
 
-#: src/option.c:511
+#: src/option.c:513
 msgid "Set double-click action"
 msgstr "設定連按兩下滑鼠的動作"
 
-#: src/option.c:515
+#: src/option.c:517
 #, fuzzy
 msgid "Set row action"
 msgstr "設定連按兩下滑鼠的動作"
 
-#: src/option.c:517
+#: src/option.c:519
 msgid "Expand all tree nodes"
 msgstr ""
 
-#: src/option.c:519
+#: src/option.c:521
 msgid "Use regex in search"
 msgstr "在搜尋中使用 regex"
 
-#: src/option.c:521
+#: src/option.c:523
 #, fuzzy
 msgid "Disable selection"
 msgstr "顯示檔案選取對話框"
 
-#: src/option.c:523
+#: src/option.c:525
 msgid "Add new records on the top of a list"
 msgstr ""
 
-#: src/option.c:525
+#: src/option.c:527
 msgid "Don't use markup in tooltips"
 msgstr ""
 
-#: src/option.c:527
+#: src/option.c:529
 msgid "Use column name as a header tooltip"
 msgstr ""
 
-#: src/option.c:529
+#: src/option.c:531
 #, fuzzy
 msgid "Set columns alignment"
 msgstr "設定表單中的欄數量"
 
-#: src/option.c:531
+#: src/option.c:533
 #, fuzzy
 msgid "Set headers alignment"
 msgstr "設定行事曆的月"
 
-#: src/option.c:537
+#: src/option.c:539
 #, fuzzy
 msgid "Display notebook dialog"
 msgstr "顯示圖示方塊對話框"
 
-#: src/option.c:539
+#: src/option.c:541
 msgid "Add a tab to notebook"
 msgstr ""
 
-#: src/option.c:539
+#: src/option.c:541
 msgid "LABEL"
 msgstr ""
 
-#: src/option.c:541
+#: src/option.c:543
 #, fuzzy
 msgid "Set position of a notebook tabs (top, bottom, left or right)"
 msgstr "顯示剩餘時間指示器 (頂端、底部、左側、右側)"
 
-#: src/option.c:543
+#: src/option.c:545
 #, fuzzy
 msgid "Set tab borders"
 msgstr "設定視窗邊線"
 
-#: src/option.c:545
+#: src/option.c:547
 #, fuzzy
 msgid "Set active tab"
 msgstr "設定輸入框標籤"
 
-#: src/option.c:547
+#: src/option.c:549
 msgid "Expand tabs"
 msgstr ""
 
-#: src/option.c:549
+#: src/option.c:551
 msgid "Use stack mode"
 msgstr ""
 
-#: src/option.c:556
+#: src/option.c:558
 msgid "Display notification"
 msgstr "顯示通知"
 
-#: src/option.c:558 src/option.c:574
+#: src/option.c:560 src/option.c:576
 #, fuzzy
 msgid "Set initial popup menu"
 msgstr "設定初始字型"
 
-#: src/option.c:560
+#: src/option.c:562
 msgid "Disable exit on middle click"
 msgstr ""
 
-#: src/option.c:562 src/option.c:576
+#: src/option.c:564 src/option.c:578
 #, fuzzy
 msgid "Doesn't show icon at startup"
 msgstr "在工作列中不顯示視窗"
 
-#: src/option.c:564
+#: src/option.c:566
 msgid "Set icon size for fully specified icons (default - 16)"
 msgstr ""
 
-#: src/option.c:572
+#: src/option.c:574
 msgid "Display indicator icon (StatusNotifier/AppIndicator)"
 msgstr ""
 
-#: src/option.c:583
+#: src/option.c:585
 #, fuzzy
 msgid "Display paned dialog"
 msgstr "顯示尺度對話框"
 
-#: src/option.c:585
+#: src/option.c:587
 msgid "Set orientation (hor[izontal] or vert[ical])"
 msgstr ""
 
-#: src/option.c:587
+#: src/option.c:589
 #, fuzzy
 msgid "Set initial splitter position"
 msgstr "設定初始百分比"
 
-#: src/option.c:589
+#: src/option.c:591
 msgid "Set focused pane (1 or 2)"
 msgstr ""
 
-#: src/option.c:589
+#: src/option.c:591
 msgid "PANE"
 msgstr ""
 
-#: src/option.c:595
+#: src/option.c:597
 #, fuzzy
 msgid "Display picture dialog"
 msgstr "顯示清單對話框"
 
-#: src/option.c:597
+#: src/option.c:599
 #, fuzzy
 msgid "Set initial size (fit or orig)"
 msgstr "設定初始字型"
 
-#: src/option.c:599
+#: src/option.c:601
 msgid "Set increment for picture scaling (default - 5)"
 msgstr ""
 
-#: src/option.c:601
+#: src/option.c:603
 msgid "Set action on image changing"
 msgstr ""
 
-#: src/option.c:607
+#: src/option.c:609
 #, fuzzy
 msgid "Display popup dialog"
 msgstr "顯示清單對話框"
 
-#: src/option.c:609
+#: src/option.c:611
 #, fuzzy
 msgid "Set alignment of title and text (left, center or right)"
 msgstr "設定欄位標籤的對齊 (靠左、置中或靠右)"
 
-#: src/option.c:611
+#: src/option.c:613
 msgid "Set transparency"
 msgstr ""
 
-#: src/option.c:611
+#: src/option.c:613
 #, fuzzy
 msgid "PERCENT"
 msgstr "百分比"
 
-#: src/option.c:613
+#: src/option.c:615
 msgid "Don't close popup by timeout"
 msgstr ""
 
-#: src/option.c:619
+#: src/option.c:621
 msgid "Display printing dialog"
 msgstr "顯示列印對話框"
 
-#: src/option.c:621
+#: src/option.c:623
 #, fuzzy
 msgid "Set source type (text, image or raw)"
 msgstr "設定來源型態 (型態 - TEXT, IMAGE 或 RAW)"
 
-#: src/option.c:623
+#: src/option.c:625
 msgid "Add headers to page"
 msgstr "將頁首加入頁面"
 
-#: src/option.c:629
+#: src/option.c:631
 msgid "Display progress indication dialog"
 msgstr "顯示進度指示對話框"
 
-#: src/option.c:631
+#: src/option.c:633
 #, fuzzy
 msgid "Add the progress bar (norm, rtl, pulse, cpulse or perm)"
 msgstr "加入進度條 (型態 - NORM, RTL 或 PULSE)"
 
-#: src/option.c:633
+#: src/option.c:635
 msgid "Watch for specific bar for auto close"
 msgstr ""
 
-#: src/option.c:635
+#: src/option.c:637
 #, fuzzy
 msgid "Set alignment of bar labels (left, center or right)"
 msgstr "設定欄位標籤的對齊 (靠左、置中或靠右)"
 
-#: src/option.c:637
+#: src/option.c:639
 msgid "Set progress text"
 msgstr "設定進度文字"
 
-#: src/option.c:639
+#: src/option.c:641
 #, fuzzy
 msgid "Hide text on progress bar"
 msgstr "脈衝式進度條"
 
-#: src/option.c:641
+#: src/option.c:643
 msgid "Pulsate progress bar"
 msgstr "脈衝式進度條"
 
-#: src/option.c:643
+#: src/option.c:645
 #, fuzzy
 msgid "Conlinuous pulsating progress bar"
 msgstr "脈衝式進度條"
 
-#: src/option.c:646
+#: src/option.c:648
 #, no-c-format
 msgid "Dismiss the dialog when 100% has been reached"
 msgstr "當達到 100% 時去除對話框"
 
-#: src/option.c:649
+#: src/option.c:651
 msgid "Kill parent process if cancel button is pressed"
 msgstr "如果按下取消按鈕就砍除上層進程"
 
-#: src/option.c:652
+#: src/option.c:654
 msgid "Right-To-Left progress bar direction"
 msgstr "進度條方向由右到左"
 
-#: src/option.c:654
+#: src/option.c:656
 msgid "Show log window"
 msgstr ""
 
-#: src/option.c:656
+#: src/option.c:658
 msgid "Expand log window"
 msgstr ""
 
-#: src/option.c:658
+#: src/option.c:660
 #, fuzzy
 msgid "Place log window above progress bar"
 msgstr "脈衝式進度條"
 
-#: src/option.c:660
+#: src/option.c:662
 msgid "Height of log window"
 msgstr ""
 
-#: src/option.c:666
+#: src/option.c:668
 msgid "Display scale dialog"
 msgstr "顯示尺度對話框"
 
-#: src/option.c:668
+#: src/option.c:670
 msgid "Set initial value"
 msgstr "設定初始值"
 
-#: src/option.c:668 src/option.c:670 src/option.c:672 src/option.c:674
-#: src/option.c:678 src/option.c:745 src/option.c:747
+#: src/option.c:670 src/option.c:672 src/option.c:674 src/option.c:676
+#: src/option.c:680 src/option.c:747 src/option.c:749
 msgid "VALUE"
 msgstr "值"
 
-#: src/option.c:670
+#: src/option.c:672
 msgid "Set minimum value"
 msgstr "設定最小值"
 
-#: src/option.c:672
+#: src/option.c:674
 msgid "Set maximum value"
 msgstr "設定最大值"
 
-#: src/option.c:674
+#: src/option.c:676
 msgid "Set step size"
 msgstr "設定步增值"
 
-#: src/option.c:676
+#: src/option.c:678
 msgid "Only allow values in step increments"
 msgstr ""
 
-#: src/option.c:678
+#: src/option.c:680
 msgid "Set paging size"
 msgstr "設定換頁大小"
 
-#: src/option.c:680
+#: src/option.c:682
 msgid "Print partial values"
 msgstr "列印部分值"
 
-#: src/option.c:682
+#: src/option.c:684
 msgid "Hide value"
 msgstr "隱藏值"
 
-#: src/option.c:684
+#: src/option.c:686
 msgid "Invert direction"
 msgstr "反相方向"
 
-#: src/option.c:686
+#: src/option.c:688
 msgid "Show +/- buttons in scale"
 msgstr ""
 
-#: src/option.c:688
+#: src/option.c:690
 msgid "Add mark to scale (may be used multiple times)"
 msgstr "將標記加入尺度 (也許會被多次使用)"
 
-#: src/option.c:688
+#: src/option.c:690
 msgid "NAME:VALUE"
 msgstr "名稱:值"
 
-#: src/option.c:694
+#: src/option.c:696
 msgid "Display text information dialog"
 msgstr "顯示文字資訊對話框"
 
-#: src/option.c:696
+#: src/option.c:698
 msgid "Enable text wrapping"
 msgstr "啟用文字環繞"
 
-#: src/option.c:698
+#: src/option.c:700
 #, fuzzy
 msgid "Set justification (left, right, center or fill)"
 msgstr "設定調整 (型態 - left, right, center 或 fill)"
 
-#: src/option.c:700
+#: src/option.c:702
 msgid "Set text margins"
 msgstr "設定文字邊距"
 
-#: src/option.c:702
+#: src/option.c:704
 #, fuzzy
 msgid "Jump to specific line"
 msgstr "隱藏特定欄"
 
-#: src/option.c:704
+#: src/option.c:706
 msgid "Use specified color for text"
 msgstr "使用指定的文字顏色"
 
-#: src/option.c:706
+#: src/option.c:708
 msgid "Use specified color for background"
 msgstr "使用指定的背景顏色"
 
-#: src/option.c:708
+#: src/option.c:710
 msgid "Show cursor in read-only mode"
 msgstr ""
 
-#: src/option.c:710
+#: src/option.c:712
 msgid "Make URI clickable"
 msgstr "讓 URI 可點選"
 
-#: src/option.c:712
+#: src/option.c:714
 #, fuzzy
 msgid "Use specified color for links"
 msgstr "使用指定的文字顏色"
 
-#: src/option.c:714
+#: src/option.c:716
 msgid "Use pango markup"
 msgstr ""
 
-#: src/option.c:716
+#: src/option.c:718
 msgid "Save file instead of print on exit"
 msgstr ""
 
-#: src/option.c:718
+#: src/option.c:720
 msgid "Confirm save the file if text was changed"
-msgstr ""
-
-#: src/option.c:725
-#, fuzzy
-msgid "Use specified langauge for syntax highlighting"
-msgstr "使用指定的文字顏色"
-
-#: src/option.c:725
-msgid "LANG"
 msgstr ""
 
 #: src/option.c:727
 #, fuzzy
+msgid "Use specified langauge for syntax highlighting"
+msgstr "使用指定的文字顏色"
+
+#: src/option.c:727
+msgid "LANG"
+msgstr ""
+
+#: src/option.c:729
+#, fuzzy
 msgid "Use specified theme"
 msgstr "使用指定的字型"
 
-#: src/option.c:729
+#: src/option.c:731
 msgid "Show line numbers"
 msgstr ""
 
-#: src/option.c:731
+#: src/option.c:733
 msgid "Highlight current line"
 msgstr ""
 
-#: src/option.c:733
+#: src/option.c:735
 msgid "Enable line marks"
 msgstr ""
 
-#: src/option.c:735
+#: src/option.c:737
 msgid "Set color for first type marks"
 msgstr ""
 
-#: src/option.c:737
+#: src/option.c:739
 msgid "Set color for second type marks"
 msgstr ""
 
-#: src/option.c:739
+#: src/option.c:741
 msgid "Set position of right margin"
 msgstr ""
 
-#: src/option.c:739
+#: src/option.c:741
 msgid "[POS]"
 msgstr ""
 
-#: src/option.c:741
+#: src/option.c:743
 msgid "Highlight matching brackets"
 msgstr ""
 
-#: src/option.c:743
+#: src/option.c:745
 msgid "Use autoindent"
 msgstr ""
 
-#: src/option.c:745
+#: src/option.c:747
 #, fuzzy
 msgid "Set tabulation width"
 msgstr "設定寬度"
 
-#: src/option.c:747
+#: src/option.c:749
 #, fuzzy
 msgid "Set indentation width"
 msgstr "設定寬度"
 
-#: src/option.c:749
+#: src/option.c:751
 msgid "Set smart Home/End behavior"
 msgstr ""
 
-#: src/option.c:751
+#: src/option.c:753
 msgid "Enable smart backspace"
 msgstr ""
 
-#: src/option.c:753
+#: src/option.c:755
 msgid "Insert spaces instead of tabs"
 msgstr ""
 
-#: src/option.c:760
+#: src/option.c:762
 msgid "Sets a filename filter"
 msgstr "設定檔名篩選器"
 
-#: src/option.c:760
+#: src/option.c:762
 msgid "NAME | PATTERN1 PATTERN2 ..."
 msgstr "名稱 | 胚騰1 胚騰2…"
 
-#: src/option.c:762
+#: src/option.c:764
 #, fuzzy
 msgid "Sets a mime-type filter"
 msgstr "設定檔名篩選器"
 
-#: src/option.c:762
+#: src/option.c:764
 #, fuzzy
 msgid "NAME | MIME1 MIME2 ..."
 msgstr "名稱 | 胚騰1 胚騰2…"
 
-#: src/option.c:764
+#: src/option.c:766
 #, fuzzy
 msgid "Add filter for images"
 msgstr "將頁首加入頁面"
 
-#: src/option.c:764
+#: src/option.c:766
 #, fuzzy
 msgid "[NAME]"
 msgstr "名稱:識別號"
 
-#: src/option.c:770 src/tools.c:64
+#: src/option.c:772 src/tools.c:64
 msgid "Print version"
 msgstr "印出版本"
 
-#: src/option.c:772
+#: src/option.c:774
 msgid "Load additional CSS settings from file or string"
 msgstr ""
 
-#: src/option.c:775
+#: src/option.c:777
 #, fuzzy
 msgid "Load additional CSS settings from file"
 msgstr "從檔案載入額外引數"
 
-#: src/option.c:778
+#: src/option.c:780
 msgid "Set policy for horizontal scrollbars (auto, always, never)"
 msgstr ""
 
-#: src/option.c:780
+#: src/option.c:782
 msgid "Set policy for vertical scrollbars (auto, always, never)"
 msgstr ""
 
-#: src/option.c:782
+#: src/option.c:784
 msgid "Add path for search icons by name"
 msgstr ""
 
-#: src/option.c:784
+#: src/option.c:786
 msgid "Write settings to file and exit"
 msgstr ""
 
-#: src/option.c:790
+#: src/option.c:792
 msgid "Load extra arguments from file"
 msgstr "從檔案載入額外引數"
 
-#: src/option.c:1001
+#: src/option.c:1003
 #, c-format
 msgid "Mark %s doesn't have a value\n"
 msgstr "標記 %s 沒有值\n"
 
-#: src/option.c:1048 src/picture.c:286
+#: src/option.c:1050 src/picture.c:286
 msgid "Images"
 msgstr ""
 
-#: src/option.c:1113
+#: src/option.c:1115
 #, fuzzy, c-format
 msgid "Unknown color mode: %s\n"
 msgstr "不明命令『%s』\n"
 
-#: src/option.c:1132
+#: src/option.c:1134
 #, fuzzy, c-format
 msgid "Unknown buttons layout type: %s\n"
 msgstr "不明的來源型態：%s\n"
 
-#: src/option.c:1147
+#: src/option.c:1149
 #, c-format
 msgid "Unknown align type: %s\n"
 msgstr "不明的對齊型態：%s\n"
 
-#: src/option.c:1171
+#: src/option.c:1173
 #, c-format
 msgid "Unknown justification type: %s\n"
 msgstr "不明的調整型態：%s\n"
 
-#: src/option.c:1188
+#: src/option.c:1190
 #, fuzzy, c-format
 msgid "Unknown tab position type: %s\n"
 msgstr "不明的對齊型態：%s\n"
 
-#: src/option.c:1225
+#: src/option.c:1227
 #, c-format
 msgid "Unknown ellipsize type: %s\n"
 msgstr "不明的省略型態：%s\n"
 
-#: src/option.c:1238
+#: src/option.c:1240
 #, fuzzy, c-format
 msgid "Unknown orientation: %s\n"
 msgstr "不明的對齊型態：%s\n"
 
-#: src/option.c:1253
+#: src/option.c:1255
 #, c-format
 msgid "Unknown source type: %s\n"
 msgstr "不明的來源型態：%s\n"
 
-#: src/option.c:1264
+#: src/option.c:1266
 #, fuzzy
 msgid "Progress log"
 msgstr "進度選項"
 
-#: src/option.c:1277
+#: src/option.c:1279
 #, fuzzy, c-format
 msgid "Unknown size type: %s\n"
 msgstr "不明的省略型態：%s\n"
 
-#: src/option.c:1321
+#: src/option.c:1323
 #, fuzzy, c-format
 msgid "Unknown completion type: %s\n"
 msgstr "不明的對齊型態：%s\n"
 
-#: src/option.c:1353
+#: src/option.c:1355
 #, fuzzy, c-format
 msgid "Unknown boolean format type: %s\n"
 msgstr "不明的來源型態：%s\n"
 
-#: src/option.c:1369
+#: src/option.c:1371
 #, fuzzy, c-format
 msgid "Unknown grid lines type: %s\n"
 msgstr "不明的對齊型態：%s\n"
 
-#: src/option.c:1386
+#: src/option.c:1388
 #, fuzzy, c-format
 msgid "Unknown scrollbar policy type: %s\n"
 msgstr "不明的來源型態：%s\n"
 
-#: src/option.c:1437
+#: src/option.c:1439
 #, fuzzy, c-format
 msgid "Unknown window type: %s\n"
 msgstr "不明的對齊型態：%s\n"
 
-#: src/option.c:1466
+#: src/option.c:1468
 #, fuzzy, c-format
 msgid "Unknown smart Home/End mode: %s\n"
 msgstr "不明的來源型態：%s\n"
 
-#: src/option.c:1576
+#: src/option.c:1578
 #, fuzzy, c-format
 msgid "Unknown signal: %s\n"
 msgstr "不明的對齊型態：%s\n"
 
-#: src/option.c:1811
+#: src/option.c:1814
 msgid "File exist. Overwrite?"
 msgstr "檔案已存在。覆寫？"
 
-#: src/option.c:1953
+#: src/option.c:1956
 msgid "File was changed. Save it?"
 msgstr ""
 
-#: src/option.c:1984
+#: src/option.c:1987
 #, fuzzy
 msgid "- Yet another dialoging program"
 msgstr "又一個對話框程式"
 
-#: src/option.c:1988
+#: src/option.c:1991
 msgid "General options"
 msgstr "一般選項"
 
-#: src/option.c:1988
+#: src/option.c:1991
 msgid "Show general options"
 msgstr "顯示一般選項"
 
-#: src/option.c:1994
+#: src/option.c:1997
 #, fuzzy
 msgid "Common options"
 msgstr "表單選項"
 
-#: src/option.c:1994
+#: src/option.c:1997
 #, fuzzy
 msgid "Show common options"
 msgstr "顯示表單選項"
 
-#: src/option.c:2000
+#: src/option.c:2003
 #, fuzzy
 msgid "About dialog options"
 msgstr "列印對話框選項"
 
-#: src/option.c:2000
+#: src/option.c:2003
 #, fuzzy
 msgid "Show custom about dialog options"
 msgstr "顯示列印對話框選項"
 
-#: src/option.c:2006
+#: src/option.c:2009
 #, fuzzy
 msgid "Application selection options"
 msgstr "字型選擇選項"
 
-#: src/option.c:2006
+#: src/option.c:2009
 #, fuzzy
 msgid "Show application selection options"
 msgstr "顯示字型選擇選項"
 
-#: src/option.c:2012
+#: src/option.c:2015
 msgid "Calendar options"
 msgstr "行事曆選項"
 
-#: src/option.c:2012
+#: src/option.c:2015
 msgid "Show calendar options"
 msgstr "顯示行事曆選項"
 
-#: src/option.c:2018
+#: src/option.c:2021
 msgid "Color selection options"
 msgstr "顏色選擇選項"
 
-#: src/option.c:2018
+#: src/option.c:2021
 msgid "Show color selection options"
 msgstr "顯示顏色選擇選項"
 
-#: src/option.c:2024
+#: src/option.c:2027
 msgid "DND options"
 msgstr "拖放選項"
 
-#: src/option.c:2024
+#: src/option.c:2027
 msgid "Show drag-n-drop options"
 msgstr "顯示拖放選項"
 
-#: src/option.c:2030
+#: src/option.c:2033
 msgid "Text entry options"
 msgstr "文字輸入框選項"
 
-#: src/option.c:2030
+#: src/option.c:2033
 msgid "Show text entry options"
 msgstr "顯示文字輸入框選項"
 
-#: src/option.c:2036
+#: src/option.c:2039
 msgid "File selection options"
 msgstr "檔案選取選項"
 
-#: src/option.c:2036
+#: src/option.c:2039
 msgid "Show file selection options"
 msgstr "顯示檔案選取選項"
 
-#: src/option.c:2042
+#: src/option.c:2045
 msgid "Font selection options"
 msgstr "字型選擇選項"
 
-#: src/option.c:2042
+#: src/option.c:2045
 msgid "Show font selection options"
 msgstr "顯示字型選擇選項"
 
-#: src/option.c:2048
+#: src/option.c:2051
 msgid "Form options"
 msgstr "表單選項"
 
-#: src/option.c:2048
+#: src/option.c:2051
 msgid "Show form options"
 msgstr "顯示表單選項"
 
-#: src/option.c:2055
+#: src/option.c:2058
 #, fuzzy
 msgid "HTML options"
 msgstr "清單選項"
 
-#: src/option.c:2055
+#: src/option.c:2058
 #, fuzzy
 msgid "Show HTML options"
 msgstr "顯示表單選項"
 
-#: src/option.c:2062
+#: src/option.c:2065
 msgid "Icons box options"
 msgstr "圖示框選項"
 
-#: src/option.c:2062
+#: src/option.c:2065
 msgid "Show icons box options"
 msgstr "顯示圖示框選項"
 
-#: src/option.c:2068
+#: src/option.c:2071
 msgid "List options"
 msgstr "清單選項"
 
-#: src/option.c:2068
+#: src/option.c:2071
 msgid "Show list options"
 msgstr "顯示清單選項"
 
-#: src/option.c:2074
+#: src/option.c:2077
 #, fuzzy
 msgid "Notebook options"
 msgstr "拖放選項"
 
-#: src/option.c:2074
+#: src/option.c:2077
 #, fuzzy
 msgid "Show notebook dialog options"
 msgstr "顯示列印對話框選項"
 
-#: src/option.c:2081
+#: src/option.c:2084
 msgid "Notification icon options"
 msgstr "通知圖示選項"
 
-#: src/option.c:2082
+#: src/option.c:2085
 msgid "Show notification icon options"
 msgstr "顯示通知圖示選項"
 
-#: src/option.c:2090
+#: src/option.c:2093
 #, fuzzy
 msgid "StatusNotifier/AppIndicator options"
 msgstr "通知圖示選項"
 
-#: src/option.c:2091
+#: src/option.c:2094
 #, fuzzy
 msgid "Show indicator options"
 msgstr "顯示列印對話框選項"
 
-#: src/option.c:2098
+#: src/option.c:2101
 #, fuzzy
 msgid "Paned dialog options"
 msgstr "列印對話框選項"
 
-#: src/option.c:2098
+#: src/option.c:2101
 #, fuzzy
 msgid "Show paned dialog options"
 msgstr "顯示列印對話框選項"
 
-#: src/option.c:2104
+#: src/option.c:2107
 #, fuzzy
 msgid "Picture dialog options"
 msgstr "列印對話框選項"
 
-#: src/option.c:2104
+#: src/option.c:2107
 #, fuzzy
 msgid "Show picture dialog options"
 msgstr "顯示列印對話框選項"
 
-#: src/option.c:2110
+#: src/option.c:2113
 #, fuzzy
 msgid "Popup dialog options"
 msgstr "列印對話框選項"
 
-#: src/option.c:2110
+#: src/option.c:2113
 #, fuzzy
 msgid "Show popup dialog options"
 msgstr "顯示列印對話框選項"
 
-#: src/option.c:2116
+#: src/option.c:2119
 msgid "Print dialog options"
 msgstr "列印對話框選項"
 
-#: src/option.c:2116
+#: src/option.c:2119
 msgid "Show print dialog options"
 msgstr "顯示列印對話框選項"
 
-#: src/option.c:2122
+#: src/option.c:2125
 msgid "Progress options"
 msgstr "進度選項"
 
-#: src/option.c:2122
+#: src/option.c:2125
 msgid "Show progress options"
 msgstr "顯示進度選項"
 
-#: src/option.c:2128
+#: src/option.c:2131
 msgid "Scale options"
 msgstr "尺度選項"
 
-#: src/option.c:2128
+#: src/option.c:2131
 msgid "Show scale options"
 msgstr "顯示尺度選項"
 
-#: src/option.c:2134
+#: src/option.c:2137
 msgid "Text information options"
 msgstr "文字資訊選項"
 
-#: src/option.c:2134
+#: src/option.c:2137
 msgid "Show text information options"
 msgstr "顯示文字資訊選項"
 
-#: src/option.c:2141
+#: src/option.c:2144
 #, fuzzy
 msgid "SourceView options"
 msgstr "尺度選項"
 
-#: src/option.c:2141
+#: src/option.c:2144
 #, fuzzy
 msgid "Show SourceView options"
 msgstr "顯示表單選項"
 
-#: src/option.c:2148
+#: src/option.c:2151
 #, fuzzy
 msgid "File filter options"
 msgstr "檔案選取選項"
 
-#: src/option.c:2148
+#: src/option.c:2151
 #, fuzzy
 msgid "Show file filter options"
 msgstr "顯示檔案選取選項"
 
-#: src/option.c:2154
+#: src/option.c:2157
 msgid "Miscellaneous options"
 msgstr "雜項選項"
 
-#: src/option.c:2154
+#: src/option.c:2157
 msgid "Show miscellaneous options"
 msgstr "顯示雜項選項"
 
@@ -2527,7 +2537,7 @@ msgstr ""
 msgid "Insert spaces instead of tabulation:CHK"
 msgstr ""
 
-#: src/yad-settings.sh:113 data/yad-settings.desktop.in:3
+#: src/yad-settings.sh:113 data/yad-settings.desktop.in:4
 msgid "YAD settings"
 msgstr ""
 
@@ -2547,15 +2557,15 @@ msgstr ""
 msgid "Editor"
 msgstr ""
 
-#: data/yad-icon-browser.desktop.in:3
+#: data/yad-icon-browser.desktop.in:4
 msgid "Icon Browser"
 msgstr "圖示瀏覽器"
 
-#: data/yad-icon-browser.desktop.in:4
+#: data/yad-icon-browser.desktop.in:5
 msgid "Inspect GTK Icon Theme"
 msgstr "檢閱 GTK 圖示布景主題"
 
-#: data/yad-settings.desktop.in:4
+#: data/yad-settings.desktop.in:5
 msgid "Simple GUI for editing YAD settings"
 msgstr ""
 

--- a/src/main.c
+++ b/src/main.c
@@ -600,7 +600,12 @@ create_dialog (void)
   gtk_widget_show_all (vbox);
 
   if (default_btn)
-    gtk_widget_grab_focus (default_btn);
+    {
+      gtk_style_context_add_class (gtk_widget_get_style_context (default_btn), "suggested-action");
+      gtk_widget_set_can_default (default_btn, TRUE);
+      gtk_widget_grab_default (default_btn);
+      gtk_widget_grab_focus (default_btn);
+    }
 
   /* parse geometry or move window, if given. must be after showing widget */
   if (!options.data.maximized && !options.data.fullscreen)

--- a/src/main.c
+++ b/src/main.c
@@ -599,7 +599,9 @@ create_dialog (void)
   /* show widgets */
   gtk_widget_show_all (vbox);
 
-  if (default_btn)
+  if (options.data.default_button && !default_btn)
+    g_printerr (_("WARNING: --default-button '%s' does not match any button\n"), options.data.default_button);
+  else if (default_btn)
     {
       gtk_style_context_add_class (gtk_widget_get_style_context (default_btn), "suggested-action");
       gtk_widget_set_can_default (default_btn, TRUE);

--- a/src/main.c
+++ b/src/main.c
@@ -522,6 +522,8 @@ create_dialog (void)
     options.data.no_buttons = TRUE;
 #endif
 
+  GtkWidget *default_btn = NULL;
+
   if (!options.data.no_buttons)
     {
       GtkWidget *btn;
@@ -546,6 +548,9 @@ create_dialog (void)
               g_signal_connect (G_OBJECT (btn), "clicked", G_CALLBACK (btn_cb), b->cmd);
               gtk_box_pack_start (GTK_BOX (bbox), btn, TRUE, TRUE, 0);
 
+              if (options.data.default_button && g_strcmp0 (b->name, options.data.default_button) == 0)
+                default_btn = btn;
+
               tmp = tmp->next;
             }
           while (tmp != NULL);
@@ -561,6 +566,8 @@ create_dialog (void)
               g_signal_connect (G_OBJECT (btn), "clicked", G_CALLBACK (btn_cb), NULL);
               gtk_box_pack_start (GTK_BOX (bbox), btn, TRUE, TRUE, 0);
 
+              if (options.data.default_button && g_strcmp0 ("yad-close", options.data.default_button) == 0)
+                default_btn = btn;
             }
           else
             {
@@ -571,12 +578,18 @@ create_dialog (void)
               g_signal_connect (G_OBJECT (btn), "clicked", G_CALLBACK (btn_cb), NULL);
               gtk_box_pack_start (GTK_BOX (bbox), btn, TRUE, TRUE, 0);
 
+              if (options.data.default_button && g_strcmp0 ("yad-cancel", options.data.default_button) == 0)
+                default_btn = btn;
+
               /*add ok button */
               btn = gtk_button_new ();
               gtk_container_add (GTK_CONTAINER (btn), get_label ("yad-ok", 2, btn));
               g_object_set_data (G_OBJECT (btn), "resp", GINT_TO_POINTER (YAD_RESPONSE_OK));
               g_signal_connect (G_OBJECT (btn), "clicked", G_CALLBACK (btn_cb), NULL);
               gtk_box_pack_start (GTK_BOX (bbox), btn, TRUE, TRUE, 0);
+
+              if (options.data.default_button && g_strcmp0 ("yad-ok", options.data.default_button) == 0)
+                default_btn = btn;
             }
         }
       /* add buttons box to main window */
@@ -585,6 +598,9 @@ create_dialog (void)
 
   /* show widgets */
   gtk_widget_show_all (vbox);
+
+  if (default_btn)
+    gtk_widget_grab_focus (default_btn);
 
   /* parse geometry or move window, if given. must be after showing widget */
   if (!options.data.maximized && !options.data.fullscreen)

--- a/src/option.c
+++ b/src/option.c
@@ -130,6 +130,8 @@ static GOptionEntry general_options[] = {
     N_("Don't show buttons"), NULL },
   { "buttons-layout", 0, 0, G_OPTION_ARG_CALLBACK, set_buttons_layout,
     N_("Set buttons layout type (spread, edge, start, end or center)"), N_("TYPE") },
+  { "default-button", 0, 0, G_OPTION_ARG_STRING, &options.data.default_button,
+    N_("Set focus to the named button when dialog opens"), N_("NAME") },
   { "no-markup", 0, 0, G_OPTION_ARG_NONE, &options.data.no_markup,
     N_("Don't use pango markup language in dialog's text"), NULL },
   { "no-escape", 0, 0, G_OPTION_ARG_NONE, &options.data.no_escape,
@@ -1684,6 +1686,7 @@ yad_options_init (void)
   options.data.buttons = NULL;
   options.data.no_buttons = FALSE;
   options.data.buttons_layout = GTK_BUTTONBOX_END;
+  options.data.default_button = NULL;
   options.data.borders = settings->border;
   options.data.no_markup = FALSE;
   options.data.no_escape = FALSE;

--- a/src/yad.h
+++ b/src/yad.h
@@ -256,6 +256,7 @@ typedef struct {
   gboolean selectable_labels;
   gboolean keep_icon_size;
   GtkButtonBoxStyle buttons_layout;
+  gchar *default_button;
   gint def_resp;
   gboolean use_interp;
   gchar *interp;


### PR DESCRIPTION
I use yad to create chicken boxes for installations, replacing a prompting function. I would prefer that if someone blindly hits return without reading, they take the least destructive option. I need to set which button that is. I therefore submit this patch. Please advise of any further changes you would like me to make. Thank you.